### PR TITLE
Test against multiple conda versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,8 @@ install:
   - printenv | sort
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda false
   - if test x"$CONDA_CANARY" = xtrue ; then conda update -n root -c conda-canary conda; fi
-  - conda install -n root conda-build psutil
+  - if test x"$MINICONDA_VERSION" = x"4.1.11" ; then CONDA_BUILD_CONSTRAINT='=2.1.5'; else CONDA_BUILD_CONSTRAINT='' ; fi
+  - conda install -n root conda-build$CONDA_BUILD_CONSTRAINT psutil
   - conda info -a
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       OS_PACKAGES=libffi ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   - source "$HOME"/miniconda/bin/activate root
   - printenv | sort
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda false
-  - if "$CONDA_CANARY" ; then conda update -n root -c conda-canary conda; fi
+  - if test x"$CONDA_CANARY" = xtrue ; then conda update -n root -c conda-canary conda; fi
   - conda install -n root conda-build psutil
   - conda info -a
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,36 +5,61 @@ language: c
 # https://github.com/travis-ci/travis-ci/issues/6861
 sudo: required
 env:
-  - TRAVIS_PYTHON_VERSION=2.7 TEST_TARGET=tests
-  - TRAVIS_PYTHON_VERSION=3.4 TEST_TARGET=tests
-  - TRAVIS_PYTHON_VERSION=3.5 TEST_TARGET=tests
-  - TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=tests
-  - TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=packaging
+  # All supported python versions
+  - MINICONDA_VERSION=4.1.11 TRAVIS_PYTHON_VERSION=2.7 TEST_TARGET=tests CONDA_CANARY=false
+  - MINICONDA_VERSION=4.1.11 TRAVIS_PYTHON_VERSION=3.4 TEST_TARGET=tests CONDA_CANARY=false
+  - MINICONDA_VERSION=4.1.11 TRAVIS_PYTHON_VERSION=3.5 TEST_TARGET=tests CONDA_CANARY=false
+  - MINICONDA_VERSION=4.1.11 TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=tests CONDA_CANARY=false
+  # Can build the package
+  - MINICONDA_VERSION=4.1.11 TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=packaging CONDA_CANARY=false
+  # 4.2 miniconda
+  - MINICONDA_VERSION=4.2.12 TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=tests CONDA_CANARY=false
+  # 4.3 miniconda
+  - MINICONDA_VERSION=4.3.11 TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=tests CONDA_CANARY=false
+  # conda canary
+  - MINICONDA_VERSION=4.3.11 TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=tests CONDA_CANARY=true
 os:
   - linux
   - osx
 matrix:
+  # disable all but one job on OS X, we just want to smoke test OS X.
   exclude:
     - os: osx
-      env: TRAVIS_PYTHON_VERSION=3.5 TEST_TARGET=packaging
+      env: MINICONDA_VERSION=4.1.11 TRAVIS_PYTHON_VERSION=2.7 TEST_TARGET=tests CONDA_CANARY=false
+    - os: osx
+      env: MINICONDA_VERSION=4.1.11 TRAVIS_PYTHON_VERSION=3.4 TEST_TARGET=tests CONDA_CANARY=false
+    - os: osx
+      env: MINICONDA_VERSION=4.1.11 TRAVIS_PYTHON_VERSION=3.5 TEST_TARGET=tests CONDA_CANARY=false
+    - os: osx
+      env: MINICONDA_VERSION=4.1.11 TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=packaging CONDA_CANARY=false
+    - os: osx
+      env: MINICONDA_VERSION=4.2.12 TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=tests CONDA_CANARY=false
+    - os: osx
+      env: MINICONDA_VERSION=4.3.11 TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=tests CONDA_CANARY=false
+    - os: osx
+      env: MINICONDA_VERSION=4.3.11 TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=tests CONDA_CANARY=true
+  allow_failures:
+    # conda canary shouldn't block the build, just show us an FYI
+    - env: MINICONDA_VERSION=4.3.11 TRAVIS_PYTHON_VERSION=3.6 TEST_TARGET=tests CONDA_CANARY=true
 install:
   - printenv | sort
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      MINICONDA_VERSION=2 ;
+      MINICONDA_PYVERSION=2 ;
     else
-      MINICONDA_VERSION=3 ;
+      MINICONDA_PYVERSION=3 ;
     fi ;
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       MINICONDA_OS=Linux ;
     else
       MINICONDA_OS=MacOSX ;
     fi ;
-    echo "Fetching Python $MINICONDA_VERSION miniconda for $MINICONDA_OS" ;
-    wget https://repo.continuum.io/miniconda/Miniconda$MINICONDA_VERSION-4.1.11-$MINICONDA_OS-x86_64.sh -O miniconda.sh
+    echo "Fetching Python $MINICONDA_PYVERSION miniconda for $MINICONDA_OS" ;
+    wget https://repo.continuum.io/miniconda/Miniconda$MINICONDA_PYVERSION-$MINICONDA_VERSION-$MINICONDA_OS-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p "$HOME"/miniconda
   - source "$HOME"/miniconda/bin/activate root
   - printenv | sort
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda false
+  - if "$CONDA_CANARY" ; then conda update -n root -c conda-canary conda; fi
   - conda install -n root conda-build psutil
   - conda info -a
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -99,16 +99,26 @@ def test_conda_create_no_packages():
     with_directory_contents(dict(), do_test)
 
 
+def _assert_packages_not_found(e):
+    # conda has changed this message several times
+    ok = False
+    for message in ('No packages found', 'Package missing in current', 'Package not found'):
+        if message in str(e):
+            ok = True
+    if not ok:
+        # pytest truncates the exception message sometimes?
+        print("Not the exception we wanted: %r" % e)
+        raise AssertionError("Expecting package not found error, got: %s" % repr(e))
+
+
 def test_conda_create_bad_package():
     def do_test(dirname):
         envdir = os.path.join(dirname, "myenv")
 
         with pytest.raises(conda_api.CondaError) as excinfo:
             conda_api.create(prefix=envdir, pkgs=['this_is_not_a_real_package'])
-        # print this because pytest truncates it
-        print("bad package excinfo.value: " + repr(excinfo.value))
-        # at some point conda changed this error message
-        assert ('No packages found' in repr(excinfo.value) or 'Package missing in current' in repr(excinfo.value))
+
+        _assert_packages_not_found(excinfo.value)
         assert 'this_is_not_a_real_package' in repr(excinfo.value)
 
     with_directory_contents(dict(), do_test)

--- a/anaconda_project/internal/test/test_default_conda_manager.py
+++ b/anaconda_project/internal/test/test_default_conda_manager.py
@@ -116,7 +116,8 @@ def test_conda_create_and_install_and_remove(monkeypatch):
         # test for error removing
         with pytest.raises(CondaManagerError) as excinfo:
             manager.remove_packages(prefix=envdir, packages=['ipython'])
-        assert 'no packages found to remove' in str(excinfo.value)
+        # different versions of conda word this differently
+        assert 'no packages found to remove' in str(excinfo.value) or 'Package not found' in str(excinfo.value)
         assert not manager._timestamp_file_up_to_date(envdir, spec)
 
         # test failure to exec pip


### PR DESCRIPTION
Also, only test one python version on OS X, not all of them.
Don't think OS X has ever failed even once when Linux passed,
so no need to waste so many jobs.