### PR TITLE
Add line numbers to syntax errors, and filename info to problems

### DIFF
--- a/anaconda_project/commands/test/test_bundle.py
+++ b/anaconda_project/commands/test/test_bundle.py
@@ -50,6 +50,6 @@ def test_archive_command_on_invalid_project(capsys):
         out, err = capsys.readouterr()
         assert '' == out
         assert ('variables section contains wrong value type 42,' + ' should be dict or list of requirements\n' +
-                'Unable to load the project.\n') == err
+                'Unable to load the project.\n') in err
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)

--- a/anaconda_project/commands/test/test_clean.py
+++ b/anaconda_project/commands/test/test_clean.py
@@ -31,6 +31,6 @@ def test_clean_command_on_invalid_project(capsys):
         out, err = capsys.readouterr()
         assert '' == out
         assert ('variables section contains wrong value type 42,' + ' should be dict or list of requirements\n' +
-                'Unable to load the project.\n' + 'Failed to clean everything up.\n') == err
+                'Unable to load the project.\n' + 'Failed to clean everything up.\n') in err
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)

--- a/anaconda_project/commands/test/test_command_commands.py
+++ b/anaconda_project/commands/test/test_command_commands.py
@@ -292,7 +292,7 @@ def _test_command_command_project_problem(capsys, monkeypatch, command, append_d
         out, err = capsys.readouterr()
         assert '' == out
         assert ('variables section contains wrong value type 42,' + ' should be dict or list of requirements\n' +
-                'Unable to load the project.\n') == err
+                'Unable to load the project.\n') in err
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 

--- a/anaconda_project/commands/test/test_download_commands.py
+++ b/anaconda_project/commands/test/test_download_commands.py
@@ -161,7 +161,7 @@ def _test_download_command_with_project_file_problems(capsys, monkeypatch, comma
         out, err = capsys.readouterr()
         assert '' == out
         assert ('variables section contains wrong value type 42,' + ' should be dict or list of requirements\n' +
-                'Unable to load the project.\n') == err
+                'Unable to load the project.\n') in err
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 
@@ -311,7 +311,7 @@ def test_list_downloads_with_project_file_problems(capsys, monkeypatch):
         out, err = capsys.readouterr()
         assert '' == out
         assert ('variables section contains wrong value type 42,' + ' should be dict or list of requirements\n' +
-                'Unable to load the project.\n') == err
+                'Unable to load the project.\n') in err
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 

--- a/anaconda_project/commands/test/test_environment_commands.py
+++ b/anaconda_project/commands/test/test_environment_commands.py
@@ -78,7 +78,7 @@ def _test_environment_command_with_project_file_problems(capsys, monkeypatch, co
         out, err = capsys.readouterr()
         assert '' == out
         assert ('variables section contains wrong value type 42,' + ' should be dict or list of requirements\n' +
-                'Unable to load the project.\n') == err
+                'Unable to load the project.\n') in err
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 

--- a/anaconda_project/commands/test/test_project_load.py
+++ b/anaconda_project/commands/test/test_project_load.py
@@ -52,7 +52,7 @@ def test_interactively_fix_project(monkeypatch, capsys):
         assert project.problems == []
 
         out, err = capsys.readouterr()
-        assert out == ("%s has an empty env_specs section.\nAdd an environment spec to anaconda-project.yml? " %
+        assert out == ("%s: The env_specs section is empty.\nAdd an environment spec to anaconda-project.yml? " %
                        os.path.join(dirname, DEFAULT_PROJECT_FILENAME))
         assert err == ""
 
@@ -73,11 +73,11 @@ def test_interactively_no_fix_project(monkeypatch, capsys):
         _monkeypatch_input(monkeypatch, ["n"])
 
         project = load_project(dirname)
-        assert project.problems == ["%s has an empty env_specs section." % os.path.join(dirname,
-                                                                                        DEFAULT_PROJECT_FILENAME)]
+        assert project.problems == ["%s: The env_specs section is empty." % os.path.join(dirname,
+                                                                                         DEFAULT_PROJECT_FILENAME)]
 
         out, err = capsys.readouterr()
-        assert out == ("%s has an empty env_specs section.\nAdd an environment spec to anaconda-project.yml? " %
+        assert out == ("%s: The env_specs section is empty.\nAdd an environment spec to anaconda-project.yml? " %
                        os.path.join(dirname, DEFAULT_PROJECT_FILENAME))
         assert err == ""
 

--- a/anaconda_project/commands/test/test_service_commands.py
+++ b/anaconda_project/commands/test/test_service_commands.py
@@ -238,7 +238,7 @@ def _test_service_command_with_project_file_problems(capsys, monkeypatch, comman
         out, err = capsys.readouterr()
         assert '' == out
         assert ('variables section contains wrong value type 42,' + ' should be dict or list of requirements\n' +
-                'Unable to load the project.\n') == err
+                'Unable to load the project.\n') in err
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 

--- a/anaconda_project/commands/test/test_upload.py
+++ b/anaconda_project/commands/test/test_upload.py
@@ -46,7 +46,7 @@ def test_upload_command_on_invalid_project(capsys):
         out, err = capsys.readouterr()
         assert '' == out
         assert ('variables section contains wrong value type 42,' + ' should be dict or list of requirements\n' +
-                'Unable to load the project.\n') == err
+                'Unable to load the project.\n') in err
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 

--- a/anaconda_project/commands/test/test_variable_commands.py
+++ b/anaconda_project/commands/test/test_variable_commands.py
@@ -90,7 +90,7 @@ def test_add_variable_project_problem(capsys):
     assert out == ''
     expected_err = ('variables section contains wrong value type 42, should be dict or list of requirements\n'
                     'Unable to load the project.\n')
-    assert err == expected_err
+    assert expected_err in err
 
 
 def test_remove_variable_command(monkeypatch):
@@ -178,7 +178,7 @@ def test_list_variables_with_project_file_problems(capsys):
         out, err = capsys.readouterr()
         assert '' == out
         assert ('variables section contains wrong value type 42,' + ' should be dict or list of requirements\n' +
-                'Unable to load the project.\n') == err
+                'Unable to load the project.\n') in err
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 
@@ -192,7 +192,7 @@ def test_set_variables_with_project_file_problems(capsys):
         out, err = capsys.readouterr()
         assert '' == out
         assert ('variables section contains wrong value type 42,' + ' should be dict or list of requirements\n' +
-                'Unable to load the project.\n') == err
+                'Unable to load the project.\n') in err
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 
@@ -206,7 +206,7 @@ def test_unset_variables_with_project_file_problems(capsys):
         out, err = capsys.readouterr()
         assert '' == out
         assert ('variables section contains wrong value type 42,' + ' should be dict or list of requirements\n' +
-                'Unable to load the project.\n') == err
+                'Unable to load the project.\n') in err
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -43,13 +43,22 @@ ALL_COMMAND_TYPES = (COMMAND_TYPE_CONDA_APP_ENTRY, COMMAND_TYPE_SHELL, COMMAND_T
 class ProjectProblem(object):
     """A possibly-autofixable problem with a project."""
 
-    def __init__(self, text, fix_prompt=None, fix_function=None, no_fix_function=None, only_a_suggestion=False):
+    def __init__(self,
+                 text,
+                 fix_prompt=None,
+                 fix_function=None,
+                 no_fix_function=None,
+                 only_a_suggestion=False,
+                 line_number=None,
+                 column_number=None):
         """Create a project problem."""
         self.text = text
         self.fix_prompt = fix_prompt
         self.fix_function = fix_function
         self.no_fix_function = no_fix_function
         self.only_a_suggestion = only_a_suggestion
+        self.maybe_line_number = line_number
+        self.maybe_column_number = column_number
 
     @property
     def can_fix(self):
@@ -117,11 +126,15 @@ class _ConfigCache(object):
             problems.append("Project directory '%s' does not exist." % self.directory_path)
 
         if project_file.corrupted:
-            problems.append("%s has a syntax error that needs to be fixed by hand: %s" %
-                            (project_file.filename, project_file.corrupted_error_message))
+            problems.append(ProjectProblem(text=("%s has a syntax error that needs to be fixed by hand: %s" % (
+                project_file.filename, project_file.corrupted_error_message)),
+                                           line_number=project_file.corrupted_maybe_line,
+                                           column_number=project_file.corrupted_maybe_column))
         if conda_meta_file.corrupted:
-            problems.append("%s has a syntax error that needs to be fixed by hand: %s" %
-                            (conda_meta_file.filename, conda_meta_file.corrupted_error_message))
+            problems.append(ProjectProblem(text=("%s has a syntax error that needs to be fixed by hand: %s" % (
+                conda_meta_file.filename, conda_meta_file.corrupted_error_message)),
+                                           line_number=project_file.corrupted_maybe_line,
+                                           column_number=project_file.corrupted_maybe_column))
 
         if project_exists and not (project_file.corrupted or conda_meta_file.corrupted):
             self._update_name(problems, project_file, conda_meta_file)

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -45,6 +45,7 @@ class ProjectProblem(object):
 
     def __init__(self,
                  text,
+                 filename=None,
                  fix_prompt=None,
                  fix_function=None,
                  no_fix_function=None,
@@ -52,11 +53,16 @@ class ProjectProblem(object):
                  line_number=None,
                  column_number=None):
         """Create a project problem."""
-        self.text = text
+        self.text_without_filename = text
+        if filename is None:
+            self.text = text
+        else:
+            self.text = "%s: %s" % (filename, text)
         self.fix_prompt = fix_prompt
         self.fix_function = fix_function
         self.no_fix_function = no_fix_function
         self.only_a_suggestion = only_a_suggestion
+        self.maybe_filename = filename
         self.maybe_line_number = line_number
         self.maybe_column_number = column_number
 
@@ -90,6 +96,10 @@ def _make_problems_into_objects(problems):
         else:
             new_problems.append(ProjectProblem(text=p))
     return new_problems
+
+
+def _file_problem(problems, yaml_file, text):
+    problems.append(ProjectProblem(text=text, filename=yaml_file.filename))
 
 
 class _ConfigCache(object):
@@ -126,13 +136,13 @@ class _ConfigCache(object):
             problems.append("Project directory '%s' does not exist." % self.directory_path)
 
         if project_file.corrupted:
-            problems.append(ProjectProblem(text=("%s has a syntax error that needs to be fixed by hand: %s" % (
-                project_file.filename, project_file.corrupted_error_message)),
+            problems.append(ProjectProblem(text=("Syntax error: %s" % (project_file.corrupted_error_message)),
+                                           filename=project_file.filename,
                                            line_number=project_file.corrupted_maybe_line,
                                            column_number=project_file.corrupted_maybe_column))
         if conda_meta_file.corrupted:
-            problems.append(ProjectProblem(text=("%s has a syntax error that needs to be fixed by hand: %s" % (
-                conda_meta_file.filename, conda_meta_file.corrupted_error_message)),
+            problems.append(ProjectProblem(text=("Syntax error: %s" % (conda_meta_file.corrupted_error_message)),
+                                           filename=conda_meta_file.filename,
                                            line_number=project_file.corrupted_maybe_line,
                                            column_number=project_file.corrupted_maybe_column))
 
@@ -163,17 +173,17 @@ class _ConfigCache(object):
         name = project_file.get_value('name', None)
         if name is not None:
             if not is_string(name):
-                problems.append("%s: name: field should have a string value not %r" % (project_file.filename, name))
+                _file_problem(problems, project_file, "name: field should have a string value not %r" % name)
                 name = None
             elif len(name.strip()) == 0:
-                problems.append("%s: name: field is an empty or all-whitespace string." % (project_file.filename))
+                _file_problem(problems, project_file, "name: field is an empty or all-whitespace string.")
                 name = None
 
         if name is None:
             name = conda_meta_file.name
             if name is not None and not is_string(name):
-                problems.append("%s: package: name: field should have a string value not %r" %
-                                (conda_meta_file.filename, name))
+                _file_problem(problems, conda_meta_file,
+                              "package: name: field should have a string value not %r" % name)
                 name = None
 
         if name is None:
@@ -184,7 +194,7 @@ class _ConfigCache(object):
     def _update_description(self, problems, project_file):
         desc = project_file.get_value('description', None)
         if desc is not None and not is_string(desc):
-            problems.append("%s: description: field should have a string value not %r" % (project_file.filename, desc))
+            _file_problem(problems, project_file, "description: field should have a string value not %r" % desc)
             desc = None
 
         if desc is None:
@@ -195,14 +205,13 @@ class _ConfigCache(object):
     def _update_icon(self, problems, project_file, conda_meta_file):
         icon = project_file.get_value('icon', None)
         if icon is not None and not is_string(icon):
-            problems.append("%s: icon: field should have a string value not %r" % (project_file.filename, icon))
+            _file_problem(problems, project_file, "icon: field should have a string value not %r" % (icon))
             icon = None
 
         if icon is None:
             icon = conda_meta_file.icon
             if icon is not None and not is_string(icon):
-                problems.append("%s: app: icon: field should have a string value not %r" %
-                                (conda_meta_file.filename, icon))
+                _file_problem(problems, conda_meta_file, "app: icon: field should have a string value not %r" % icon)
                 icon = None
             if icon is not None:
                 # relative to conda.recipe
@@ -221,8 +230,8 @@ class _ConfigCache(object):
 
         def check_conda_reserved(key):
             if key in ('CONDA_DEFAULT_ENV', 'CONDA_ENV_PATH', 'CONDA_PREFIX'):
-                problems.append(("Environment variable %s is reserved for Conda's use, " +
-                                 "so it can't appear in the variables section.") % key)
+                _file_problem(problems, project_file, ("Environment variable %s is reserved for Conda's use, " +
+                                                       "so it can't appear in the variables section.") % key)
                 return True
             else:
                 return False
@@ -237,7 +246,8 @@ class _ConfigCache(object):
                 if check_conda_reserved(key):
                     continue
                 if key.strip() == '':
-                    problems.append("Variable name cannot be empty string, found: '{}' as name".format(key))
+                    _file_problem(problems, project_file,
+                                  "Variable name cannot be empty string, found: '{}' as name".format(key))
                     continue
                 raw_options = variables[key]
 
@@ -257,18 +267,23 @@ class _ConfigCache(object):
             for item in variables:
                 if is_string(item):
                     if item.strip() == '':
-                        problems.append("Variable name cannot be empty string, found: '{}' as name".format(item))
+                        _file_problem(problems, project_file,
+                                      "Variable name cannot be empty string, found: '{}' as name".format(item))
                         continue
                     if check_conda_reserved(item):
                         continue
                     requirement = self.registry.find_requirement_by_env_var(item, options=dict())
                     requirements.append(requirement)
                 else:
-                    problems.append(
-                        "variables section should contain environment variable names, {item} is not a string".format(
-                            item=item))
+                    _file_problem(
+                        problems,
+                        project_file,
+                        ("variables section should contain environment variable names, {item} is not a string".format(
+                            item=item)))
         else:
-            problems.append(
+            _file_problem(
+                problems,
+                project_file,
                 "variables section contains wrong value type {value}, should be dict or list of requirements".format(
                     value=variables))
 
@@ -279,13 +294,14 @@ class _ConfigCache(object):
             return
 
         if not isinstance(downloads, dict):
-            problems.append("{}: 'downloads:' section should be a dictionary, found {}".format(project_file.filename,
-                                                                                               repr(downloads)))
+            _file_problem(problems, project_file,
+                          "'downloads:' section should be a dictionary, found {}".format(repr(downloads)))
             return
 
         for varname, item in downloads.items():
             if varname.strip() == '':
-                problems.append("Download name cannot be empty string, found: '{}' as name".format(varname))
+                _file_problem(problems, project_file,
+                              "Download name cannot be empty string, found: '{}' as name".format(varname))
                 continue
             DownloadRequirement._parse(self.registry, varname, item, problems, requirements)
 
@@ -296,13 +312,15 @@ class _ConfigCache(object):
             return
 
         if not isinstance(services, dict):
-            problems.append(("{}: 'services:' section should be a dictionary from environment variable to " +
-                             "service type, found {}").format(project_file.filename, repr(services)))
+            _file_problem(problems, project_file,
+                          ("'services:' section should be a dictionary from environment variable to " +
+                           "service type, found {}").format(repr(services)))
             return
 
         for varname, item in services.items():
             if varname.strip() == '':
-                problems.append("Service name cannot be empty string, found: '{}' as name".format(varname))
+                _file_problem(problems, project_file,
+                              "Service name cannot be empty string, found: '{}' as name".format(varname))
                 continue
             ServiceRequirement._parse(self.registry, varname, item, problems, requirements)
 
@@ -310,8 +328,8 @@ class _ConfigCache(object):
         def _parse_string_list_with_special(parent_dict, key, what, special_filter):
             items = parent_dict.get(key, [])
             if not isinstance(items, (list, tuple)):
-                problems.append("%s: %s: value should be a list of %ss, not '%r'" %
-                                (project_file.filename, key, what, items))
+                _file_problem(problems, project_file,
+                              "%s: value should be a list of %ss, not '%r'" % (key, what, items))
                 return ([], [])
             cleaned = []
             special = []
@@ -321,8 +339,8 @@ class _ConfigCache(object):
                 elif special_filter(item):
                     special.append(item)
                 else:
-                    problems.append("%s: %s: value should be a %s (as a string) not '%r'" %
-                                    (project_file.filename, key, what, item))
+                    _file_problem(problems, project_file,
+                                  ("%s: value should be a %s (as a string) not '%r'" % (key, what, item)))
             return (cleaned, special)
 
         def _parse_string_list(parent_dict, key, what):
@@ -337,7 +355,7 @@ class _ConfigCache(object):
             for dep in deps:
                 parsed = conda_api.parse_spec(dep)
                 if parsed is None:
-                    problems.append("%s: invalid package specification: %s" % (project_file.filename, dep))
+                    _file_problem(problems, project_file, "invalid package specification: %s" % (dep))
 
             # note that multiple "pip:" dicts are allowed
             pip_deps = []
@@ -348,7 +366,7 @@ class _ConfigCache(object):
             for dep in pip_deps:
                 parsed = pip_api.parse_spec(dep)
                 if parsed is None:
-                    problems.append("%s: invalid pip package specifier: %s" % (project_file.filename, dep))
+                    _file_problem(problems, project_file, "invalid pip package specifier: %s" % (dep))
 
             return (deps, pip_deps)
 
@@ -373,12 +391,13 @@ class _ConfigCache(object):
                 env_specs_is_empty_or_missing = True
             for (name, attrs) in env_specs.items():
                 if name.strip() == '':
-                    problems.append("Environment spec name cannot be empty string, found: '{}' as name".format(name))
+                    _file_problem(problems, project_file,
+                                  "Environment spec name cannot be empty string, found: '{}' as name".format(name))
                     continue
                 description = attrs.get('description', None)
                 if description is not None and not is_string(description):
-                    problems.append("{}: 'description' field of environment {} must be a string".format(
-                        project_file.filename, name))
+                    _file_problem(problems, project_file,
+                                  ("'description' field of environment {} must be a string".format(name)))
                     continue
 
                 problem_count = len(problems)
@@ -408,9 +427,9 @@ class _ConfigCache(object):
                 if first_env_spec_name is None:
                     first_env_spec_name = name
         else:
-            problems.append(
-                "%s: env_specs should be a dictionary from environment name to environment attributes, not %r" %
-                (project_file.filename, env_specs))
+            _file_problem(problems, project_file,
+                          "env_specs should be a dictionary from environment name to environment attributes, not %r" %
+                          (env_specs))
 
         self.env_specs = dict()
 
@@ -420,9 +439,9 @@ class _ConfigCache(object):
             if name not in self.env_specs:
                 was_cycle = False
                 if name in trail:
-                    problems.append(
-                        "{}: 'inherit_from' fields create circular inheritance among these env specs: {}".format(
-                            project_file.filename, ", ".join(sorted(trail))))
+                    _file_problem(problems, project_file,
+                                  ("'inherit_from' fields create circular inheritance among these env specs: {}".format(
+                                      ", ".join(sorted(trail)))))
                     was_cycle = True
                 trail.append(name)
 
@@ -432,9 +451,9 @@ class _ConfigCache(object):
                     inherit_from_names = attrs['inherit_from_names']
                     for parent in inherit_from_names:
                         if parent not in env_spec_attrs:
-                            problems.append(("{}: name '{}' in 'inherit_from' field of env spec {} does not match " +
-                                             "the name of another env spec").format(project_file.filename, parent,
-                                                                                    attrs['name']))
+                            _file_problem(problems, project_file,
+                                          ("name '{}' in 'inherit_from' field of env spec {} does not match " +
+                                           "the name of another env spec").format(parent, attrs['name']))
                         else:
                             inherit_from = make_env_spec(parent, trail)
                             attrs['inherit_from'] = attrs['inherit_from'] + (inherit_from, )
@@ -499,6 +518,8 @@ class _ConfigCache(object):
                 project.project_file.set_value(['skip_imports', 'environment'],
                                                importable_spec.channels_and_packages_hash)
 
+            # we don't set the filename here because it isn't really an error in the
+            # file, it ends up reading strangely.
             problems.append(ProjectProblem(text=text,
                                            fix_prompt=prompt,
                                            fix_function=overwrite_env_spec_from_importable,
@@ -514,7 +535,8 @@ class _ConfigCache(object):
                 default_spec = _anaconda_default_env_spec(self.global_base_env_spec)
                 project.project_file.set_value(['env_specs', default_spec.name], default_spec.to_json())
 
-            problems.append(ProjectProblem(text=("%s has an empty env_specs section." % project_file.filename),
+            problems.append(ProjectProblem(text="The env_specs section is empty.",
+                                           filename=project_file.filename,
                                            fix_prompt=("Add an environment spec to %s?" % os.path.basename(
                                                project_file.filename)),
                                            fix_function=add_default_env_spec))
@@ -540,43 +562,47 @@ class _ConfigCache(object):
         commands = dict()
         commands_section = project_file.get_value('commands', None)
         if commands_section is not None and not isinstance(commands_section, dict):
-            problems.append("%s: 'commands:' section should be a dictionary from command names to attributes, not %r" %
-                            (project_file.filename, commands_section))
+            _file_problem(problems, project_file,
+                          "'commands:' section should be a dictionary from command names to attributes, not %r" %
+                          (commands_section))
             failed = True
         elif commands_section is not None:
             for (name, attrs) in commands_section.items():
                 if name.strip() == '':
-                    problems.append("Command variable name cannot be empty string, found: '{}' as name".format(name))
+                    _file_problem(problems, project_file,
+                                  "Command variable name cannot be empty string, found: '{}' as name".format(name))
                     failed = True
                     continue
                 if first_command_name is None:
                     first_command_name = name
 
                 if not isinstance(attrs, dict):
-                    problems.append("%s: command name '%s' should be followed by a dictionary of attributes not %r" %
-                                    (project_file.filename, name, attrs))
+                    _file_problem(problems, project_file,
+                                  "command name '%s' should be followed by a dictionary of attributes not %r" %
+                                  (name, attrs))
                     failed = True
                     continue
 
                 if 'description' in attrs and not is_string(attrs['description']):
-                    problems.append("{}: 'description' field of command {} must be a string".format(
-                        project_file.filename, name))
+                    _file_problem(problems, project_file,
+                                  "'description' field of command {} must be a string".format(name))
                     failed = True
 
                 if 'supports_http_options' in attrs and not isinstance(attrs['supports_http_options'], bool):
-                    problems.append("{}: 'supports_http_options' field of command {} must be a boolean".format(
-                        project_file.filename, name))
+                    _file_problem(problems, project_file,
+                                  ("'supports_http_options' field of command {} must be a boolean".format(name)))
                     failed = True
 
                 if 'env_spec' in attrs:
                     if not is_string(attrs['env_spec']):
-                        problems.append(
-                            "{}: 'env_spec' field of command {} must be a string (an environment spec name)".format(
-                                project_file.filename, name))
+                        _file_problem(
+                            problems, project_file,
+                            "'env_spec' field of command {} must be a string (an environment spec name)".format(name))
                         failed = True
                     elif attrs['env_spec'] not in self.env_specs:
-                        problems.append("%s: env_spec '%s' for command '%s' does not appear in the env_specs section" %
-                                        (project_file.filename, attrs['env_spec'], name))
+                        _file_problem(problems, project_file,
+                                      "env_spec '%s' for command '%s' does not appear in the env_specs section" %
+                                      (attrs['env_spec'], name))
                         failed = True
 
                 copied_attrs = deepcopy(attrs)
@@ -595,13 +621,12 @@ class _ConfigCache(object):
                     command_types.append(attr)
 
                     if not is_string(copied_attrs[attr]):
-                        problems.append("%s: command '%s' attribute '%s' should be a string not '%r'" %
-                                        (project_file.filename, name, attr, copied_attrs[attr]))
+                        _file_problem(problems, project_file, "command '%s' attribute '%s' should be a string not '%r'"
+                                      % (name, attr, copied_attrs[attr]))
                         failed = True
 
                 if len(command_types) == 0:
-                    problems.append("%s: command '%s' does not have a command line in it" %
-                                    (project_file.filename, name))
+                    _file_problem(problems, project_file, "command '%s' does not have a command line in it" % (name))
                     failed = True
 
                 if ('notebook' in copied_attrs or 'bokeh_app' in copied_attrs) and (len(command_types) > 1):
@@ -609,8 +634,9 @@ class _ConfigCache(object):
                     others = copy(command_types)
                     others.remove(label)
                     others = [("'%s'" % other) for other in others]
-                    problems.append("%s: command '%s' has multiple commands in it, '%s' can't go with %s" %
-                                    (project_file.filename, name, label, ", ".join(others)))
+                    _file_problem(problems, project_file,
+                                  "command '%s' has multiple commands in it, '%s' can't go with %s" %
+                                  (name, label, ", ".join(others)))
                     failed = True
 
                 # note that once one command fails, we don't add any more
@@ -639,8 +665,9 @@ class _ConfigCache(object):
                 # skip ALL notebooks forever
                 return
             elif not isinstance(skipped_notebooks, list):
-                problems.append("{}: 'skip_imports: notebooks:' value should be a list, found {}".format(
-                    project_file.filename, repr(skipped_notebooks)))
+                _file_problem(
+                    problems, project_file,
+                    "'skip_imports: notebooks:' value should be a list, found {}".format(repr(skipped_notebooks)))
                 return
         else:
             skipped_notebooks = []
@@ -702,7 +729,8 @@ class _ConfigCache(object):
         if len(need_to_import) == 1:
             relative_name = need_to_import[0]
             problem = ProjectProblem(
-                text="%s: No command runs notebook %s" % (project_file.filename, relative_name),
+                text="No command runs notebook %s" % (relative_name),
+                filename=project_file.filename,
                 fix_prompt="Create a command in %s for %s?" % (os.path.basename(project_file.filename), relative_name),
                 fix_function=make_add_notebook_func(relative_name, self.default_env_spec_name),
                 no_fix_function=make_no_add_notebook_func(relative_name),
@@ -721,13 +749,13 @@ class _ConfigCache(object):
                 for f in no_add_funcs:
                     f(project)
 
-            problem = ProjectProblem(
-                text="%s: No commands run notebooks %s" % (project_file.filename, ", ".join(need_to_import)),
-                fix_prompt="Create commands in %s for all missing notebooks?" % (os.path.basename(project_file.filename)
-                                                                                 ),
-                fix_function=add_all,
-                no_fix_function=no_add_all,
-                only_a_suggestion=True)
+            problem = ProjectProblem(text="No commands run notebooks %s" % (", ".join(need_to_import)),
+                                     filename=project_file.filename,
+                                     fix_prompt="Create commands in %s for all missing notebooks?" % (os.path.basename(
+                                         project_file.filename)),
+                                     fix_function=add_all,
+                                     no_fix_function=no_add_all,
+                                     only_a_suggestion=True)
             problems.append(problem)
 
     def _verify_command_dependencies(self, problems, project_file):
@@ -747,13 +775,13 @@ class _ConfigCache(object):
                             packages.append(m)
                     project.project_file.set_value(['env_specs', env_spec.name, 'packages'], packages)
 
-                problem = ProjectProblem(
-                    text=("%s: Command %s uses env spec %s which does not have the packages: %s" % (
-                        project_file.filename, command.name, env_spec.name, ", ".join(missing))),
-                    fix_prompt=("Add %s to env spec %s in %s?" % (", ".join(missing), env_spec.name, os.path.basename(
-                        project_file.filename))),
-                    fix_function=add_packages_to_env_spec,
-                    only_a_suggestion=True)
+                problem = ProjectProblem(text=("Command %s uses env spec %s which does not have the packages: %s" % (
+                    command.name, env_spec.name, ", ".join(missing))),
+                                         filename=project_file.filename,
+                                         fix_prompt=("Add %s to env spec %s in %s?" % (", ".join(
+                                             missing), env_spec.name, os.path.basename(project_file.filename))),
+                                         fix_function=add_packages_to_env_spec,
+                                         only_a_suggestion=True)
                 problems.append(problem)
 
 

--- a/anaconda_project/test/test_prepare.py
+++ b/anaconda_project/test/test_prepare.py
@@ -82,8 +82,8 @@ def test_unprepare_problem_project():
         status = unprepare(project, result)
         assert not status
         assert status.status_description == 'Unable to load the project.'
-        assert status.errors == ['variables section contains wrong value type 42, ' +
-                                 'should be dict or list of requirements']
+        assert status.errors == [('%s: variables section contains wrong value type 42, ' +
+                                  'should be dict or list of requirements') % project.project_file.filename]
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, unprepare_problems)
 

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1040,6 +1040,14 @@ def test_corrupted_project_file_and_meta_file():
         assert 'anaconda-project.yml has a syntax error that needs to be fixed by hand' in project.problems[0]
         assert 'meta.yaml has a syntax error that needs to be fixed by hand' in project.problems[1]
 
+        problem1 = project.problem_objects[0]
+        assert problem1.maybe_line_number == 2
+        assert problem1.maybe_column_number == 9
+
+        problem2 = project.problem_objects[1]
+        assert problem2.maybe_line_number == 2
+        assert problem2.maybe_column_number == 9
+
     with_directory_contents(
         {DEFAULT_PROJECT_FILENAME: """
 ^

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -187,11 +187,15 @@ variables:
 def test_problem_empty_names():
     def check_problem(dirname):
         project = project_no_dedicated_env(dirname)
-        assert "Variable name cannot be empty string, found: ' ' as name" in project.problems
-        assert "Download name cannot be empty string, found: ' ' as name" in project.problems
-        assert "Service name cannot be empty string, found: ' ' as name" in project.problems
-        assert "Environment spec name cannot be empty string, found: ' ' as name" in project.problems
-        assert "Command variable name cannot be empty string, found: ' ' as name" in project.problems
+
+        def _fn(s):
+            return "%s: %s" % (project.project_file.filename, s)
+
+        assert _fn("Variable name cannot be empty string, found: ' ' as name") in project.problems
+        assert _fn("Download name cannot be empty string, found: ' ' as name") in project.problems
+        assert _fn("Service name cannot be empty string, found: ' ' as name") in project.problems
+        assert _fn("Environment spec name cannot be empty string, found: ' ' as name") in project.problems
+        assert _fn("Command variable name cannot be empty string, found: ' ' as name") in project.problems
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
@@ -214,7 +218,8 @@ commands:
 def test_problem_empty_names_var_list():
     def check_problem(dirname):
         project = project_no_dedicated_env(dirname)
-        assert "Variable name cannot be empty string, found: ' ' as name" in project.problems
+        assert ("%s: Variable name cannot be empty string, found: ' ' as name" %
+                project.project_file.filename) in project.problems
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
@@ -595,8 +600,8 @@ packages:
 def test_complain_about_conda_env_in_variables_list():
     def check_complain_about_conda_env_var(dirname):
         project = project_no_dedicated_env(dirname)
-        template = "Environment variable %s is reserved for Conda's use, " + \
-                   "so it can't appear in the variables section."
+        template = (project.project_file.filename + ": Environment variable %s is reserved for Conda's use, " +
+                    "so it can't appear in the variables section.")
         assert [template % 'CONDA_ENV_PATH', template % 'CONDA_DEFAULT_ENV', template % 'CONDA_PREFIX'
                 ] == project.problems
 
@@ -612,8 +617,8 @@ variables:
 def test_complain_about_conda_env_in_variables_dict():
     def check_complain_about_conda_env_var(dirname):
         project = project_no_dedicated_env(dirname)
-        template = "Environment variable %s is reserved for Conda's use, " + \
-                   "so it can't appear in the variables section."
+        template = (project.project_file.filename + ": Environment variable %s is reserved for Conda's use, " +
+                    "so it can't appear in the variables section.")
         assert [template % 'CONDA_ENV_PATH', template % 'CONDA_DEFAULT_ENV', template % 'CONDA_PREFIX'
                 ] == project.problems
 
@@ -1037,16 +1042,20 @@ def test_corrupted_project_file_and_meta_file():
         project = project_no_dedicated_env(dirname)
         assert 0 == len(project.requirements)
         assert 2 == len(project.problems)
-        assert 'anaconda-project.yml has a syntax error that needs to be fixed by hand' in project.problems[0]
-        assert 'meta.yaml has a syntax error that needs to be fixed by hand' in project.problems[1]
+        assert 'anaconda-project.yml: Syntax error: ' in project.problems[0]
+        assert 'meta.yaml: Syntax error: ' in project.problems[1]
 
         problem1 = project.problem_objects[0]
         assert problem1.maybe_line_number == 2
         assert problem1.maybe_column_number == 9
+        assert problem1.maybe_filename == project.project_file.filename
+        assert problem1.text_without_filename.startswith("Syntax error:")
 
         problem2 = project.problem_objects[1]
         assert problem2.maybe_line_number == 2
         assert problem2.maybe_column_number == 9
+        assert problem2.maybe_filename == project.conda_meta_file.filename
+        assert problem2.text_without_filename.startswith("Syntax error:")
 
     with_directory_contents(
         {DEFAULT_PROJECT_FILENAME: """
@@ -2391,7 +2400,7 @@ def test_auto_fix_missing_env_specs_section():
         assert len(project.problems) == 1
         assert len(project.problem_objects) == 1
         problem = project.problem_objects[0]
-        assert problem.text == ("%s has an empty env_specs section." % os.path.join(dirname, DEFAULT_PROJECT_FILENAME))
+        assert problem.text == ("%s: The env_specs section is empty." % os.path.join(dirname, DEFAULT_PROJECT_FILENAME))
         assert problem.can_fix
 
         problem.fix(project)
@@ -2410,7 +2419,7 @@ def test_auto_fix_empty_env_specs_section():
         assert len(project.problem_objects) == 1
         assert len(project.fixable_problems) == 1
         problem = project.problem_objects[0]
-        assert problem.text == ("%s has an empty env_specs section." % os.path.join(dirname, DEFAULT_PROJECT_FILENAME))
+        assert problem.text == ("%s: The env_specs section is empty." % os.path.join(dirname, DEFAULT_PROJECT_FILENAME))
         assert problem.can_fix
 
         problem.fix(project)

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -252,8 +252,8 @@ def test_set_properties_with_project_file_problems():
         project = Project(dirname)
         status = project_ops.set_properties(project, name='foo')
         assert not status
-        assert ["variables section contains wrong value type 42, should be dict or list of requirements"
-                ] == status.errors
+        assert ["%s: variables section contains wrong value type 42, should be dict or list of requirements" %
+                project.project_file.filename] == status.errors
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 
@@ -829,8 +829,8 @@ def test_update_command_with_project_file_problems():
         status = project_ops.update_command(project, 'foo', 'unix', 'echo hello')
 
         assert not status
-        assert ["variables section contains wrong value type 42, should be dict or list of requirements"
-                ] == status.errors
+        assert ["%s: variables section contains wrong value type 42, should be dict or list of requirements" %
+                project.project_file.filename] == status.errors
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 
@@ -1252,8 +1252,8 @@ def test_add_download_with_project_file_problems():
 
         assert not os.path.isfile(os.path.join(dirname, "MYDATA"))
         assert not status
-        assert ["variables section contains wrong value type 42, should be dict or list of requirements"
-                ] == status.errors
+        assert ["%s: variables section contains wrong value type 42, should be dict or list of requirements" %
+                project.project_file.filename] == status.errors
 
         # be sure download was NOT added to the file
         project2 = project_no_dedicated_env(dirname)
@@ -1616,8 +1616,8 @@ def test_remove_packages_with_project_file_problems():
         status = project_ops.remove_packages(project, env_spec_name=None, packages=['foo'])
 
         assert not status
-        assert ["variables section contains wrong value type 42, should be dict or list of requirements"
-                ] == status.errors
+        assert ["%s: variables section contains wrong value type 42, should be dict or list of requirements" %
+                project.project_file.filename] == status.errors
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 
@@ -1767,8 +1767,8 @@ def test_add_service_with_project_file_problems():
         status = project_ops.add_service(project, service_type='redis')
 
         assert not status
-        assert ["variables section contains wrong value type 42, should be dict or list of requirements"
-                ] == status.errors
+        assert ["%s: variables section contains wrong value type 42, should be dict or list of requirements" %
+                project.project_file.filename] == status.errors
 
         # be sure service was NOT added to the file
         project2 = Project(dirname)
@@ -3123,8 +3123,8 @@ def test_upload_with_project_file_problems():
         project = Project(dirname)
         status = project_ops.upload(project)
         assert not status
-        assert ["variables section contains wrong value type 42, should be dict or list of requirements"
-                ] == status.errors
+        assert ["%s: variables section contains wrong value type 42, should be dict or list of requirements" %
+                project.project_file.filename] == status.errors
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42"}, check)
 

--- a/anaconda_project/yaml_file.py
+++ b/anaconda_project/yaml_file.py
@@ -119,6 +119,8 @@ class YamlFile(object):
         """
         self._corrupted = False
         self._corrupted_error_message = None
+        self._corrupted_maybe_line = None
+        self._corrupted_maybe_column = None
         self._change_count = self._change_count + 1
 
         try:
@@ -134,6 +136,15 @@ class YamlFile(object):
         except YAMLError as e:
             self._corrupted = True
             self._corrupted_error_message = str(e)
+            # Not sure all this paranoia is needed
+            # about whether these values really exist,
+            # but hard to prove it isn't.
+            mark = getattr(e, 'problem_mark', None)
+            if mark is not None:
+                if mark.line is not None and mark.line >= 0:
+                    self._corrupted_maybe_line = mark.line
+                if mark.column is not None and mark.column >= 0:
+                    self._corrupted_maybe_column = mark.column
             self._yaml = None
 
         if self._yaml is None:
@@ -177,6 +188,24 @@ class YamlFile(object):
             Corruption message or None.
         """
         return self._corrupted_error_message
+
+    @property
+    def corrupted_maybe_line(self):
+        """Get the line number for syntax error, or None if unavailable.
+
+        Returns:
+            Corruption line or None.
+        """
+        return self._corrupted_maybe_line
+
+    @property
+    def corrupted_maybe_column(self):
+        """Get the column for syntax error, or None if unavailable.
+
+        Returns:
+            Corruption column or None.
+        """
+        return self._corrupted_maybe_column
 
     @property
     def change_count(self):


### PR DESCRIPTION
Problems now have properties:
 * maybe_line (line number or None)
 * maybe_column (column number or None)
 * maybe_filename (filename with the problem, or None)
 * text_without_filename (the problem.text minus filename in front if normally there would be one)

cc @goanpeca 