### PR TITLE
Rather than always putting 'python' in env, add it only if env spec i…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ install:
   - conda install -y -q -c conda-forge keyring
 
 script:
-  - if test "$TEST_TARGET" = tests; then LANG=en_US.UTF-8 python setup.py test; fi
+  - if test "$TEST_TARGET" = tests; then LANG=en_US.UTF-8 python setup.py test -a '-vv'; fi
   - if test "$TRAVIS_PYTHON_VERSION" = "3.5" && test "$TEST_TARGET" = "packaging"; then
       git fetch --unshallow ;
       LANG=en_US.UTF-8 python setup.py conda_package ;

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -180,7 +180,10 @@ class DefaultCondaManager(CondaManager):
         if deviations is None:
             deviations = self.find_environment_deviations(prefix, spec)
 
-        command_line_packages = set(['python']).union(set(spec.conda_packages))
+        command_line_packages = set(spec.conda_packages)
+        # conda won't let us create a completely empty environment
+        if len(command_line_packages) == 0:
+            command_line_packages = set(['python'])
 
         if os.path.isdir(os.path.join(prefix, 'conda-meta')):
             missing = deviations.missing_packages

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -193,7 +193,8 @@ class DefaultCondaManager(CondaManager):
                 try:
                     conda_api.install(prefix=prefix, pkgs=specs, channels=spec.channels)
                 except conda_api.CondaError as e:
-                    raise CondaManagerError("Failed to install missing packages: " + ", ".join(missing))
+                    raise CondaManagerError("Failed to install missing packages: {}: {}".format(", ".join(missing), str(
+                        e)))
         elif create:
             # Create environment from scratch
             try:
@@ -211,7 +212,8 @@ class DefaultCondaManager(CondaManager):
             try:
                 pip_api.install(prefix=prefix, pkgs=specs)
             except pip_api.PipError as e:
-                raise CondaManagerError("Failed to install missing pip packages: " + ", ".join(missing))
+                raise CondaManagerError("Failed to install missing pip packages: {}: {}".format(", ".join(missing), str(
+                    e)))
 
         # write a file to tell us we can short-circuit next time
         self._write_timestamp_file(prefix, spec)

--- a/anaconda_project/prepare.py
+++ b/anaconda_project/prepare.py
@@ -114,6 +114,11 @@ class PrepareResult(with_metaclass(ABCMeta)):
         """Override object which was passed to prepare()."""
         return self._overrides
 
+    @property
+    def errors(self):
+        """Get lines of error output."""
+        raise NotImplementedError()  # pragma: no cover
+
 
 class PrepareSuccess(PrepareResult):
     """Class describing the successful result of preparing the project to run."""
@@ -132,6 +137,11 @@ class PrepareSuccess(PrepareResult):
     def command_exec_info(self):
         """``CommandExecInfo`` instance if available, None if not."""
         return self._command_exec_info
+
+    @property
+    def errors(self):
+        """Get empty list of errors."""
+        return []
 
     def update_environ(self, environ):
         """Overwrite ``environ`` with any additions from the prepared environ.
@@ -156,7 +166,7 @@ class PrepareFailure(PrepareResult):
 
     @property
     def errors(self):
-        """Get lines of error output."""
+        """Get non-empty list of errors."""
         return self._errors
 
     def print_output(self):

--- a/anaconda_project/test/test_prepare.py
+++ b/anaconda_project/test/test_prepare.py
@@ -35,6 +35,7 @@ def test_prepare_empty_directory():
         project = project_no_dedicated_env(dirname)
         environ = minimal_environ()
         result = prepare_without_interaction(project, environ=environ)
+        assert result.errors == []
         assert result
         assert dict(PROJECT_DIR=project.directory_path) == strip_environ(result.environ)
         assert dict() == strip_environ(environ)
@@ -59,6 +60,7 @@ def test_unprepare_empty_directory():
         project = project_no_dedicated_env(dirname)
         environ = minimal_environ()
         result = prepare_without_interaction(project, environ=environ)
+        assert result.errors == []
         assert result
         status = unprepare(project, result)
         assert status
@@ -86,6 +88,7 @@ def test_unprepare_nothing_to_do():
         project = project_no_dedicated_env(dirname)
         environ = minimal_environ()
         result = prepare_without_interaction(project, environ=environ)
+        assert result.errors == []
         assert result
         status = unprepare(project, result, whitelist=[])
         assert status
@@ -113,6 +116,8 @@ def test_default_to_system_environ():
                     print("ORIGINAL PATH: " + repr(original))
                     print("UPDATED PATH: " + repr(updated))
                     assert original == updated
+                assert result.errors == []
+                assert result
                 assert result.environ.get(key) == os.environ.get(key)
 
     with_directory_contents(dict(), prepare_system_environ)
@@ -123,6 +128,7 @@ def test_prepare_some_env_var_already_set():
         project = project_no_dedicated_env(dirname)
         environ = minimal_environ(FOO='bar')
         result = prepare_without_interaction(project, environ=environ)
+        assert result.errors == []
         assert result
         assert dict(FOO='bar', PROJECT_DIR=project.directory_path) == strip_environ(result.environ)
         assert dict(FOO='bar') == strip_environ(environ)
@@ -219,11 +225,13 @@ def test_prepare_choose_command():
         project = project_no_dedicated_env(dirname)
         environ = minimal_environ()
         result = prepare_without_interaction(project, environ=environ, command_name='foo')
+        assert result.errors == []
         assert result
         assert os.path.join(project.directory_path, 'foo.py') in result.command_exec_info.args
 
         environ = minimal_environ()
         result = prepare_without_interaction(project, environ=environ, command_name='bar')
+        assert result.errors == []
         assert result
         assert os.path.join(project.directory_path, 'bar.py') in result.command_exec_info.args
 
@@ -250,6 +258,7 @@ def test_prepare_command_not_in_project():
                                                  env_spec=project.default_env_spec_name))
         environ = minimal_environ()
         result = prepare_without_interaction(project, environ=environ, command=command)
+        assert result.errors == []
         assert result
         assert os.path.join(project.directory_path, 'foo.py') in result.command_exec_info.args
 
@@ -313,6 +322,7 @@ def test_prepare_choose_environment():
 
             environ = minimal_environ()
             result = prepare_without_interaction(project, environ=environ, env_spec_name='bar')
+            assert result.errors == []
             assert result
             expected_path = project.env_specs['bar'].path(project.directory_path)
             assert result.environ[env_var] == expected_path
@@ -362,6 +372,7 @@ def test_update_environ():
         project = project_no_dedicated_env(dirname)
         environ = minimal_environ(FOO='bar')
         result = prepare_without_interaction(project, environ=environ)
+        assert result.errors == []
         assert result
 
         other = minimal_environ(BAR='baz')
@@ -643,6 +654,7 @@ def test_prepare_asking_for_password_with_browser(monkeypatch):
         project = project_no_dedicated_env(dirname)
         environ = minimal_environ()
         result = prepare_with_browser_ui(project, environ=environ, keep_going_until_success=False, io_loop=io_loop)
+        assert result.errors == []
         assert result
         assert dict(FOO_PASSWORD='bloop', PROJECT_DIR=project.directory_path) == strip_environ(result.environ)
         assert dict() == strip_environ(environ)

--- a/anaconda_project/test/test_prepare.py
+++ b/anaconda_project/test/test_prepare.py
@@ -32,7 +32,7 @@ import anaconda_project.internal.keyring as keyring
 
 def test_prepare_empty_directory():
     def prepare_empty(dirname):
-        project = project_no_dedicated_env(dirname)
+        project = Project(dirname)
         environ = minimal_environ()
         result = prepare_without_interaction(project, environ=environ)
         assert result.errors == []
@@ -57,7 +57,7 @@ def test_prepare_bad_provide_mode():
 
 def test_unprepare_empty_directory():
     def unprepare_empty(dirname):
-        project = project_no_dedicated_env(dirname)
+        project = Project(dirname)
         environ = minimal_environ()
         result = prepare_without_interaction(project, environ=environ)
         assert result.errors == []
@@ -85,7 +85,7 @@ def test_unprepare_problem_project():
 
 def test_unprepare_nothing_to_do():
     def unprepare_nothing(dirname):
-        project = project_no_dedicated_env(dirname)
+        project = Project(dirname)
         environ = minimal_environ()
         result = prepare_without_interaction(project, environ=environ)
         assert result.errors == []
@@ -120,7 +120,12 @@ def test_default_to_system_environ():
                 assert result
                 assert result.environ.get(key) == os.environ.get(key)
 
-    with_directory_contents(dict(), prepare_system_environ)
+    with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME: """
+packages: []
+        """
+        }, prepare_system_environ)
 
 
 def test_prepare_some_env_var_already_set():


### PR DESCRIPTION
…s empty

This avoids duplicate python packages on the `conda create` command line,
and would in theory allow a pythonless environment I suppose, not sure
conda supports that but maybe it does.