### PR TITLE
Add registers_fusion_function:true if a notebook contains @fusion.register

### DIFF
--- a/anaconda_project/commands/test/test_command_commands.py
+++ b/anaconda_project/commands/test/test_command_commands.py
@@ -224,7 +224,7 @@ def test_add_command_guessing_notebook(monkeypatch, capsys):
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: 'packages:\n - notebook\n',
-         'file.ipynb': ""}, check_guessing_notebook)
+         'file.ipynb': "{}"}, check_guessing_notebook)
 
 
 def test_add_command_with_env_spec(monkeypatch, capsys):

--- a/anaconda_project/internal/notebook_analyzer.py
+++ b/anaconda_project/internal/notebook_analyzer.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2017, Continuum Analytics, Inc. All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+"""Analyze notebook files."""
+from __future__ import absolute_import
+
+import codecs
+import json
+import re
+
+from anaconda_project.internal.py2_compat import is_string
+
+_comment_re = re.compile("#.*$", re.MULTILINE)
+_fusion_register_re = re.compile(r"^\s*@fusion\.register", re.MULTILINE)
+
+
+# see if some source has @fusion.register. This is
+# obviously sort of heuristic, but without executing
+# the python we can only do so much.
+def _has_fusion_register(source):
+    # dump comments so commenting out fusion.register
+    # would work as expected
+    source = re.sub(_comment_re, "", source)
+    return re.match(_fusion_register_re, source) is not None
+
+
+def details(filename, errors):
+    try:
+        with codecs.open(filename, encoding='utf-8') as f:
+            json_string = f.read()
+            parsed = json.loads(json_string)
+    except Exception as e:
+        errors.append("Failed to read or parse %s: %s" % (filename, str(e)))
+        return None
+
+    details = dict()
+    found_fusion = False
+
+    if isinstance(parsed, dict) and \
+       'cells' in parsed and \
+       isinstance(parsed['cells'], list):
+        for cell in parsed['cells']:
+            if 'source' in cell:
+                if isinstance(cell['source'], list):
+                    source = "".join([s for s in cell['source'] if is_string(s)])
+                    if _has_fusion_register(source):
+                        found_fusion = True
+
+    if found_fusion:
+        details['registers_fusion_function'] = True
+
+    return details

--- a/anaconda_project/internal/notebook_analyzer.py
+++ b/anaconda_project/internal/notebook_analyzer.py
@@ -27,7 +27,7 @@ def _has_fusion_register(source):
     return re.match(_fusion_register_re, source) is not None
 
 
-def details(filename, errors):
+def extras(filename, errors):
     try:
         with codecs.open(filename, encoding='utf-8') as f:
             json_string = f.read()
@@ -36,7 +36,7 @@ def details(filename, errors):
         errors.append("Failed to read or parse %s: %s" % (filename, str(e)))
         return None
 
-    details = dict()
+    extras = dict()
     found_fusion = False
 
     if isinstance(parsed, dict) and \
@@ -50,6 +50,6 @@ def details(filename, errors):
                         found_fusion = True
 
     if found_fusion:
-        details['registers_fusion_function'] = True
+        extras['registers_fusion_function'] = True
 
-    return details
+    return extras

--- a/anaconda_project/internal/test/test_notebook_analyzer.py
+++ b/anaconda_project/internal/test/test_notebook_analyzer.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2017, Continuum Analytics, Inc. All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+from __future__ import absolute_import, print_function, unicode_literals
+
+import json
+import os
+
+import anaconda_project.internal.notebook_analyzer as notebook_analyzer
+
+from anaconda_project.internal.test.tmpfile_utils import with_directory_contents
+
+
+def _fake_notebook_json_with_code(source):
+    ipynb = {
+        "cells": [
+            {"cell_type": "code",
+             # source is a list of lines with the newline included in each
+             "source": [(s + "\n") for s in source.split("\n")]}
+        ]
+    }
+    return ipynb
+
+
+def _with_code_in_notebook_file(source, f):
+    def check(dirname):
+        filename = os.path.join(dirname, "foo.ipynb")
+        return f(filename)
+
+    json_string = json.dumps(_fake_notebook_json_with_code(source))
+    with_directory_contents({"foo.ipynb": json_string}, check)
+
+
+def test_details_with_simple_has_fusion_register():
+    def check(filename):
+        errors = []
+        details = notebook_analyzer.details(filename, errors)
+        assert [] == errors
+        assert details == {'registers_fusion_function': True}
+
+    _with_code_in_notebook_file("""
+@fusion.register
+def some_func():
+   pass
+    """, check)
+
+
+def test_details_without_has_fusion_register():
+    def check(filename):
+        errors = []
+        details = notebook_analyzer.details(filename, errors)
+        assert [] == errors
+        assert details == {}
+
+    _with_code_in_notebook_file("""
+def some_func():
+   pass
+    """, check)
+
+
+def test_fusion_register():
+    assert not notebook_analyzer._has_fusion_register("")
+    assert not notebook_analyzer._has_fusion_register("fusion.register\n")
+    assert notebook_analyzer._has_fusion_register("@fusion.register\n")
+    assert notebook_analyzer._has_fusion_register("    @fusion.register\n")
+    assert not notebook_analyzer._has_fusion_register("# @fusion.register\n")
+    assert notebook_analyzer._has_fusion_register("# foo\n@fusion.register\n")
+    assert notebook_analyzer._has_fusion_register("# foo\n\n    @fusion.register\n")
+    assert notebook_analyzer._has_fusion_register("@fusion.register # foo\n")
+    assert notebook_analyzer._has_fusion_register("""
+@fusion.register(args=blah)
+def some_func():
+   pass
+""")
+    assert not notebook_analyzer._has_fusion_register("""
+# @fusion.register
+def some_func():
+   pass
+""")
+
+
+def test_details_with_io_error(monkeypatch):
+    def mock_codecs_open(*args, **kwargs):
+        raise IOError("Nope")
+
+    monkeypatch.setattr('codecs.open', mock_codecs_open)
+    errors = []
+    details = notebook_analyzer.details("blah", errors)
+    assert [] != errors
+    assert details is None
+    assert 'Failed to read or parse' in errors[0]

--- a/anaconda_project/internal/test/test_notebook_analyzer.py
+++ b/anaconda_project/internal/test/test_notebook_analyzer.py
@@ -34,12 +34,12 @@ def _with_code_in_notebook_file(source, f):
     with_directory_contents({"foo.ipynb": json_string}, check)
 
 
-def test_details_with_simple_has_fusion_register():
+def test_extras_with_simple_has_fusion_register():
     def check(filename):
         errors = []
-        details = notebook_analyzer.details(filename, errors)
+        extras = notebook_analyzer.extras(filename, errors)
         assert [] == errors
-        assert details == {'registers_fusion_function': True}
+        assert extras == {'registers_fusion_function': True}
 
     _with_code_in_notebook_file("""
 @fusion.register
@@ -48,12 +48,12 @@ def some_func():
     """, check)
 
 
-def test_details_without_has_fusion_register():
+def test_extras_without_has_fusion_register():
     def check(filename):
         errors = []
-        details = notebook_analyzer.details(filename, errors)
+        extras = notebook_analyzer.extras(filename, errors)
         assert [] == errors
-        assert details == {}
+        assert extras == {}
 
     _with_code_in_notebook_file("""
 def some_func():
@@ -82,13 +82,13 @@ def some_func():
 """)
 
 
-def test_details_with_io_error(monkeypatch):
+def test_extras_with_io_error(monkeypatch):
     def mock_codecs_open(*args, **kwargs):
         raise IOError("Nope")
 
     monkeypatch.setattr('codecs.open', mock_codecs_open)
     errors = []
-    details = notebook_analyzer.details("blah", errors)
+    extras = notebook_analyzer.extras("blah", errors)
     assert [] != errors
-    assert details is None
+    assert extras is None
     assert 'Failed to read or parse' in errors[0]

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -25,6 +25,7 @@ from anaconda_project.version import version
 from anaconda_project.internal.py2_compat import is_string
 from anaconda_project.internal.simple_status import SimpleStatus
 from anaconda_project.internal.slugify import slugify
+import anaconda_project.internal.notebook_analyzer as notebook_analyzer
 import anaconda_project.internal.conda_api as conda_api
 import anaconda_project.internal.pip_api as pip_api
 
@@ -725,7 +726,14 @@ class _ConfigCache(object):
 
         def make_add_notebook_func(relative_name, env_spec_name):
             def add_notebook(project):
-                command_dict = {'notebook': relative_name, 'env_spec': env_spec_name}
+                errors = []
+                details = notebook_analyzer.details(os.path.join(self.directory_path, relative_name), errors)
+                # TODO this is broken, need to refactor so fix functions can return
+                # errors and probably also log progress indication.
+                assert [] == errors
+                assert details is not None
+
+                command_dict = {'notebook': relative_name, 'env_spec': env_spec_name, 'details': details}
                 project.project_file.set_value(['commands', relative_name], command_dict)
 
             return add_notebook

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -593,7 +593,7 @@ class _ConfigCache(object):
 
                 _unknown_field_suggestions(project_file, problems, attrs,
                                            ('description', 'env_spec', 'supports_http_options', 'bokeh_app', 'notebook',
-                                            'unix', 'windows', 'conda_app_entry'))
+                                            'unix', 'windows', 'conda_app_entry', 'details'))
 
                 if 'description' in attrs and not is_string(attrs['description']):
                     _file_problem(problems, project_file,
@@ -617,10 +617,19 @@ class _ConfigCache(object):
                                       (attrs['env_spec'], name))
                         failed = True
 
+                if 'details' in attrs:
+                    if not isinstance(attrs['details'], dict):
+                        _file_problem(problems, project_file,
+                                      "'details' field of command {} must be a dictionary".format(name))
+                        failed = True
+
                 copied_attrs = deepcopy(attrs)
 
                 if 'env_spec' not in copied_attrs:
                     copied_attrs['env_spec'] = self.default_env_spec_name
+
+                if 'details' not in copied_attrs:
+                    copied_attrs['details'] = dict()
 
                 command_types = []
                 for attr in ALL_COMMAND_TYPES:
@@ -1131,6 +1140,8 @@ class Project(object):
                 commands[key]['unix'] = command.unix_shell_commandline
             if command is self.default_command:
                 commands[key]['default'] = True
+            if len(command.details) > 0:
+                commands[key]['details'] = command.details
             commands[key]['env_spec'] = command.default_env_spec_name
             commands[key]['supports_http_options'] = command.supports_http_options
         json['commands'] = commands

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -17,7 +17,7 @@ from anaconda_project.plugins.requirement import EnvVarRequirement
 from anaconda_project.plugins.requirements.conda_env import CondaEnvRequirement
 from anaconda_project.plugins.requirements.download import DownloadRequirement
 from anaconda_project.plugins.requirements.service import ServiceRequirement
-from anaconda_project.project_commands import ProjectCommand
+from anaconda_project.project_commands import (ProjectCommand, all_known_command_attributes)
 from anaconda_project.project_file import ProjectFile
 from anaconda_project.archiver import _list_relative_paths_for_unignored_project_files
 from anaconda_project.version import version
@@ -592,9 +592,7 @@ class _ConfigCache(object):
                     failed = True
                     continue
 
-                _unknown_field_suggestions(project_file, problems, attrs,
-                                           ('description', 'env_spec', 'supports_http_options', 'bokeh_app', 'notebook',
-                                            'unix', 'windows', 'conda_app_entry', 'details'))
+                _unknown_field_suggestions(project_file, problems, attrs, all_known_command_attributes)
 
                 if 'description' in attrs and not is_string(attrs['description']):
                     _file_problem(problems, project_file,
@@ -618,19 +616,15 @@ class _ConfigCache(object):
                                       (attrs['env_spec'], name))
                         failed = True
 
-                if 'details' in attrs:
-                    if not isinstance(attrs['details'], dict):
-                        _file_problem(problems, project_file,
-                                      "'details' field of command {} must be a dictionary".format(name))
-                        failed = True
+                if 'registers_fusion_function' in attrs and not isinstance(attrs['registers_fusion_function'], bool):
+                    _file_problem(problems, project_file,
+                                  ("'registers_fusion_function' field of command {} must be a boolean".format(name)))
+                    failed = True
 
                 copied_attrs = deepcopy(attrs)
 
                 if 'env_spec' not in copied_attrs:
                     copied_attrs['env_spec'] = self.default_env_spec_name
-
-                if 'details' not in copied_attrs:
-                    copied_attrs['details'] = dict()
 
                 command_types = []
                 for attr in ALL_COMMAND_TYPES:
@@ -727,13 +721,14 @@ class _ConfigCache(object):
         def make_add_notebook_func(relative_name, env_spec_name):
             def add_notebook(project):
                 errors = []
-                details = notebook_analyzer.details(os.path.join(self.directory_path, relative_name), errors)
+                extras = notebook_analyzer.extras(os.path.join(self.directory_path, relative_name), errors)
                 # TODO this is broken, need to refactor so fix functions can return
                 # errors and probably also log progress indication.
                 assert [] == errors
-                assert details is not None
+                assert extras is not None
 
-                command_dict = {'notebook': relative_name, 'env_spec': env_spec_name, 'details': details}
+                command_dict = {'notebook': relative_name, 'env_spec': env_spec_name}
+                command_dict.update(extras)
                 project.project_file.set_value(['commands', relative_name], command_dict)
 
             return add_notebook
@@ -1148,10 +1143,9 @@ class Project(object):
                 commands[key]['unix'] = command.unix_shell_commandline
             if command is self.default_command:
                 commands[key]['default'] = True
-            if len(command.details) > 0:
-                commands[key]['details'] = command.details
             commands[key]['env_spec'] = command.default_env_spec_name
             commands[key]['supports_http_options'] = command.supports_http_options
+            commands[key].update(command.extras)
         json['commands'] = commands
         envs = dict()
         for key, env in self.env_specs.items():

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -407,6 +407,11 @@ class ProjectCommand(object):
         assert description is not None
         return description
 
+    @property
+    def details(self):
+        """Dictionary of extra details."""
+        return self._attributes.get('details', {})
+
     def _choose_args_and_shell(self, environ, extra_args=None):
         assert extra_args is None or isinstance(extra_args, list)
 

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -28,6 +28,11 @@ try:
 except ImportError:  # pragma: no cover (py2 only)
     from urllib import quote as url_quote  # pragma: no cover (py2 only)
 
+standard_command_attributes = ('description', 'env_spec', 'supports_http_options', 'bokeh_app', 'notebook', 'unix',
+                               'windows', 'conda_app_entry')
+extra_command_attributes = ('registers_fusion_function', )
+all_known_command_attributes = standard_command_attributes + extra_command_attributes
+
 
 def _is_windows():
     # it's tempting to cache this but it hoses our test monkeypatching so don't.
@@ -408,9 +413,17 @@ class ProjectCommand(object):
         return description
 
     @property
-    def details(self):
-        """Dictionary of extra details."""
-        return self._attributes.get('details', {})
+    def extras(self):
+        """Dictionary of extra attributes not covered by other properties.
+
+        These are typically 'plugin specific' (only for notebook, only for bokeh,
+        etc.)
+        """
+        result = dict()
+        for k in self._attributes.keys():
+            if k in extra_command_attributes:
+                result[k] = self._attributes[k]
+        return result
 
     def _choose_args_and_shell(self, environ, extra_args=None):
         assert extra_args is None or isinstance(extra_args, list)

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -854,14 +854,13 @@ def add_command(project, name, command_type, command, env_spec_name=None, suppor
         errors = []
         # TODO missing notebook should be an error caught before here
         if os.path.isfile(notebook_file):
-            details = notebook_analyzer.details(notebook_file, errors)
+            extras = notebook_analyzer.extras(notebook_file, errors)
         else:
-            details = {}
+            extras = {}
         if len(errors) > 0:
             failed = SimpleStatus(success=False, description="Unable to add the command.", errors=errors)
             return failed
-        if len(details) > 0:
-            command_dict['details'] = details
+        command_dict.update(extras)
 
     project.project_file.use_changes_without_saving()
 

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1065,29 +1065,31 @@ def test_command_with_non_boolean_supports_http_options():
         check)
 
 
-def test_command_with_non_dict_details():
+def test_command_with_non_boolean_registers_fusion_function():
     def check(dirname):
         project = project_no_dedicated_env(dirname)
         assert 1 == len(project.problems)
-        expected_error = "%s: 'details' field of command %s must be a dictionary" % (project.project_file.basename,
-                                                                                     'default')
+        expected_error = "%s: 'registers_fusion_function' field of command %s must be a boolean" % (
+            project.project_file.basename, 'default')
         assert expected_error == project.problems[0]
 
     with_directory_contents_completing_project_file(
-        {DEFAULT_PROJECT_FILENAME: "commands:\n default:\n     unix: 'boo'\n     details: []\n"}, check)
+        {DEFAULT_PROJECT_FILENAME: "commands:\n default:\n     unix: 'boo'\n     registers_fusion_function: 'blah'\n"},
+        check)
 
 
-def test_command_with_details():
+def test_command_with_extras():
     def check(dirname):
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
 
         assert 'default' in project.commands
         command = project.commands['default']
-        assert command.details == {"a": 42}
+        assert command.extras == {"registers_fusion_function": True}
 
     with_directory_contents_completing_project_file(
-        {DEFAULT_PROJECT_FILENAME: "commands:\n default:\n     unix: 'boo'\n     details: { \"a\" : 42 }\n"}, check)
+        {DEFAULT_PROJECT_FILENAME: "commands:\n default:\n     unix: 'boo'\n     registers_fusion_function: true\n"},
+        check)
 
 
 def test_command_with_custom_description():
@@ -2105,7 +2107,6 @@ commands:
     unix: echo hi
     description: "say hi"
     supports_http_options: true
-    details: { 'something' : [ 42 ] }
   bar:
     windows: echo boo
     env_spec: lol
@@ -2114,10 +2115,10 @@ commands:
   myapp:
     bokeh_app: main.py
     env_spec: woot
-    details: { 'hi' : 'stuff' }
   foo.ipynb:
     description: 'Notebook foo.ipynb'
     notebook: foo.ipynb
+    registers_fusion_function: true
 
 packages:
   - foo
@@ -2175,17 +2176,16 @@ def test_get_publication_info_from_complex_project():
                                  'default': True,
                                  'env_spec': 'default',
                                  'unix': 'echo hi',
-                                 'supports_http_options': True,
-                                 'details': {'something': [42]}},
+                                 'supports_http_options': True},
                          'myapp': {'description': 'Bokeh app main.py',
                                    'bokeh_app': 'main.py',
                                    'env_spec': 'woot',
-                                   'supports_http_options': True,
-                                   'details': {'hi': 'stuff'}},
+                                   'supports_http_options': True},
                          'foo.ipynb': {'description': 'Notebook foo.ipynb',
                                        'notebook': 'foo.ipynb',
                                        'env_spec': 'default',
-                                       'supports_http_options': True}},
+                                       'supports_http_options': True,
+                                       'registers_fusion_function': True}},
             'downloads': {'FOO': {'encrypted': False,
                                   'title': 'FOO',
                                   'description': 'A downloaded file which is referenced by FOO.',

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1395,11 +1395,11 @@ def test_notebook_guess_command():
         {
             DEFAULT_PROJECT_FILENAME:
             "commands:\n default:\n    unix: echo 'pass'\nservices:\n    REDIS_URL: redis\npackages: ['notebook']\n",
-            'test.ipynb': 'pretend there is notebook data here',
-            'envs/should_ignore_this.ipynb': 'pretend this is more notebook data',
-            'services/should_ignore_this.ipynb': 'pretend this is more notebook data',
-            '.should_ignore_dotfile.ipynb': 'moar fake notebook',
-            '.should_ignore_dotdir/foo.ipynb': 'still moar fake notebook'
+            'test.ipynb': '{}',
+            'envs/should_ignore_this.ipynb': '{}',
+            'services/should_ignore_this.ipynb': '{}',
+            '.should_ignore_dotfile.ipynb': '{}',
+            '.should_ignore_dotdir/foo.ipynb': '{}'
         }, check_notebook_guess_command)
 
     # anaconda-project run data.ipynb
@@ -1427,12 +1427,12 @@ def test_notebook_guess_command_can_be_default():
             DEFAULT_PROJECT_FILENAME: "packages: ['notebook']\n",
             # we pick the first command alphabetically in this case
             # so the test looks for that
-            'a.ipynb': 'pretend there is notebook data here',
-            'b.ipynb': 'pretend there is notebook data here',
-            'c.ipynb': 'pretend there is notebook data here',
-            'd/d.ipynb': 'pretend there is notebook data here',
-            'e.ipynb': 'pretend there is notebook data here',
-            'f.ipynb': 'pretend there is notebook data here'
+            'a.ipynb': '{}',
+            'b.ipynb': '{}',
+            'c.ipynb': '{}',
+            'd/d.ipynb': '{}',
+            'e.ipynb': '{}',
+            'f.ipynb': '{}'
         },
         check_notebook_guess_command_can_be_default)
 
@@ -1462,8 +1462,8 @@ def test_multiple_notebooks_suggestion_rejected():
         {
             DEFAULT_PROJECT_FILENAME:
             "commands:\n default:\n    unix: echo 'pass'\nservices:\n    REDIS_URL: redis\npackages: ['notebook']\n",
-            'test.ipynb': 'pretend there is notebook data here',
-            'foo/test2.ipynb': 'pretend there is notebook data here',
+            'test.ipynb': '{}',
+            'foo/test2.ipynb': '{}',
             'envs/should_ignore_this.ipynb': 'pretend this is more notebook data',
             'services/should_ignore_this.ipynb': 'pretend this is more notebook data',
             '.should_ignore_dotfile.ipynb': 'moar fake notebook',
@@ -1488,7 +1488,7 @@ def test_skip_all_notebook_imports():
         {
             DEFAULT_PROJECT_FILENAME:
             "commands:\n default:\n    unix: echo 'pass'\nservices:\n    REDIS_URL: redis\npackages: ['notebook']\n",
-            'test.ipynb': 'pretend there is notebook data here'
+            'test.ipynb': '{}'
         }, check)
 
 
@@ -1530,7 +1530,7 @@ def test_single_notebook_suggestion_rejected():
         {
             DEFAULT_PROJECT_FILENAME:
             "commands:\n default:\n    unix: echo 'pass'\nservices:\n    REDIS_URL: redis\npackages: ['notebook']\n",
-            'test.ipynb': 'pretend there is notebook data here',
+            'test.ipynb': '{}',
             'envs/should_ignore_this.ipynb': 'pretend this is more notebook data',
             'services/should_ignore_this.ipynb': 'pretend this is more notebook data',
             '.should_ignore_dotfile.ipynb': 'moar fake notebook',

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1065,6 +1065,31 @@ def test_command_with_non_boolean_supports_http_options():
         check)
 
 
+def test_command_with_non_dict_details():
+    def check(dirname):
+        project = project_no_dedicated_env(dirname)
+        assert 1 == len(project.problems)
+        expected_error = "%s: 'details' field of command %s must be a dictionary" % (project.project_file.basename,
+                                                                                     'default')
+        assert expected_error == project.problems[0]
+
+    with_directory_contents_completing_project_file(
+        {DEFAULT_PROJECT_FILENAME: "commands:\n default:\n     unix: 'boo'\n     details: []\n"}, check)
+
+
+def test_command_with_details():
+    def check(dirname):
+        project = project_no_dedicated_env(dirname)
+        assert [] == project.problems
+
+        assert 'default' in project.commands
+        command = project.commands['default']
+        assert command.details == {"a": 42}
+
+    with_directory_contents_completing_project_file(
+        {DEFAULT_PROJECT_FILENAME: "commands:\n default:\n     unix: 'boo'\n     details: { \"a\" : 42 }\n"}, check)
+
+
 def test_command_with_custom_description():
     def check(dirname):
         project = project_no_dedicated_env(dirname)
@@ -2080,6 +2105,7 @@ commands:
     unix: echo hi
     description: "say hi"
     supports_http_options: true
+    details: { 'something' : [ 42 ] }
   bar:
     windows: echo boo
     env_spec: lol
@@ -2088,6 +2114,7 @@ commands:
   myapp:
     bokeh_app: main.py
     env_spec: woot
+    details: { 'hi' : 'stuff' }
   foo.ipynb:
     description: 'Notebook foo.ipynb'
     notebook: foo.ipynb
@@ -2148,11 +2175,13 @@ def test_get_publication_info_from_complex_project():
                                  'default': True,
                                  'env_spec': 'default',
                                  'unix': 'echo hi',
-                                 'supports_http_options': True},
+                                 'supports_http_options': True,
+                                 'details': {'something': [42]}},
                          'myapp': {'description': 'Bokeh app main.py',
                                    'bokeh_app': 'main.py',
                                    'env_spec': 'woot',
-                                   'supports_http_options': True},
+                                   'supports_http_options': True,
+                                   'details': {'hi': 'stuff'}},
                          'foo.ipynb': {'description': 'Notebook foo.ipynb',
                                        'notebook': 'foo.ipynb',
                                        'env_spec': 'default',

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -806,7 +806,7 @@ def test_add_command_notebook():
         assert len(command.keys()) == 3
         assert command['notebook'] == 'foo.ipynb'
         assert command['env_spec'] == 'default'
-        assert command['details'] == {'registers_fusion_function': True}
+        assert command['registers_fusion_function'] is True
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: "",

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -217,7 +217,7 @@ def test_create_imports_notebook():
 
         assert ['foo.ipynb'] == list(project.commands.keys())
 
-    with_directory_contents({'foo.ipynb': 'not a real notebook'}, check_create)
+    with_directory_contents({'foo.ipynb': '{}'}, check_create)
 
 
 def test_set_properties():

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -147,6 +147,24 @@ Bokeh apps and notebooks have a shorthand syntax:
       notebook: bar.ipynb
       description: "Opens the notebook bar.ipynb"
 
+Command details
+===============
+
+Commands can have a ``details:`` section with extra details
+relevant to the special command type.
+
+An example is that notebooks can annotate that they
+contain a function registered with Anaconda Fusion:
+
+.. code-block:: yaml
+
+  commands:
+    bar:
+      notebook: bar.ipynb
+      description: "Notebook exporting an Anaconda Fusion function."
+      details:
+        registers_fusion_function: true
+
 
 HTTP Commands
 =============

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -147,14 +147,11 @@ Bokeh apps and notebooks have a shorthand syntax:
       notebook: bar.ipynb
       description: "Opens the notebook bar.ipynb"
 
-Command details
-===============
+Notebook-specific options
+=========================
 
-Commands can have a ``details:`` section with extra details
-relevant to the special command type.
-
-An example is that notebooks can annotate that they
-contain a function registered with Anaconda Fusion:
+Notebook commands can annotate that they contain a function
+registered with Anaconda Fusion:
 
 .. code-block:: yaml
 
@@ -162,8 +159,11 @@ contain a function registered with Anaconda Fusion:
     bar:
       notebook: bar.ipynb
       description: "Notebook exporting an Anaconda Fusion function."
-      details:
-        registers_fusion_function: true
+      registers_fusion_function: true
+
+If your notebook contains ``@fusion.register`` when you
+``anaconda-project init`` or ``anaconda-project add-command``,
+``registers_fusion_function: true`` will be added automatically.
 
 
 HTTP Commands

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ coding_utf8_header = u"# -*- coding: utf-8 -*-\n"
 
 copyright_header = u"""
 # ----------------------------------------------------------------------------
-# Copyright © 2016, Continuum Analytics, Inc. All rights reserved.
+# Copyright © 2017, Continuum Analytics, Inc. All rights reserved.
 #
 # The full license is in the file LICENSE.txt, distributed with this software.
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
There are a couple of TODO I put in here for pre-existing limitations that should be cleaned up,
but don't want to do those in this PR.

One thing about this, it will not add the `registers_fusion_function` if `@fusion.register` is added to a notebook _after_ the notebook is already in anaconda-project.yml. At that point people would have to add the `details: { registers_fusion_function: true }` line themselves.

cc @fpliger 