### PR TITLE
Improvements to the default anaconda-project.yml

### DIFF
--- a/anaconda_project/commands/test/test_environment_commands.py
+++ b/anaconda_project/commands/test/test_environment_commands.py
@@ -285,6 +285,26 @@ def test_export_env_spec(capsys, monkeypatch):
         }, check)
 
 
+def test_export_env_spec_default_name(capsys, monkeypatch):
+    def check(dirname):
+        _monkeypatch_pwd(monkeypatch, dirname)
+
+        exported = os.path.join(dirname, "exported.yml")
+        code = _parse_args_and_run_subcommand(['anaconda-project', 'export-env-spec', exported])
+        assert code == 0
+
+        out, err = capsys.readouterr()
+        assert '' == err
+        assert ('Exported environment spec foo to %s.\n' % exported) == out
+
+    with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME: 'env_specs:\n  foo:\n    channels: []\n    packages:\n    - bar\n' +
+            '  bar:\n    channels: []\n    packages:\n    - baz\n',
+            'envs/foo/bin/test': 'code here'
+        }, check)
+
+
 def test_export_env_spec_no_filename(capsys, monkeypatch):
     def check(dirname):
         _monkeypatch_pwd(monkeypatch, dirname)

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -285,9 +285,13 @@ class EnvSpec(object):
         # have ordering... OrderedDict doesn't work because the
         # yaml saver saves them as some "!!omap" nonsense. Other
         # than ordering, the formatting isn't even preserved here.
-        template_json = ryaml.load("something:\n    packages: []\n" + "    channels: []\n",
+        template_json = ryaml.load("something:\n    description: null\n" + "    packages: []\n" + "    channels: []\n",
                                    Loader=ryaml.RoundTripLoader)
 
+        if self._description is not None:
+            template_json['something']['description'] = self._description
+        else:
+            del template_json['something']['description']
         template_json['something']['packages'] = packages
         template_json['something']['channels'] = channels
 

--- a/anaconda_project/project_file.py
+++ b/anaconda_project/project_file.py
@@ -121,9 +121,8 @@ class ProjectFile(YamlFile):
         sections['packages'] = ("In the packages section, list any packages that must be installed\n" +
                                 "before your code runs.\n" + "Use `anaconda-project add-packages` to add packages.\n")
 
-        sections['channels'] = (
-            "In the channels section, list any Conda channel URLs to be searched\n" + "for packages.\n" + "\n" +
-            "For example,\n" + "\n" + "channels:\n" + "   - https://conda.anaconda.org/asmeurer\n")
+        sections['channels'] = ("In the channels section, list any Conda channel URLs to be searched\n" +
+                                "for packages.\n" + "\n" + "For example,\n" + "\n" + "channels:\n" + "   - mychannel\n")
 
         sections['env_specs'] = (
             "You can define multiple, named environment specs.\n" + "Each inherits any global packages or channels,\n" +

--- a/anaconda_project/project_file.py
+++ b/anaconda_project/project_file.py
@@ -156,4 +156,21 @@ class ProjectFile(YamlFile):
         for env_spec in default_env_specs:
             as_json['env_specs'][env_spec.name] = env_spec.to_json()
 
+        if len(default_env_specs) == 1:
+            # if there's only one env spec, keep it for name/description
+            # and put the packages and channels up in the global sections
+            spec_name = next(iter(as_json['env_specs']))
+            spec_json = as_json['env_specs'][spec_name]
+
+            def move_list_elements(src, dest):
+                # we want to preserve the dest list object with comments
+                del dest[:]
+                dest.extend(src)
+                del src[:]
+
+            if 'packages' in spec_json:
+                move_list_elements(spec_json['packages'], as_json['packages'])
+            if 'channels' in spec_json:
+                move_list_elements(spec_json['channels'], as_json['channels'])
+
         return as_json

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -446,17 +446,19 @@ def export_env_spec(project, name, filename):
 
     Args:
         project (Project): the project
-        name (str): environment spec name
+        name (str): environment spec name or None for default
         filename (str): file to export to
 
     Returns:
         ``Status`` instance
     """
-    assert name is not None
-
     failed = project.problems_status()
     if failed is not None:
         return failed
+
+    if name is None:
+        name = project.default_env_spec_name
+    assert name is not None
 
     if name not in project.env_specs:
         problem = "Environment spec {} doesn't exist.".format(name)

--- a/anaconda_project/test/test_env_spec.py
+++ b/anaconda_project/test/test_env_spec.py
@@ -250,6 +250,7 @@ def test_to_json():
                  inherit_from_names=(),
                  inherit_from=())
     spec = EnvSpec(name="foo",
+                   description="The Foo Spec",
                    conda_packages=['a', 'b'],
                    pip_packages=['c', 'd'],
                    channels=['x', 'y'],
@@ -257,7 +258,23 @@ def test_to_json():
                    inherit_from=(hi, ))
     json = spec.to_json()
 
-    assert {'channels': ['x', 'y'], 'inherit_from': 'hi', 'packages': ['a', 'b', {'pip': ['c', 'd']}]} == json
+    assert {'description': "The Foo Spec",
+            'channels': ['x', 'y'],
+            'inherit_from': 'hi',
+            'packages': ['a', 'b', {'pip': ['c', 'd']}]} == json
+
+
+def test_to_json_no_description_no_pip_no_inherit():
+    # should be able to jsonify a spec with no description
+    spec = EnvSpec(name="foo",
+                   conda_packages=['a', 'b'],
+                   pip_packages=[],
+                   channels=['x', 'y'],
+                   inherit_from_names=(),
+                   inherit_from=())
+    json = spec.to_json()
+
+    assert {'channels': ['x', 'y'], 'packages': ['a', 'b']} == json
 
 
 def test_to_json_multiple_inheritance():

--- a/anaconda_project/test/test_project_file.py
+++ b/anaconda_project/test/test_project_file.py
@@ -60,7 +60,7 @@ packages: []
 # For example,
 #
 # channels:
-#    - https://conda.anaconda.org/asmeurer
+#    - mychannel
 #
 channels: []
 #

--- a/anaconda_project/test/test_project_file.py
+++ b/anaconda_project/test/test_project_file.py
@@ -9,8 +9,9 @@ import os
 
 from anaconda_project.internal.test.tmpfile_utils import with_directory_contents
 from anaconda_project.project_file import ProjectFile, DEFAULT_PROJECT_FILENAME, possible_project_file_names
+from anaconda_project.env_spec import EnvSpec
 
-expected_default_file = """# This is an Anaconda project file.
+expected_default_file_template = """# This is an Anaconda project file.
 #
 # Here you can describe your project and how to run it.
 # Use `anaconda-project run` to run the project.
@@ -47,13 +48,17 @@ services: {}
 # Use `anaconda-project add-download` to add downloads.
 #
 downloads: {}
-#
+%s%s%s"""
+
+empty_global_packages = """#
 # In the packages section, list any packages that must be installed
 # before your code runs.
 # Use `anaconda-project add-packages` to add packages.
 #
 packages: []
-#
+"""
+
+empty_global_channels = """#
 # In the channels section, list any Conda channel URLs to be searched
 # for packages.
 #
@@ -63,7 +68,9 @@ packages: []
 #    - mychannel
 #
 channels: []
-#
+"""
+
+empty_default_env_specs = """#
 # You can define multiple, named environment specs.
 # Each inherits any global packages or channels,
 # but can have its own unique ones also.
@@ -71,6 +78,15 @@ channels: []
 #
 env_specs: {default: {packages: [], channels: []}}
 """
+
+
+def _make_file_contents(packages, channels, env_specs):
+    return expected_default_file_template % (packages, channels, env_specs)
+
+
+expected_default_file = _make_file_contents(packages=empty_global_packages,
+                                            channels=empty_global_channels,
+                                            env_specs=empty_default_env_specs)
 
 
 def test_create_missing_project_file():
@@ -119,3 +135,117 @@ def test_load_directory_without_project_file():
         assert project_file.get_value(["a", "b"]) is None
 
     with_directory_contents(dict(), read_missing_file)
+
+
+abc_xyz_populated_env_specs = """#
+# You can define multiple, named environment specs.
+# Each inherits any global packages or channels,
+# but can have its own unique ones also.
+# Use `anaconda-project add-env-spec` to add environment specs.
+#
+env_specs: {abc: {description: ABC, packages: [anaconda], channels: [mychannel]}}
+"""
+
+anaconda_global_packages = """#
+# In the packages section, list any packages that must be installed
+# before your code runs.
+# Use `anaconda-project add-packages` to add packages.
+#
+packages: [anaconda]
+"""
+
+mychannel_global_channels = """#
+# In the channels section, list any Conda channel URLs to be searched
+# for packages.
+#
+# For example,
+#
+# channels:
+#    - mychannel
+#
+channels: [mychannel]
+"""
+
+abc_empty_env_spec = """#
+# You can define multiple, named environment specs.
+# Each inherits any global packages or channels,
+# but can have its own unique ones also.
+# Use `anaconda-project add-env-spec` to add environment specs.
+#
+env_specs: {abc: {description: ABC, packages: [], channels: []}}
+"""
+
+expected_one_env_spec_contents = _make_file_contents(packages=anaconda_global_packages,
+                                                     channels=mychannel_global_channels,
+                                                     env_specs=abc_empty_env_spec)
+
+
+def test_create_missing_project_file_one_default_env_spec():
+    def create_file(dirname):
+        def default_env_specs_func():
+            return [EnvSpec(name='abc',
+                            conda_packages=['anaconda'],
+                            pip_packages=[],
+                            channels=['mychannel'],
+                            description="ABC",
+                            inherit_from_names=(),
+                            inherit_from=())]
+
+        filename = os.path.join(dirname, DEFAULT_PROJECT_FILENAME)
+        assert not os.path.exists(filename)
+        project_file = ProjectFile.load_for_directory(dirname, default_env_specs_func=default_env_specs_func)
+        assert project_file is not None
+        assert not os.path.exists(filename)
+        project_file.save()
+        assert os.path.exists(filename)
+        with codecs.open(filename, 'r', 'utf-8') as file:
+            contents = file.read()
+            assert expected_one_env_spec_contents == contents
+
+    with_directory_contents(dict(), create_file)
+
+
+abc_xyz_env_specs = """#
+# You can define multiple, named environment specs.
+# Each inherits any global packages or channels,
+# but can have its own unique ones also.
+# Use `anaconda-project add-env-spec` to add environment specs.
+#
+env_specs: {abc: {description: ABC, packages: [anaconda], channels: [mychannel]},
+  xyz: {description: XYZ, packages: [foo], channels: [bar]}}
+"""
+
+expected_two_env_spec_contents = _make_file_contents(packages=empty_global_packages,
+                                                     channels=empty_global_channels,
+                                                     env_specs=abc_xyz_env_specs)
+
+
+def test_create_missing_project_file_two_default_env_specs():
+    def create_file(dirname):
+        def default_env_specs_func():
+            return [EnvSpec(name='abc',
+                            conda_packages=['anaconda'],
+                            pip_packages=[],
+                            channels=['mychannel'],
+                            description="ABC",
+                            inherit_from_names=(),
+                            inherit_from=()), EnvSpec(name='xyz',
+                                                      conda_packages=['foo'],
+                                                      pip_packages=[],
+                                                      channels=['bar'],
+                                                      description="XYZ",
+                                                      inherit_from_names=(),
+                                                      inherit_from=())]
+
+        filename = os.path.join(dirname, DEFAULT_PROJECT_FILENAME)
+        assert not os.path.exists(filename)
+        project_file = ProjectFile.load_for_directory(dirname, default_env_specs_func=default_env_specs_func)
+        assert project_file is not None
+        assert not os.path.exists(filename)
+        project_file.save()
+        assert os.path.exists(filename)
+        with codecs.open(filename, 'r', 'utf-8') as file:
+            contents = file.read()
+            assert expected_two_env_spec_contents == contents
+
+    with_directory_contents(dict(), create_file)


### PR DESCRIPTION
The main thing here is to close #20 by using global `packages:` instead of env-spec-specific `packages:` by default. Fixed a few other things I found along the way too.