### PR TITLE
Include "default" for variables in publication_info()

### DIFF
--- a/anaconda_project/plugins/requirement.py
+++ b/anaconda_project/plugins/requirement.py
@@ -290,6 +290,17 @@ class EnvVarRequirement(Requirement):
         else:
             return any(self.env_var.endswith(suffix) for suffix in _secret_suffixes)
 
+    @property
+    def default_as_string(self):
+        """Get the default, forced to string or None."""
+        value = self.options.get('default', None)
+        if value is None:
+            return None
+        else:
+            # see _parse_default above, it can be a string already,
+            # or an integer
+            return str(value)
+
     def _get_value_of_env_var(self, environ):
         """A "protected" method for subtypes to use."""
         value = environ.get(self.env_var, None)

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -1170,15 +1170,23 @@ class Project(object):
         for req in self.requirements:
             if isinstance(req, CondaEnvRequirement):
                 continue
-            elif isinstance(req, DownloadRequirement):
-                downloads[req.env_var] = dict(title=req.title,
-                                              description=req.description,
-                                              encrypted=req.encrypted,
-                                              url=req.url)
-            elif isinstance(req, ServiceRequirement):
-                services[req.env_var] = dict(title=req.title, description=req.description, type=req.service_type)
-            elif isinstance(req, EnvVarRequirement):
-                variables[req.env_var] = dict(title=req.title, description=req.description, encrypted=req.encrypted)
+
+            if isinstance(req, EnvVarRequirement):
+                data = dict(title=req.title, description=req.description, encrypted=req.encrypted)
+
+                default = req.default_as_string
+                if default is not None:
+                    data['default'] = default
+
+                if isinstance(req, DownloadRequirement):
+                    data['url'] = req.url
+                    downloads[req.env_var] = data
+                elif isinstance(req, ServiceRequirement):
+                    data['type'] = req.service_type
+                    services[req.env_var] = data
+                elif isinstance(req, EnvVarRequirement):
+                    variables[req.env_var] = data
+
         json['downloads'] = downloads
         json['variables'] = variables
         json['services'] = services

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -2151,8 +2151,8 @@ services:
 
 variables:
   SOMETHING: {}
-  SOMETHING_ELSE: {}
-
+  SOMETHING_ELSE:
+     default: 42
 """
 
 
@@ -2207,11 +2207,13 @@ def test_get_publication_info_from_complex_project():
                                         'description': 'SOMETHING environment variable must be set.'},
                           'SOMETHING_ELSE': {'encrypted': False,
                                              'title': 'SOMETHING_ELSE',
-                                             'description': 'SOMETHING_ELSE environment variable must be set.'}},
+                                             'description': 'SOMETHING_ELSE environment variable must be set.',
+                                             'default': "42"}},
             'services': {'REDIS_URL':
                          {'title': 'REDIS_URL',
                           'description': 'A running Redis server, located by a redis: URL set as REDIS_URL.',
-                          'type': 'redis'}}
+                          'type': 'redis',
+                          'encrypted': False}}
         }
 
         assert expected == project.publication_info()


### PR DESCRIPTION
If the default is None/missing we leave it out of the JSON.

We canonicalize the default to a string, even if it was an int
or float in anaconda-project.yml, so the server side doesn't have
to deal with that.

Also did a little DRY cleanup in publication_info() across the
requirement types. This leads to supplying encrypted=False for
downloads and services, but that seems fine.