### PR TITLE
Disallow archiving/uploading projects without a project file

### DIFF
--- a/anaconda_project/archiver.py
+++ b/anaconda_project/archiver.py
@@ -297,6 +297,18 @@ def _archive_project(project, filename):
     if failed is not None:
         return failed
 
+    if not os.path.exists(project.project_file.filename):
+        return SimpleStatus(success=False,
+                            description="Can't create an archive.",
+                            errors=[("%s does not exist." % project.project_file.basename)])
+
+    # this would most likely happen in a GUI editor, if it reloaded
+    # the project from memory but hadn't saved yet.
+    if project.project_file.has_unsaved_changes:
+        return SimpleStatus(success=False,
+                            description="Can't create an archive.",
+                            errors=[("%s has been modified but not saved." % project.project_file.basename)])
+
     errors = []
     infos = _enumerate_archive_files(project.directory_path, errors, requirements=project.requirements)
     if infos is None:

--- a/anaconda_project/commands/project_load.py
+++ b/anaconda_project/commands/project_load.py
@@ -17,6 +17,7 @@ def load_project(dirname):
     project = Project(dirname)
 
     if console_utils.stdin_is_interactive():
+        had_fixable = len(project.fixable_problems) > 0
         for problem in project.fixable_problems:
             print(problem.text)
             should_fix = console_utils.console_ask_yes_or_no(problem.fix_prompt, default=False)
@@ -25,7 +26,9 @@ def load_project(dirname):
             else:
                 problem.no_fix(project)
 
-        # no-op if the fixes didn't do anything
-        project.project_file.save()
+        # both fix() and no_fix() can modify project_file, if no changes
+        # were made this is a no-op.
+        if had_fixable:
+            project.project_file.save()
 
     return project

--- a/anaconda_project/internal/test/tmpfile_utils.py
+++ b/anaconda_project/internal/test/tmpfile_utils.py
@@ -78,7 +78,7 @@ def with_directory_contents(contents, func):
 def complete_project_file_content(content):
     yaml = _load_string(content)
     if yaml is None:
-        return content
+        raise AssertionError("Broken yaml: %r" % content)
     elif 'env_specs' not in yaml:
         modified = (content + "\n" + "env_specs:\n" + "  default:\n" + "    description: default\n" + "\n")
         try:

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -2777,3 +2777,11 @@ def test_unknown_field_in_env_spec():
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: "env_specs:\n  foo:\n    packages: [something]\n    somejunk: True\n"}, check)
+
+
+def test_empty_file_has_problems():
+    def check(dirname):
+        project = project_no_dedicated_env(dirname)
+        assert ['anaconda-project.yml: The env_specs section is empty.'] == project.problems
+
+    with_directory_contents({DEFAULT_PROJECT_FILENAME: ""}, check)

--- a/anaconda_project/test/test_yaml_file.py
+++ b/anaconda_project/test/test_yaml_file.py
@@ -114,6 +114,15 @@ def test_read_missing_yaml_file_and_get_default_due_to_missing_section():
     with_directory_contents(dict(), check_missing)
 
 
+def test_read_empty_yaml_file_and_get_default_due_to_missing_section():
+    def check_missing(dirname):
+        yaml = YamlFile(os.path.join(dirname, "nope.yaml"))
+        value = yaml.get_value(["z", "b"], "default")
+        assert "default" == value
+
+    with_directory_contents({"nope.yaml": ""}, check_missing)
+
+
 def test_read_yaml_file_that_is_a_directory():
     def check_read_directory(dirname):
         filename = os.path.join(dirname, "dir.yaml")
@@ -198,6 +207,34 @@ a:
         assert 42 == value2
 
     with_directory_contents(dict(), set_abc)
+
+
+def test_read_empty_yaml_file_and_set_value():
+    def set_abc(dirname):
+        filename = os.path.join(dirname, "foo.yaml")
+        assert os.path.exists(filename)
+        yaml = YamlFile(filename)
+        value = yaml.get_value(["a", "b"])
+        assert value is None
+        yaml.set_value(["a", "b"], 42)
+        yaml.save()
+        assert os.path.exists(filename)
+
+        import codecs
+        with codecs.open(filename, 'r', 'utf-8') as file:
+            changed = file.read()
+            expected = """
+a:
+  b: 42
+""" [1:]
+
+            assert expected == changed
+
+        yaml2 = YamlFile(filename)
+        value2 = yaml2.get_value(["a", "b"])
+        assert 42 == value2
+
+    with_directory_contents({"foo.yaml": ""}, set_abc)
 
 
 def test_read_yaml_file_and_add_section():

--- a/anaconda_project/yaml_file.py
+++ b/anaconda_project/yaml_file.py
@@ -232,6 +232,11 @@ class YamlFile(object):
         """
         return self._change_count
 
+    @property
+    def has_unsaved_changes(self):
+        """Get whether changes are all saved."""
+        return self._dirty
+
     def use_changes_without_saving(self):
         """Apply any in-memory changes as if we'd saved, but don't actually save.
 


### PR DESCRIPTION
There's also a change in here to make empty project files invalid, instead of implicitly assuming they have default project file contents.

Should fix #11 (by returning a failed status from the upload function).
