### PR TITLE
Move variables/services/downloads to be per-env-spec

### DIFF
--- a/anaconda_project/api.py
+++ b/anaconda_project/api.py
@@ -380,7 +380,7 @@ class AnacondaProject(object):
                                            vars_to_unset=vars_to_unset,
                                            prepare_result=prepare_result)
 
-    def add_download(self, project, env_var, url, filename=None, hash_algorithm=None, hash_value=None):
+    def add_download(self, project, env_spec_name, env_var, url, filename=None, hash_algorithm=None, hash_value=None):
         """Attempt to download the URL; if successful, add it as a download to the project.
 
         The returned ``Status`` should be a ``RequirementStatus`` for
@@ -391,6 +391,7 @@ class AnacondaProject(object):
 
         Args:
             project (Project): the project
+            env_spec_name (str): environment spec name or None for all environment specs
             env_var (str): env var to store the local filename
             url (str): url to download
             filename (optional, str): Name to give file or directory after downloading
@@ -402,13 +403,14 @@ class AnacondaProject(object):
             ``Status`` instance
         """
         return project_ops.add_download(project=project,
+                                        env_spec_name=env_spec_name,
                                         env_var=env_var,
                                         url=url,
                                         filename=filename,
                                         hash_algorithm=hash_algorithm,
                                         hash_value=hash_value)
 
-    def remove_download(self, project, prepare_result, env_var):
+    def remove_download(self, project, env_spec_name, env_var, prepare_result=None):
         """Remove file or directory referenced by ``env_var`` from file system and the project.
 
         The returned ``Status`` will be an instance of ``SimpleStatus``. A False
@@ -417,13 +419,17 @@ class AnacondaProject(object):
 
         Args:
             project (Project): the project
-            prepare_result (PrepareResult): result of a previous prepare
+            env_spec_name (str): environment spec name or None for all environment specs
             env_var (str): env var to store the local filename
+            prepare_result (PrepareResult): result of a previous prepare
 
         Returns:
             ``Status`` instance
         """
-        return project_ops.remove_download(project=project, prepare_result=prepare_result, env_var=env_var)
+        return project_ops.remove_download(project=project,
+                                           env_spec_name=env_spec_name,
+                                           env_var=env_var,
+                                           prepare_result=prepare_result)
 
     def add_env_spec(self, project, name, packages, channels):
         """Attempt to create the environment spec and add it to anaconda-project.yml.
@@ -688,7 +694,7 @@ class AnacondaProject(object):
         """
         return project_ops.remove_command(project=project, name=name)
 
-    def add_service(self, project, service_type, variable_name=None):
+    def add_service(self, project, env_spec_name, service_type, variable_name=None):
         """Add a service to anaconda-project.yml.
 
         The returned ``Status`` should be a ``RequirementStatus`` for
@@ -699,15 +705,19 @@ class AnacondaProject(object):
 
         Args:
             project (Project): the project
+            env_spec_name (str): environment spec name or None for all environment specs
             service_type (str): which kind of service
             variable_name (str): environment variable name (None for default)
 
         Returns:
             ``Status`` instance
         """
-        return project_ops.add_service(project=project, service_type=service_type, variable_name=variable_name)
+        return project_ops.add_service(project=project,
+                                       env_spec_name=env_spec_name,
+                                       service_type=service_type,
+                                       variable_name=variable_name)
 
-    def remove_service(self, project, prepare_result, variable_name):
+    def remove_service(self, project, env_spec_name, variable_name, prepare_result=None):
         """Remove a service to anaconda-project.yml.
 
         Returns a ``Status`` instance which evaluates to True on
@@ -716,13 +726,17 @@ class AnacondaProject(object):
 
         Args:
             project (Project): the project
-            prepare_result (PrepareResult): result of a previous prepare
+            env_spec_name (str): environment spec name or None for all environment specs
             variable_name (str): environment variable name for the service requirement
+            prepare_result (PrepareResult): result of a previous prepare or None
 
         Returns:
             ``Status`` instance
         """
-        return project_ops.remove_service(project=project, prepare_result=prepare_result, variable_name=variable_name)
+        return project_ops.remove_service(project=project,
+                                          env_spec_name=env_spec_name,
+                                          variable_name=variable_name,
+                                          prepare_result=prepare_result)
 
     def clean(self, project, prepare_result):
         """Blow away auto-provided state for the project.

--- a/anaconda_project/api.py
+++ b/anaconda_project/api.py
@@ -296,7 +296,7 @@ class AnacondaProject(object):
         """
         return project_ops.set_properties(project=project, name=name, icon=icon, description=description)
 
-    def add_variables(self, project, vars_to_add, defaults):
+    def add_variables(self, project, env_spec_name, vars_to_add, defaults):
         """Add variables in anaconda-project.yml, optionally setting their defaults.
 
         Returns a ``Status`` instance which evaluates to True on
@@ -305,15 +305,19 @@ class AnacondaProject(object):
 
         Args:
             project (Project): the project
+            env_spec_name (str): environment spec name or None for all environment specs
             vars_to_add (list of str): variable names
             defaults (dict): dictionary from keys to defaults, can be empty
 
         Returns:
             ``Status`` instance
         """
-        return project_ops.add_variables(project=project, vars_to_add=vars_to_add, defaults=defaults)
+        return project_ops.add_variables(project=project,
+                                         env_spec_name=env_spec_name,
+                                         vars_to_add=vars_to_add,
+                                         defaults=defaults)
 
-    def remove_variables(self, project, vars_to_remove, env_spec_name=None):
+    def remove_variables(self, project, env_spec_name, vars_to_remove, prepare_result=None):
         """Remove variables from anaconda-project.yml and unset their values in local project state.
 
         Returns a ``Status`` instance which evaluates to True on
@@ -322,15 +326,19 @@ class AnacondaProject(object):
 
         Args:
             project (Project): the project
+            env_spec_name (str): environment spec name or None for all environment specs
             vars_to_remove (list of tuple): key-value pairs
-            env_spec_name (str): name of env spec to use
+            prepare_result (PrepareResult): result of a previous prepare or None
 
         Returns:
             ``Status`` instance
         """
-        return project_ops.remove_variables(project=project, vars_to_remove=vars_to_remove, env_spec_name=env_spec_name)
+        return project_ops.remove_variables(project=project,
+                                            env_spec_name=env_spec_name,
+                                            vars_to_remove=vars_to_remove,
+                                            prepare_result=prepare_result)
 
-    def set_variables(self, project, vars_and_values, env_spec_name=None):
+    def set_variables(self, project, env_spec_name, vars_and_values, prepare_result=None):
         """Set variables' values in anaconda-project-local.yml.
 
         Returns a ``Status`` instance which evaluates to True on
@@ -339,15 +347,19 @@ class AnacondaProject(object):
 
         Args:
             project (Project): the project
+            env_spec_name (str): environment spec name or None for all environment specs
             vars_and_values (list of tuple): key-value pairs
-            env_spec_name (str): name of env spec to use
+            prepare_result (PrepareResult): result of a previous prepare or None
 
         Returns:
             ``Status`` instance
         """
-        return project_ops.set_variables(project=project, vars_and_values=vars_and_values, env_spec_name=env_spec_name)
+        return project_ops.set_variables(project=project,
+                                         env_spec_name=env_spec_name,
+                                         vars_and_values=vars_and_values,
+                                         prepare_result=prepare_result)
 
-    def unset_variables(self, project, vars_to_unset, env_spec_name=None):
+    def unset_variables(self, project, env_spec_name, vars_to_unset, prepare_result=None):
         """Unset variables' values in anaconda-project-local.yml.
 
         Returns a ``Status`` instance which evaluates to True on
@@ -356,13 +368,17 @@ class AnacondaProject(object):
 
         Args:
             project (Project): the project
+            env_spec_name (str): environment spec name or None for all environment specs
             vars_to_unset (list of str): variable names
-            env_spec_name (str): name of env spec to use
+            prepare_result (PrepareResult): result of a previous prepare or None
 
         Returns:
             ``Status`` instance
         """
-        return project_ops.unset_variables(project=project, vars_to_unset=vars_to_unset, env_spec_name=env_spec_name)
+        return project_ops.unset_variables(project=project,
+                                           env_spec_name=env_spec_name,
+                                           vars_to_unset=vars_to_unset,
+                                           prepare_result=prepare_result)
 
     def add_download(self, project, env_var, url, filename=None, hash_algorithm=None, hash_value=None):
         """Attempt to download the URL; if successful, add it as a download to the project.

--- a/anaconda_project/archiver.py
+++ b/anaconda_project/archiver.py
@@ -308,7 +308,9 @@ def _archive_project(project, filename):
         frontend.error("%s has been modified but not saved." % project.project_file.basename)
         return SimpleStatus(success=False, description="Can't create an archive.", errors=frontend.pop_errors())
 
-    infos = _enumerate_archive_files(project.directory_path, frontend, requirements=project.requirements)
+    infos = _enumerate_archive_files(project.directory_path,
+                                     frontend,
+                                     requirements=project.union_of_requirements_for_all_envs)
     if infos is None:
         return SimpleStatus(success=False,
                             description="Failed to list files in the project.",

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -205,6 +205,14 @@ class EnvSpec(object):
         return self._import_hash
 
     def _get_inherited(self, public_attr, key_func=None):
+        private_attr = '_' + public_attr
+
+        def getter(spec):
+            return getattr(spec, private_attr)
+
+        return self._get_inherited_with_getter(getter, key_func=key_func)
+
+    def _get_inherited_with_getter(self, getter, key_func=None):
         def _linearized_ancestors(specs, accumulator):
             for spec in specs:
                 if spec not in accumulator:
@@ -215,10 +223,9 @@ class EnvSpec(object):
         _linearized_ancestors([self], ancestors)
         assert ancestors[-1] is self
 
-        private_attr = '_' + public_attr
         to_combine = []
         for spec in ancestors:
-            to_combine.append(getattr(spec, private_attr))
+            to_combine.append(getter(spec))
         combined = []
         for item in to_combine:
             combined = _combine_keeping_last_duplicate(combined, item, key_func=key_func)

--- a/anaconda_project/internal/cli/download_commands.py
+++ b/anaconda_project/internal/cli/download_commands.py
@@ -16,13 +16,14 @@ from anaconda_project.prepare import prepare_without_interaction
 from anaconda_project.provide import PROVIDE_MODE_CHECK
 
 
-def add_download(project_dir, filename_variable, download_url, filename, hash_algorithm, hash_value):
+def add_download(project_dir, env_spec_name, filename_variable, download_url, filename, hash_algorithm, hash_value):
     """Add an item to the downloads section."""
     project = load_project(project_dir)
     if (hash_algorithm or hash_value) and not bool(hash_algorithm and hash_value):
         print("Error: mutually dependant parameters: --hash-algorithm and --hash-value.", file=sys.stderr)
         return 1
     status = project_ops.add_download(project,
+                                      env_spec_name=env_spec_name,
                                       env_var=filename_variable,
                                       url=download_url,
                                       filename=filename,
@@ -37,14 +38,17 @@ def add_download(project_dir, filename_variable, download_url, filename, hash_al
         return 1
 
 
-def remove_download(project_dir, filename_variable):
+def remove_download(project_dir, env_spec_name, filename_variable):
     """Remove a download requirement from project and from file system."""
     project = load_project(project_dir)
     # we can remove a download even if prepare fails, so disable
     # printing errors in the frontend.
     with project.null_frontend():
-        result = prepare_without_interaction(project, mode=PROVIDE_MODE_CHECK)
-    status = project_ops.remove_download(project, result, env_var=filename_variable)
+        result = prepare_without_interaction(project, env_spec_name=env_spec_name, mode=PROVIDE_MODE_CHECK)
+    status = project_ops.remove_download(project,
+                                         env_spec_name=env_spec_name,
+                                         env_var=filename_variable,
+                                         prepare_result=result)
     if status:
         print(status.status_description)
         print("Removed {} from the project file.".format(filename_variable))
@@ -54,17 +58,15 @@ def remove_download(project_dir, filename_variable):
         return 1
 
 
-def list_downloads(project_dir):
+def list_downloads(project_dir, env_spec_name):
     """List the downloads present in project."""
     project = load_project(project_dir)
     if console_utils.print_project_problems(project):
         return 1
 
-    if project.downloads(project.default_env_spec_name):
+    if project.downloads(env_spec_name):
         print("Downloads for project: {}\n".format(project_dir))
-        console_utils.print_names_and_descriptions(
-            project.download_requirements(project.default_env_spec_name),
-            name_attr='title')
+        console_utils.print_names_and_descriptions(project.download_requirements(env_spec_name), name_attr='title')
     else:
         print("No downloads found in project.")
     return 0
@@ -72,15 +74,15 @@ def list_downloads(project_dir):
 
 def main_add(args):
     """Start the download command and return exit status code."""
-    return add_download(args.directory, args.filename_variable, args.download_url, args.filename, args.hash_algorithm,
-                        args.hash_value)
+    return add_download(args.directory, args.env_spec, args.filename_variable, args.download_url, args.filename,
+                        args.hash_algorithm, args.hash_value)
 
 
 def main_remove(args):
     """Start the remove download command and return exit status code."""
-    return remove_download(args.directory, args.filename_variable)
+    return remove_download(args.directory, args.env_spec, args.filename_variable)
 
 
 def main_list(args):
     """Start the list download command and return exit status code."""
-    return list_downloads(args.directory)
+    return list_downloads(args.directory, args.env_spec)

--- a/anaconda_project/internal/cli/download_commands.py
+++ b/anaconda_project/internal/cli/download_commands.py
@@ -60,9 +60,11 @@ def list_downloads(project_dir):
     if console_utils.print_project_problems(project):
         return 1
 
-    if project.downloads:
+    if project.downloads(project.default_env_spec_name):
         print("Downloads for project: {}\n".format(project_dir))
-        console_utils.print_names_and_descriptions(project.download_requirements, name_attr='title')
+        console_utils.print_names_and_descriptions(
+            project.download_requirements(project.default_env_spec_name),
+            name_attr='title')
     else:
         print("No downloads found in project.")
     return 0

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -136,6 +136,7 @@ def _parse_args_and_run_subcommand(argv):
     preset.set_defaults(main=upload.main)
 
     preset = subparsers.add_parser('add-variable', help="Add a required environment variable to the project")
+    add_env_spec_arg(preset)
     preset.add_argument('vars_to_add', metavar='VARS_TO_ADD', default=None, nargs=REMAINDER)
     preset.add_argument('--default',
                         metavar='DEFAULT_VALUE',
@@ -145,22 +146,26 @@ def _parse_args_and_run_subcommand(argv):
     preset.set_defaults(main=variable_commands.main_add)
 
     preset = subparsers.add_parser('remove-variable', help="Remove an environment variable from the project")
+    add_env_spec_arg(preset)
     add_directory_arg(preset)
     preset.add_argument('vars_to_remove', metavar='VARS_TO_REMOVE', default=None, nargs=REMAINDER)
     preset.set_defaults(main=variable_commands.main_remove)
 
     preset = subparsers.add_parser('list-variables', help="List all variables on the project")
+    add_env_spec_arg(preset)
     add_directory_arg(preset)
     preset.set_defaults(main=variable_commands.main_list)
 
     preset = subparsers.add_parser('set-variable',
                                    help="Set an environment variable value in anaconda-project-local.yml")
+    add_env_spec_arg(preset)
     preset.add_argument('vars_and_values', metavar='VARS_AND_VALUES', default=None, nargs=REMAINDER)
     add_directory_arg(preset)
     preset.set_defaults(main=variable_commands.main_set)
 
     preset = subparsers.add_parser('unset-variable',
                                    help="Unset an environment variable value from anaconda-project-local.yml")
+    add_env_spec_arg(preset)
     add_directory_arg(preset)
     preset.add_argument('vars_to_unset', metavar='VARS_TO_UNSET', default=None, nargs=REMAINDER)
     preset.set_defaults(main=variable_commands.main_unset)

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -172,6 +172,7 @@ def _parse_args_and_run_subcommand(argv):
 
     preset = subparsers.add_parser('add-download', help="Add a URL to be downloaded before running commands")
     add_directory_arg(preset)
+    add_env_spec_arg(preset)
     preset.add_argument('filename_variable', metavar='ENV_VAR_FOR_FILENAME', default=None)
     preset.add_argument('download_url', metavar='DOWNLOAD_URL', default=None)
     preset.add_argument('--filename', help="The name to give the file/folder after downloading it", default=None)
@@ -184,11 +185,13 @@ def _parse_args_and_run_subcommand(argv):
 
     preset = subparsers.add_parser('remove-download', help="Remove a download from the project and from the filesystem")
     add_directory_arg(preset)
+    add_env_spec_arg(preset)
     preset.add_argument('filename_variable', metavar='ENV_VAR_FOR_FILENAME', default=None)
     preset.set_defaults(main=download_commands.main_remove)
 
     preset = subparsers.add_parser('list-downloads', help="List all downloads on the project")
     add_directory_arg(preset)
+    add_env_spec_arg(preset)
     preset.set_defaults(main=download_commands.main_list)
 
     service_types = PluginRegistry().list_service_types()
@@ -199,17 +202,20 @@ def _parse_args_and_run_subcommand(argv):
 
     preset = subparsers.add_parser('add-service', help="Add a service to be available before running commands")
     add_directory_arg(preset)
+    add_env_spec_arg(preset)
     add_service_variable_name(preset)
     preset.add_argument('service_type', metavar='SERVICE_TYPE', default=None, choices=service_choices)
     preset.set_defaults(main=service_commands.main_add)
 
     preset = subparsers.add_parser('remove-service', help="Remove a service from the project")
     add_directory_arg(preset)
+    add_env_spec_arg(preset)
     preset.add_argument('variable', metavar='SERVICE_REFERENCE', default=None)
     preset.set_defaults(main=service_commands.main_remove)
 
     preset = subparsers.add_parser('list-services', help="List services present in the project")
     add_directory_arg(preset)
+    add_env_spec_arg(preset)
     preset.set_defaults(main=service_commands.main_list)
 
     def add_package_args(preset):

--- a/anaconda_project/internal/cli/prepare_with_mode.py
+++ b/anaconda_project/internal/cli/prepare_with_mode.py
@@ -64,7 +64,7 @@ def _interactively_fix_missing_variables(project, result):
         values[status.requirement.env_var] = reply
 
     if len(values) > 0:
-        status = project_ops.set_variables(project, values.items())
+        status = project_ops.set_variables(project, result.env_spec_name, values.items(), result)
         if status:
             return True
         else:

--- a/anaconda_project/internal/cli/service_commands.py
+++ b/anaconda_project/internal/cli/service_commands.py
@@ -50,9 +50,11 @@ def list_services(project_dir):
     if console_utils.print_project_problems(project):
         return 1
 
-    if project.services:
+    if project.services(project.default_env_spec_name):
         print("Services for project: {}\n".format(project_dir))
-        console_utils.print_names_and_descriptions(project.service_requirements, name_attr='title')
+        console_utils.print_names_and_descriptions(
+            project.service_requirements(project.default_env_spec_name),
+            name_attr='title')
     else:
         print("No services found for project: {}".format(project_dir))
     return 0

--- a/anaconda_project/internal/cli/service_commands.py
+++ b/anaconda_project/internal/cli/service_commands.py
@@ -14,10 +14,13 @@ from anaconda_project.prepare import prepare_without_interaction
 from anaconda_project.provide import PROVIDE_MODE_CHECK
 
 
-def add_service(project_dir, service_type, variable_name):
+def add_service(project_dir, env_spec_name, service_type, variable_name):
     """Add an item to the services section."""
     project = load_project(project_dir)
-    status = project_ops.add_service(project, service_type=service_type, variable_name=variable_name)
+    status = project_ops.add_service(project,
+                                     env_spec_name=env_spec_name,
+                                     service_type=service_type,
+                                     variable_name=variable_name)
     if status:
         print(status.status_description)
         print("Added service %s to the project file, its address will be in %s." %
@@ -28,14 +31,17 @@ def add_service(project_dir, service_type, variable_name):
         return 1
 
 
-def remove_service(project_dir, variable_name):
+def remove_service(project_dir, env_spec_name, variable_name):
     """Remove an item from the services section."""
     project = load_project(project_dir)
     # we don't want to print errors during this prepare, remove
     # service can proceed even though the prepare fails.
     with project.null_frontend():
-        result = prepare_without_interaction(project, mode=PROVIDE_MODE_CHECK)
-    status = project_ops.remove_service(project, result, variable_name=variable_name)
+        result = prepare_without_interaction(project, env_spec_name=env_spec_name, mode=PROVIDE_MODE_CHECK)
+    status = project_ops.remove_service(project,
+                                        env_spec_name=env_spec_name,
+                                        variable_name=variable_name,
+                                        prepare_result=result)
     if status:
         print(status.status_description)
         return 0
@@ -44,17 +50,15 @@ def remove_service(project_dir, variable_name):
         return 1
 
 
-def list_services(project_dir):
+def list_services(project_dir, env_spec_name):
     """List the services listed on the project."""
     project = load_project(project_dir)
     if console_utils.print_project_problems(project):
         return 1
 
-    if project.services(project.default_env_spec_name):
+    if project.services(env_spec_name):
         print("Services for project: {}\n".format(project_dir))
-        console_utils.print_names_and_descriptions(
-            project.service_requirements(project.default_env_spec_name),
-            name_attr='title')
+        console_utils.print_names_and_descriptions(project.service_requirements(env_spec_name), name_attr='title')
     else:
         print("No services found for project: {}".format(project_dir))
     return 0
@@ -62,14 +66,14 @@ def list_services(project_dir):
 
 def main_add(args):
     """Start the add-service command and return exit status code."""
-    return add_service(args.directory, args.service_type, args.variable)
+    return add_service(args.directory, args.env_spec, args.service_type, args.variable)
 
 
 def main_remove(args):
     """Start the remove-service command and return exit status code."""
-    return remove_service(args.directory, args.variable)
+    return remove_service(args.directory, args.env_spec, args.variable)
 
 
 def main_list(args):
     """Start the list the services command and return exit status code."""
-    return list_services(args.directory)
+    return list_services(args.directory, args.env_spec)

--- a/anaconda_project/internal/cli/test/test_download_commands.py
+++ b/anaconda_project/internal/cli/test/test_download_commands.py
@@ -182,7 +182,7 @@ def test_remove_download(capsys, monkeypatch):
 
         code = _parse_args_and_run_subcommand(['anaconda-project', 'remove-download', 'TEST_FILE'])
         project = Project(dirname)
-        assert not project.downloads
+        assert not project.downloads(project.default_env_spec_name)
         assert code == 0
 
         out, err = capsys.readouterr()
@@ -203,7 +203,7 @@ def test_remove_download_dir(capsys, monkeypatch):
 
         code = _parse_args_and_run_subcommand(['anaconda-project', 'remove-download', 'TEST_FILE'])
         project = Project(dirname)
-        assert not project.downloads
+        assert not project.downloads(project.default_env_spec_name)
         assert code == 0
 
         out, err = capsys.readouterr()
@@ -290,7 +290,7 @@ def test_remove_download_missing_var(capsys, monkeypatch):
 
         code = _parse_args_and_run_subcommand(['anaconda-project', 'remove-download', 'TEST_FILE'])
         project = Project(dirname)
-        assert not project.downloads
+        assert not project.downloads(project.default_env_spec_name)
         assert code == 1
 
         out, err = capsys.readouterr()

--- a/anaconda_project/internal/cli/test/test_download_commands.py
+++ b/anaconda_project/internal/cli/test/test_download_commands.py
@@ -77,6 +77,7 @@ def test_add_download(capsys, monkeypatch):
                                        ['anaconda-project', 'add-download', 'MYDATA', 'http://localhost:123456'])
     assert len(called_params['args']) == 1
     expected_kwargs = {
+        'env_spec_name': None,
         'env_var': 'MYDATA',
         'filename': None,
         'url': 'http://localhost:123456',
@@ -92,6 +93,7 @@ def test_add_download_with_filename(capsys, monkeypatch):
         ['anaconda-project', 'add-download', 'MYDATA', 'http://localhost:123456', '--filename', 'foo'])
     assert len(called_params['args']) == 1
     expected_kwargs = {
+        'env_spec_name': None,
         'env_var': 'MYDATA',
         'filename': 'foo',
         'url': 'http://localhost:123456',
@@ -108,6 +110,7 @@ def test_add_download_with_checksum(capsys, monkeypatch):
     ])
     assert len(called_params['args']) == 1
     expected_kwargs = {
+        'env_spec_name': None,
         'env_var': 'MYDATA',
         'hash_algorithm': 'md5',
         'hash_value': 'foo',

--- a/anaconda_project/internal/cli/test/test_prepare.py
+++ b/anaconda_project/internal/cli/test/test_prepare.py
@@ -510,7 +510,7 @@ def test_ask_variables_interactively_then_set_variable_fails(monkeypatch, capsys
 
         monkeypatch.setattr('anaconda_project.internal.cli.console_utils.console_input', mock_console_input)
 
-        def mock_set_variables(project, vars_and_values):
+        def mock_set_variables(project, env_spec_name, vars_and_values, prepare_result):
             return SimpleStatus(success=False, description="Set variables FAIL")
 
         monkeypatch.setattr('anaconda_project.project_ops.set_variables', mock_set_variables)

--- a/anaconda_project/internal/cli/variable_commands.py
+++ b/anaconda_project/internal/cli/variable_commands.py
@@ -55,7 +55,9 @@ def list_variables(project_dir):
     if console_utils.print_project_problems(project):
         return 1
     print("Variables for project: {}\n".format(project_dir))
-    console_utils.print_names_and_descriptions(project.all_variable_requirements, name_attr='env_var')
+    console_utils.print_names_and_descriptions(
+        project.all_variable_requirements(project.default_env_spec_name),
+        name_attr='env_var')
     return 0
 
 

--- a/anaconda_project/internal/cli/variable_commands.py
+++ b/anaconda_project/internal/cli/variable_commands.py
@@ -14,7 +14,7 @@ from anaconda_project import project_ops
 from anaconda_project.internal.cli import console_utils
 
 
-def add_variables(project_dir, vars_to_add, default):
+def add_variables(project_dir, env_spec_name, vars_to_add, default):
     """Add env variables to project file.
 
     Returns:
@@ -26,7 +26,7 @@ def add_variables(project_dir, vars_to_add, default):
               file=sys.stderr)
         return 1
     project = load_project(project_dir)
-    status = project_ops.add_variables(project, vars_to_add, {vars_to_add[0]: default})
+    status = project_ops.add_variables(project, env_spec_name, vars_to_add, {vars_to_add[0]: default})
     if status:
         return 0
     else:
@@ -34,14 +34,14 @@ def add_variables(project_dir, vars_to_add, default):
         return 1
 
 
-def remove_variables(project_dir, vars_to_remove):
+def remove_variables(project_dir, env_spec_name, vars_to_remove):
     """Remove env variable requirements from the project file.
 
     Returns:
         Returns exit code
     """
     project = load_project(project_dir)
-    status = project_ops.remove_variables(project, vars_to_remove)
+    status = project_ops.remove_variables(project, env_spec_name, vars_to_remove)
     if status:
         return 0
     else:
@@ -49,19 +49,17 @@ def remove_variables(project_dir, vars_to_remove):
         return 1
 
 
-def list_variables(project_dir):
+def list_variables(project_dir, env_spec_name):
     """List variables present in project."""
     project = load_project(project_dir)
     if console_utils.print_project_problems(project):
         return 1
     print("Variables for project: {}\n".format(project_dir))
-    console_utils.print_names_and_descriptions(
-        project.all_variable_requirements(project.default_env_spec_name),
-        name_attr='env_var')
+    console_utils.print_names_and_descriptions(project.all_variable_requirements(env_spec_name), name_attr='env_var')
     return 0
 
 
-def set_variables(project_dir, vars_and_values):
+def set_variables(project_dir, env_spec_name, vars_and_values):
     """Set the given variables to the given values.
 
     Returns:
@@ -75,7 +73,7 @@ def set_variables(project_dir, vars_and_values):
         # maxsplit=1 -- no maxsplit keywork in py27
         fixed_vars.append(tuple(var.split('=', 1)))
     project = load_project(project_dir)
-    status = project_ops.set_variables(project, fixed_vars)
+    status = project_ops.set_variables(project, env_spec_name, fixed_vars)
     if status:
         print(status.status_description)
         return 0
@@ -84,14 +82,14 @@ def set_variables(project_dir, vars_and_values):
         return 1
 
 
-def unset_variables(project_dir, vars_to_unset):
+def unset_variables(project_dir, env_spec_name, vars_to_unset):
     """Unset the variables for local project.
 
     Returns:
         Returns exit code
     """
     project = load_project(project_dir)
-    status = project_ops.unset_variables(project, vars_to_unset)
+    status = project_ops.unset_variables(project, env_spec_name, vars_to_unset)
     if status:
         print(status.status_description)
         return 0
@@ -102,24 +100,24 @@ def unset_variables(project_dir, vars_to_unset):
 
 def main_add(args):
     """Add variables main."""
-    return add_variables(args.directory, args.vars_to_add, args.default)
+    return add_variables(args.directory, args.env_spec, args.vars_to_add, args.default)
 
 
 def main_remove(args):
     """Remove variables main."""
-    return remove_variables(args.directory, args.vars_to_remove)
+    return remove_variables(args.directory, args.env_spec, args.vars_to_remove)
 
 
 def main_list(args):
     """List the project variable names."""
-    return list_variables(args.directory)
+    return list_variables(args.directory, args.env_spec)
 
 
 def main_set(args):
     """Set the project variables."""
-    return set_variables(args.directory, args.vars_and_values)
+    return set_variables(args.directory, args.env_spec, args.vars_and_values)
 
 
 def main_unset(args):
     """Unset the project variables."""
-    return unset_variables(args.directory, args.vars_to_unset)
+    return unset_variables(args.directory, args.env_spec, args.vars_to_unset)

--- a/anaconda_project/internal/test/test_ui_server.py
+++ b/anaconda_project/internal/test/test_ui_server.py
@@ -26,7 +26,8 @@ def _no_op_prepare(config_context):
             PrepareSuccess(statuses=(),
                            command_exec_info=None,
                            environ=dict(),
-                           overrides=UserConfigOverrides()),
+                           overrides=UserConfigOverrides(),
+                           env_spec_name='something'),
             [])
         return None
 

--- a/anaconda_project/plugins/registry.py
+++ b/anaconda_project/plugins/registry.py
@@ -28,6 +28,20 @@ class PluginRegistry(object):
         from .requirement import EnvVarRequirement
         return EnvVarRequirement(registry=self, env_var=env_var, options=options)
 
+    def can_find_requirement_by_service_type(self, service_type, env_var, options):
+        """See if we can create a requirement instance given a service type.
+
+        Args:
+            service_type (str): name of the service type
+            env_var (str): environment variable name
+            options (dict): options from the project file for this requirement
+
+        Returns:
+            boolean
+        """
+        # ha. obviously not the long-term implementation
+        return service_type == 'redis'
+
     def find_requirement_by_service_type(self, service_type, env_var, options):
         """Create a requirement instance given a service type.
 
@@ -45,9 +59,11 @@ class PluginRegistry(object):
 
         # future goal will be to un-hardcode this
         if service_type == 'redis':
+            assert self.can_find_requirement_by_service_type(service_type, env_var, options)
             from .requirements.redis import RedisRequirement
             return RedisRequirement(registry=self, env_var=env_var, options=options)
         else:
+            assert not self.can_find_requirement_by_service_type(service_type, env_var, options)
             return None
 
     def list_service_types(self):

--- a/anaconda_project/plugins/requirements/service.py
+++ b/anaconda_project/plugins/requirements/service.py
@@ -16,7 +16,7 @@ class ServiceRequirement(EnvVarRequirement):
     """Abstract base class for a requirement from the services section of the project file."""
 
     @classmethod
-    def _parse(cls, registry, varname, item, problems, requirements):
+    def _parse(cls, varname, item, problems):
         """Parse an item from the services: section."""
         service_type = None
         if is_string(item):
@@ -26,25 +26,17 @@ class ServiceRequirement(EnvVarRequirement):
             service_type = item.get('type', None)
             if service_type is None:
                 problems.append("Service {} doesn't contain a 'type' field.".format(varname))
-                return
+                return None
             options = deepcopy(item)
         else:
             problems.append("Service {} should have a service type string or a dictionary as its value.".format(
                 varname))
-            return
+            return None
 
         if not EnvVarRequirement._parse_default(options, varname, problems):
-            return
+            return None
 
-        requirement = registry.find_requirement_by_service_type(service_type=service_type,
-                                                                env_var=varname,
-                                                                options=options)
-        if requirement is None:
-            problems.append("Service {} has an unknown type '{}'.".format(varname, service_type))
-        else:
-            assert isinstance(requirement, ServiceRequirement)
-            assert 'type' in requirement.options
-            requirements.append(requirement)
+        return dict(service_type=service_type, env_var=varname, options=options)
 
     @property
     def service_type(self):

--- a/anaconda_project/plugins/requirements/test/test_download_requirement.py
+++ b/anaconda_project/plugins/requirements/test/test_download_requirement.py
@@ -98,147 +98,115 @@ def test_download_with_no_checksum():
 
 def test_use_variable_name_for_filename():
     problems = []
-    requirements = []
-    DownloadRequirement._parse(PluginRegistry(),
-                               varname='FOO',
-                               item='http://example.com/',
-                               problems=problems,
-                               requirements=requirements)
+    kwargs = DownloadRequirement._parse(varname='FOO', item='http://example.com/', problems=problems)
     assert [] == problems
-    assert len(requirements) == 1
-    assert requirements[0].filename == 'FOO'
-    assert requirements[0].url == 'http://example.com/'
-    assert not requirements[0].unzip
+    assert kwargs['filename'] == 'FOO'
+    assert kwargs['url'] == 'http://example.com/'
+    assert not kwargs['unzip']
 
 
 def test_checksum_is_not_a_string():
     problems = []
-    requirements = []
-    DownloadRequirement._parse(PluginRegistry(),
-                               varname='FOO',
-                               item=dict(url='http://example.com/',
-                                         md5=[]),
-                               problems=problems,
-                               requirements=requirements)
+    kwargs = DownloadRequirement._parse(varname='FOO', item=dict(url='http://example.com/', md5=[]), problems=problems)
     assert ['Checksum value for FOO should be a string not [].'] == problems
-    assert len(requirements) == 0
+    assert kwargs is None
 
 
 def test_description_is_not_a_string():
     problems = []
-    requirements = []
-    DownloadRequirement._parse(PluginRegistry(),
-                               varname='FOO',
-                               item=dict(url='http://example.com/',
-                                         description=[]),
-                               problems=problems,
-                               requirements=requirements)
+    kwargs = DownloadRequirement._parse(varname='FOO',
+                                        item=dict(url='http://example.com/',
+                                                  description=[]),
+                                        problems=problems)
     assert ["'description' field for download item FOO is not a string"] == problems
-    assert len(requirements) == 0
+    assert kwargs is None
 
 
 def test_description_property():
     problems = []
-    requirements = []
-    DownloadRequirement._parse(PluginRegistry(),
-                               varname='FOO',
-                               item=dict(url='http://example.com/',
-                                         description="hi"),
-                               problems=problems,
-                               requirements=requirements)
+    kwargs = DownloadRequirement._parse(varname='FOO',
+                                        item=dict(url='http://example.com/',
+                                                  description="hi"),
+                                        problems=problems)
     assert [] == problems
-    assert len(requirements) == 1
-    assert requirements[0].title == 'FOO'
-    assert requirements[0].description == 'hi'
+    assert kwargs['description'] == 'hi'
+    req = DownloadRequirement(PluginRegistry(), **kwargs)
+    assert req.title == 'FOO'
 
 
 def test_download_item_is_a_list_not_a_string_or_dict():
     problems = []
-    requirements = []
-    DownloadRequirement._parse(PluginRegistry(), varname='FOO', item=[], problems=problems, requirements=requirements)
+    kwargs = DownloadRequirement._parse(varname='FOO', item=[], problems=problems)
     assert ["Download name FOO should be followed by a URL string or a dictionary describing the download."] == problems
-    assert len(requirements) == 0
+    assert kwargs is None
 
 
 def test_download_item_is_none_not_a_string_or_dict():
     problems = []
-    requirements = []
-    DownloadRequirement._parse(PluginRegistry(), varname='FOO', item=None, problems=problems, requirements=requirements)
+    kwargs = DownloadRequirement._parse(varname='FOO', item=None, problems=problems)
     assert ["Download name FOO should be followed by a URL string or a dictionary describing the download."] == problems
-    assert len(requirements) == 0
+    assert kwargs is None
 
 
 def test_unzip_is_not_a_bool():
     problems = []
-    requirements = []
-    DownloadRequirement._parse(PluginRegistry(),
-                               varname='FOO',
-                               item=dict(url='http://example.com/',
-                                         unzip=[]),
-                               problems=problems,
-                               requirements=requirements)
+    kwargs = DownloadRequirement._parse(varname='FOO',
+                                        item=dict(url='http://example.com/',
+                                                  unzip=[]),
+                                        problems=problems)
     assert ["Value of 'unzip' for download item FOO should be a boolean, not []."] == problems
-    assert len(requirements) == 0
+    assert kwargs is None
 
 
 def test_use_unzip_if_url_ends_in_zip():
     problems = []
-    requirements = []
-    DownloadRequirement._parse(PluginRegistry(),
-                               varname='FOO',
-                               item='http://example.com/bar.zip',
-                               problems=problems,
-                               requirements=requirements)
+    kwargs = DownloadRequirement._parse(varname='FOO', item='http://example.com/bar.zip', problems=problems)
     assert [] == problems
-    assert len(requirements) == 1
-    assert requirements[0].filename == 'bar'
-    assert requirements[0].url == 'http://example.com/bar.zip'
-    assert requirements[0].unzip
+    assert kwargs['filename'] == 'bar'
+    assert kwargs['url'] == 'http://example.com/bar.zip'
+    assert kwargs['unzip']
+    req = DownloadRequirement(PluginRegistry(), **kwargs)
+    assert req.filename == 'bar'
+    assert req.url == 'http://example.com/bar.zip'
+    assert req.unzip
 
 
 def test_allow_manual_override_of_use_unzip_if_url_ends_in_zip():
     problems = []
-    requirements = []
-    DownloadRequirement._parse(PluginRegistry(),
-                               varname='FOO',
-                               item=dict(url='http://example.com/bar.zip',
-                                         unzip=False),
-                               problems=problems,
-                               requirements=requirements)
+    kwargs = DownloadRequirement._parse(varname='FOO',
+                                        item=dict(url='http://example.com/bar.zip',
+                                                  unzip=False),
+                                        problems=problems)
     assert [] == problems
-    assert len(requirements) == 1
-    assert requirements[0].filename == 'bar.zip'
-    assert requirements[0].url == 'http://example.com/bar.zip'
-    assert not requirements[0].unzip
+    assert kwargs['filename'] == 'bar.zip'
+    assert kwargs['url'] == 'http://example.com/bar.zip'
+    assert not kwargs['unzip']
+
+    req = DownloadRequirement(PluginRegistry(), **kwargs)
+    assert req.filename == 'bar.zip'
+    assert req.url == 'http://example.com/bar.zip'
+    assert not req.unzip
 
 
 def test_use_unzip_if_url_ends_in_zip_and_filename_does_not():
     problems = []
-    requirements = []
-    DownloadRequirement._parse(PluginRegistry(),
-                               varname='FOO',
-                               item=dict(url='http://example.com/bar.zip',
-                                         filename='something'),
-                               problems=problems,
-                               requirements=requirements)
+    kwargs = DownloadRequirement._parse(varname='FOO',
+                                        item=dict(url='http://example.com/bar.zip',
+                                                  filename='something'),
+                                        problems=problems)
     assert [] == problems
-    assert len(requirements) == 1
-    assert requirements[0].filename == 'something'
-    assert requirements[0].url == 'http://example.com/bar.zip'
-    assert requirements[0].unzip
+    assert kwargs['filename'] == 'something'
+    assert kwargs['url'] == 'http://example.com/bar.zip'
+    assert kwargs['unzip']
 
 
 def test_no_unzip_if_url_ends_in_zip_and_filename_also_does():
     problems = []
-    requirements = []
-    DownloadRequirement._parse(PluginRegistry(),
-                               varname='FOO',
-                               item=dict(url='http://example.com/bar.zip',
-                                         filename='something.zip'),
-                               problems=problems,
-                               requirements=requirements)
+    kwargs = DownloadRequirement._parse(varname='FOO',
+                                        item=dict(url='http://example.com/bar.zip',
+                                                  filename='something.zip'),
+                                        problems=problems)
     assert [] == problems
-    assert len(requirements) == 1
-    assert requirements[0].filename == 'something.zip'
-    assert requirements[0].url == 'http://example.com/bar.zip'
-    assert not requirements[0].unzip
+    assert kwargs['filename'] == 'something.zip'
+    assert kwargs['url'] == 'http://example.com/bar.zip'
+    assert not kwargs['unzip']

--- a/anaconda_project/plugins/requirements/test/test_service_requirement.py
+++ b/anaconda_project/plugins/requirements/test/test_service_requirement.py
@@ -14,7 +14,7 @@ from anaconda_project.internal.test.tmpfile_utils import with_directory_contents
 def _load_service_requirement(dirname):
     project = Project(dirname)
     assert [] == project.problems
-    for req in project.requirements:
+    for req in project.requirements(project.default_env_spec_name):
         if isinstance(req, ServiceRequirement):
             return req
     raise RuntimeError("no ServiceRequirement found")

--- a/anaconda_project/plugins/test/test_provider.py
+++ b/anaconda_project/plugins/test/test_provider.py
@@ -79,7 +79,7 @@ def test_provider_default_method_implementations():
 def _load_env_var_requirement(dirname, env_var):
     project = Project(dirname)
 
-    for requirement in project.requirements:
+    for requirement in project.requirements(project.default_env_spec_name):
         if isinstance(requirement, EnvVarRequirement) and requirement.env_var == env_var:
             return requirement
     assert [] == project.problems

--- a/anaconda_project/prepare.py
+++ b/anaconda_project/prepare.py
@@ -21,7 +21,7 @@ from anaconda_project.internal.py2_compat import is_string
 from anaconda_project.local_state_file import LocalStateFile
 from anaconda_project.provide import (_all_provide_modes, PROVIDE_MODE_DEVELOPMENT)
 from anaconda_project.plugins.provider import ProvideContext
-from anaconda_project.plugins.requirement import EnvVarRequirement, UserConfigOverrides
+from anaconda_project.plugins.requirement import Requirement, EnvVarRequirement, UserConfigOverrides
 from anaconda_project.plugins.requirements.conda_env import CondaEnvRequirement
 
 
@@ -434,12 +434,15 @@ def _in_provide_whitelist(provide_whitelist, requirement):
         # whitelist of None means "everything"
         return True
 
-    for env_var_or_class in provide_whitelist:
-        if is_string(env_var_or_class):
-            if isinstance(requirement, EnvVarRequirement) and requirement.env_var == env_var_or_class:
+    for env_var_or_class_or_req in provide_whitelist:
+        if isinstance(env_var_or_class_or_req, Requirement):
+            if requirement is env_var_or_class_or_req:
+                return True
+        elif is_string(env_var_or_class_or_req):
+            if isinstance(requirement, EnvVarRequirement) and requirement.env_var == env_var_or_class_or_req:
                 return True
         else:
-            if isinstance(requirement, env_var_or_class):
+            if isinstance(requirement, env_var_or_class_or_req):
                 return True
     return False
 

--- a/anaconda_project/prepare.py
+++ b/anaconda_project/prepare.py
@@ -22,6 +22,7 @@ from anaconda_project.local_state_file import LocalStateFile
 from anaconda_project.provide import (_all_provide_modes, PROVIDE_MODE_DEVELOPMENT)
 from anaconda_project.plugins.provider import ProvideContext
 from anaconda_project.plugins.requirement import EnvVarRequirement, UserConfigOverrides
+from anaconda_project.plugins.requirements.conda_env import CondaEnvRequirement
 
 
 def _update_environ(dest, src):
@@ -114,6 +115,15 @@ class PrepareResult(with_metaclass(ABCMeta)):
         obscure scenario where it matters.
         """
         return self._env_spec_name
+
+    @property
+    def env_prefix(self):
+        """The prefix of the prepared env, or None if none was created."""
+        status = self.status_for(CondaEnvRequirement)
+        if status is None:
+            return None
+        varname = status.requirement.env_var
+        return self._environ.get(varname, None)
 
 
 class PrepareSuccess(PrepareResult):

--- a/anaconda_project/prepare.py
+++ b/anaconda_project/prepare.py
@@ -684,7 +684,7 @@ def _internal_prepare_in_stages(project, environ_copy, overrides, keep_going_unt
     local_state = LocalStateFile.load_for_directory(project.directory_path)
 
     statuses = []
-    for requirement in project.requirements:
+    for requirement in project.requirements(overrides.env_spec_name):
         status = requirement.check_status(environ_copy,
                                           local_state,
                                           project.default_env_spec_name_for_command(command),

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -186,12 +186,12 @@ class _ConfigCache(object):
             self._update_name(problems, project_file)
             self._update_description(problems, project_file)
             self._update_icon(problems, project_file)
+            self._update_lock_sets(problems, lock_file)
+            self._update_env_specs(problems, project_file, lock_file)
             # future: we could un-hardcode this so plugins can add stuff here
             self._update_variables(requirements, problems, project_file)
             self._update_downloads(requirements, problems, project_file)
             self._update_services(requirements, problems, project_file)
-            self._update_lock_sets(problems, lock_file)
-            self._update_env_specs(problems, project_file, lock_file)
             # this MUST be after we _update_variables since we may get CondaEnvRequirement
             # options in the variables section, and after _update_env_specs
             # since we use those

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -14,9 +14,10 @@ import shutil
 import tempfile
 
 from anaconda_project.project import Project, ALL_COMMAND_TYPES
-from anaconda_project import prepare
 from anaconda_project import archiver
 from anaconda_project import client
+from anaconda_project import prepare
+from anaconda_project import provide
 from anaconda_project.local_state_file import LocalStateFile
 from anaconda_project.frontend import _null_frontend
 from anaconda_project.plugins.requirement import EnvVarRequirement
@@ -951,6 +952,16 @@ def unlock(project, env_spec_name):
         return status
 
 
+def _check_env_spec_name(project, name):
+    if name is not None and name not in project.env_specs:
+        problem = "Environment spec {} doesn't exist.".format(name)
+        return SimpleStatus(success=False, description=problem)
+    else:
+        return None
+
+
+# this function is specific to fields that go into the EnvSpec
+# (CondaEnvRequirement/lockset-affecting)
 def _modify_inherited_field(project, name, field, additions, removals):
     # TODO this is not even as clever as remove_packages, in that
     # it simply removes from either the global or single-env-spec
@@ -962,12 +973,11 @@ def _modify_inherited_field(project, name, field, additions, removals):
     # vs. specific lists.
 
     failed = _check_problems(project)
+    if failed is None:
+        failed = _check_env_spec_name(project, name)
+
     if failed is not None:
         return failed
-
-    if name is not None and name not in project.env_specs:
-        problem = "Environment spec {} doesn't exist.".format(name)
-        return SimpleStatus(success=False, description=problem)
 
     # field values will be validated when we try out the new
     # project file, we won't save if the result is invalid.
@@ -1058,24 +1068,46 @@ def remove_platforms(project, env_spec_name, platforms):
     return _modify_platforms(project, env_spec_name, additions=[], removals=platforms)
 
 
-def _prepare_env_prefix(project, env_spec_name):
+def _prepare_env_prefix(project, env_spec_name, prepare_result, mode):
     failed = _check_problems(project)
+    if failed is None:
+        failed = _check_env_spec_name(project, env_spec_name)
     if failed is not None:
         return (None, failed)
 
     # we need an env prefix to store in keyring
-    result = prepare.prepare_without_interaction(project,
-                                                 provide_whitelist=(CondaEnvRequirement, ),
-                                                 env_spec_name=env_spec_name)
-    status = result.status_for(CondaEnvRequirement)
-    assert status is not None
-    if not status:
-        return (None, status)
+
+    env_prefix = None
+    if prepare_result is not None:
+        env_prefix = prepare_result.env_prefix
+
+    if env_prefix is None:
+        result = prepare.prepare_without_interaction(project,
+                                                     provide_whitelist=(CondaEnvRequirement, ),
+                                                     env_spec_name=env_spec_name,
+                                                     mode=mode)
+        status = result.status_for(CondaEnvRequirement)
+        assert status is not None
+        if status:
+            env_prefix = result.environ[status.requirement.env_var]
+        else:
+            # ignore errors if only checking
+            if mode == provide.PROVIDE_MODE_CHECK:
+                return (None, None)
+            else:
+                return (None, status)
+
+    return (env_prefix, None)
+
+
+def _path_to_variable(env_spec_name, varname):
+    if env_spec_name is None:
+        return ['variables', varname]
     else:
-        return (result.environ[status.requirement.env_var], status)
+        return ['env_specs', env_spec_name, 'variables', varname]
 
 
-def add_variables(project, vars_to_add, defaults=None):
+def add_variables(project, env_spec_name, vars_to_add, defaults=None):
     """Add variables in anaconda-project.yml, optionally setting their defaults.
 
     Returns a ``Status`` instance which evaluates to True on
@@ -1084,6 +1116,7 @@ def add_variables(project, vars_to_add, defaults=None):
 
     Args:
         project (Project): the project
+        env_spec_name (str): environment spec name or None for all environment specs
         vars_to_add (list of str): variable names
         defaults (dict): dictionary from keys to defaults, can be empty
 
@@ -1091,36 +1124,39 @@ def add_variables(project, vars_to_add, defaults=None):
         ``Status`` instance
     """
     failed = _check_problems(project)
+    if failed is None:
+        failed = _check_env_spec_name(project, env_spec_name)
     if failed is not None:
         return failed
 
     if defaults is None:
         defaults = dict()
 
-    present_vars = {req.env_var
-                    for req in project.requirements(project.default_env_spec_name)
-                    if isinstance(req, EnvVarRequirement)}
+    present_vars = {req.env_var for req in project.requirements(env_spec_name) if isinstance(req, EnvVarRequirement)}
     for varname in vars_to_add:
+
+        path_to_variable = _path_to_variable(env_spec_name, varname)
+
         if varname in defaults:
             # we need to update the default even if var already exists
             new_default = defaults.get(varname)
-            variable_value = project.project_file.get_value(['variables', varname])
+            variable_value = project.project_file.get_value(path_to_variable)
             if variable_value is None or not isinstance(variable_value, dict):
                 variable_value = new_default
             else:
                 variable_value['default'] = new_default
-            project.project_file.set_value(['variables', varname], variable_value)
+            project.project_file.set_value(path_to_variable, variable_value)
         elif varname not in present_vars:
             # we are only adding the var if nonexistent and should leave
             # the default alone if it's already set
-            project.project_file.set_value(['variables', varname], None)
+            project.project_file.set_value(path_to_variable, None)
     project.project_file.save()
 
     return SimpleStatus(success=True, description="Variables added to the project file.")
 
 
-def _unset_variable(project, env_prefix, varname, local_state):
-    reqs = project.find_requirements(project.default_env_spec_name, env_var=varname)
+def _unset_variable(project, env_spec_name, env_prefix, varname, local_state):
+    reqs = project.find_requirements(env_spec_name, env_var=varname)
     if len(reqs) > 0:
         req = reqs[0]
         if req.encrypted:
@@ -1133,7 +1169,7 @@ def _unset_variable(project, env_prefix, varname, local_state):
             local_state.unset_value(['variables', varname])
 
 
-def remove_variables(project, vars_to_remove, env_spec_name=None):
+def remove_variables(project, env_spec_name, vars_to_remove, prepare_result=None):
     """Remove variables from anaconda-project.yml and unset their values in local project state.
 
     Returns a ``Status`` instance which evaluates to True on
@@ -1142,27 +1178,34 @@ def remove_variables(project, vars_to_remove, env_spec_name=None):
 
     Args:
         project (Project): the project
+        env_spec_name (str): environment spec name or None for all environment specs
         vars_to_remove (list of str): variable names
-        env_spec_name (str): name of env spec to use
+        prepare_result (PrepareResult): result of a previous prepare or None
 
     Returns:
         ``Status`` instance
     """
-    (env_prefix, status) = _prepare_env_prefix(project, env_spec_name)
-    if env_prefix is None:
+    (env_prefix, status) = _prepare_env_prefix(project, env_spec_name, prepare_result, mode=provide.PROVIDE_MODE_CHECK)
+    # we allow env_prefix of None, which means the env wasn't created so we won't
+    # try to unset any values for the variable.
+    if status is not None and not status:
         return status
 
     local_state = LocalStateFile.load_for_directory(project.directory_path)
     for varname in vars_to_remove:
-        _unset_variable(project, env_prefix, varname, local_state)
-        project.project_file.unset_value(['variables', varname])
+        path_to_variable = _path_to_variable(env_spec_name, varname)
+
+        if env_prefix is not None:
+            _unset_variable(project, env_spec_name, env_prefix, varname, local_state)
+        path_to_variable = _path_to_variable(env_spec_name, varname)
+        project.project_file.unset_value(path_to_variable)
         project.project_file.save()
         local_state.save()
 
     return SimpleStatus(success=True, description="Variables removed from the project file.")
 
 
-def set_variables(project, vars_and_values, env_spec_name=None):
+def set_variables(project, env_spec_name, vars_and_values, prepare_result=None):
     """Set variables' values in anaconda-project-local.yml.
 
     Returns a ``Status`` instance which evaluates to True on
@@ -1171,13 +1214,17 @@ def set_variables(project, vars_and_values, env_spec_name=None):
 
     Args:
         project (Project): the project
+        env_spec_name (str): name of env spec to use or None for all
         vars_and_values (list of tuple): key-value pairs
-        env_spec_name (str): name of env spec to use
+        prepare_result (PrepareResult): result of a previous prepare or None
 
     Returns:
         ``Status`` instance
     """
-    (env_prefix, status) = _prepare_env_prefix(project, env_spec_name)
+    (env_prefix, status) = _prepare_env_prefix(project,
+                                               env_spec_name,
+                                               prepare_result,
+                                               mode=provide.PROVIDE_MODE_DEVELOPMENT)
     if env_prefix is None:
         return status
 
@@ -1219,7 +1266,7 @@ def set_variables(project, vars_and_values, env_spec_name=None):
         return SimpleStatus(success=True, description=description)
 
 
-def unset_variables(project, vars_to_unset, env_spec_name=None):
+def unset_variables(project, env_spec_name, vars_to_unset, prepare_result=None):
     """Unset variables' values in anaconda-project-local.yml.
 
     Returns a ``Status`` instance which evaluates to True on
@@ -1228,19 +1275,20 @@ def unset_variables(project, vars_to_unset, env_spec_name=None):
 
     Args:
         project (Project): the project
+        env_spec_name (str): name of env spec to use or None for all
         vars_to_unset (list of str): variable names
-        env_spec_name (str): name of env spec to use
+        prepare_result (PrepareResult): result of a previous prepare or None
 
     Returns:
         ``Status`` instance
     """
-    (env_prefix, status) = _prepare_env_prefix(project, env_spec_name)
+    (env_prefix, status) = _prepare_env_prefix(project, env_spec_name, prepare_result, mode=provide.PROVIDE_MODE_CHECK)
     if env_prefix is None:
         return status
 
     local_state = LocalStateFile.load_for_directory(project.directory_path)
     for varname in vars_to_unset:
-        _unset_variable(project, env_prefix, varname, local_state)
+        _unset_variable(project, env_spec_name, env_prefix, varname, local_state)
     local_state.save()
 
     return SimpleStatus(success=True, description=("Variables were unset."))

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -289,10 +289,14 @@ def remove_download(project, prepare_result, env_var):
         ``Status`` instance
     """
     failed = _check_problems(project)
+
     if failed is not None:
         return failed
+
+    assert prepare_result.env_spec_name is not None
+
     # Modify the project file _in memory only_, do not save
-    requirement = project.find_requirements(project.default_env_spec_name, env_var, klass=DownloadRequirement)
+    requirement = project.find_requirements(prepare_result.env_spec_name, env_var, klass=DownloadRequirement)
     if not requirement:
         return SimpleStatus(success=False, description="Download requirement: {} not found.".format(env_var))
     assert len(requirement) == 1  # duplicate env vars aren't allowed
@@ -1510,11 +1514,14 @@ def remove_service(project, prepare_result, variable_name):
         ``Status`` instance
     """
     failed = _check_problems(project)
+
     if failed is not None:
         return failed
 
+    assert prepare_result.env_spec_name is not None
+
     requirements = [req
-                    for req in project.find_requirements(project.default_env_spec_name,
+                    for req in project.find_requirements(prepare_result.env_spec_name,
                                                          klass=ServiceRequirement)
                     if req.service_type == variable_name or req.env_var == variable_name]
     if not requirements:

--- a/anaconda_project/test/test_api.py
+++ b/anaconda_project/test/test_api.py
@@ -272,7 +272,13 @@ def test_add_download(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.add_download', mock_add_download)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, env_var='boo', url='baz', filename="fname", hash_algorithm="md5", hash_value="foo")
+    kwargs = dict(project=43,
+                  env_spec_name="myenv",
+                  env_var='boo',
+                  url='baz',
+                  filename="fname",
+                  hash_algorithm="md5",
+                  hash_value="foo")
     result = p.add_download(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']
@@ -292,7 +298,7 @@ def test_remove_download(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.remove_download', mock_remove_download)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, prepare_result='winnebago', env_var='boo')
+    kwargs = dict(project=43, env_spec_name="blah", prepare_result='winnebago', env_var='boo')
     result = p.remove_download(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']
@@ -582,7 +588,7 @@ def test_add_service(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.add_service', mock_add_service)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, service_type='abc', variable_name='xyz')
+    kwargs = dict(project=43, env_spec_name="boo", service_type='abc', variable_name='xyz')
     result = p.add_service(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']
@@ -602,7 +608,7 @@ def test_remove_service(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.remove_service', mock_remove_service)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, prepare_result=123, variable_name='xyz')
+    kwargs = dict(project=43, env_spec_name=578, prepare_result=123, variable_name='xyz')
     result = p.remove_service(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']

--- a/anaconda_project/test/test_api.py
+++ b/anaconda_project/test/test_api.py
@@ -192,7 +192,7 @@ def test_add_variables(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.add_variables', mock_add_variables)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, vars_to_add=45, defaults=12345)
+    kwargs = dict(project=43, env_spec_name='boo', vars_to_add=45, defaults=12345)
     result = p.add_variables(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']
@@ -212,7 +212,7 @@ def test_remove_variables(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.remove_variables', mock_remove_variables)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, vars_to_remove=45, env_spec_name='foo')
+    kwargs = dict(project=43, env_spec_name='boo', vars_to_remove=45, prepare_result=57)
     result = p.remove_variables(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']
@@ -232,7 +232,7 @@ def test_set_variables(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.set_variables', mock_set_variables)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, vars_and_values=45, env_spec_name='foo')
+    kwargs = dict(project=43, env_spec_name='boo', vars_and_values=45, prepare_result=57)
     result = p.set_variables(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']
@@ -252,7 +252,7 @@ def test_unset_variables(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.unset_variables', mock_unset_variables)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, vars_to_unset=45, env_spec_name='foo')
+    kwargs = dict(project=43, env_spec_name='boo', vars_to_unset=45, prepare_result=57)
     result = p.unset_variables(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']

--- a/anaconda_project/test/test_prepare.py
+++ b/anaconda_project/test/test_prepare.py
@@ -39,6 +39,7 @@ def test_prepare_empty_directory():
         result = prepare_without_interaction(project, environ=environ)
         assert result.errors == []
         assert result
+        assert result.env_prefix is not None
         assert dict(PROJECT_DIR=project.directory_path) == strip_environ(result.environ)
         assert dict() == strip_environ(environ)
         assert result.command_exec_info is None
@@ -81,6 +82,7 @@ def test_unprepare_problem_project():
         environ = minimal_environ()
         result = prepare_without_interaction(project, environ=environ)
         assert not result
+        assert result.env_prefix is None
         status = unprepare(project, result)
         assert not status
         assert status.status_description == 'Unable to load the project.'
@@ -160,6 +162,7 @@ def test_prepare_some_env_var_not_set():
         environ = minimal_environ(BAR='bar')
         result = prepare_without_interaction(project, environ=environ)
         assert not result
+        assert result.env_prefix is not None
         assert dict(BAR='bar') == strip_environ(environ)
 
     with_directory_contents_completing_project_file(
@@ -293,6 +296,7 @@ def test_prepare_bad_command_name():
         environ = minimal_environ(BAR='bar')
         result = prepare_without_interaction(project, environ=environ, command_name="blah")
         assert not result
+        assert result.env_prefix is None
         assert result.errors
         assert "Command name 'blah' is not in" in result.errors[0]
 

--- a/anaconda_project/test/test_prepare.py
+++ b/anaconda_project/test/test_prepare.py
@@ -443,7 +443,8 @@ def test_skip_after_success_function_when_second_stage_fails():
             PrepareSuccess(statuses=(),
                            command_exec_info=None,
                            environ=dict(),
-                           overrides=UserConfigOverrides()),
+                           overrides=UserConfigOverrides(),
+                           env_spec_name='first'),
             [])
 
         def last(stage):
@@ -453,7 +454,8 @@ def test_skip_after_success_function_when_second_stage_fails():
                 PrepareFailure(statuses=(),
                                errors=[],
                                environ=dict(),
-                               overrides=UserConfigOverrides()),
+                               overrides=UserConfigOverrides(),
+                               env_spec_name='last'),
                 [])
             return None
 
@@ -490,7 +492,8 @@ def test_run_after_success_function_when_second_stage_succeeds():
             PrepareSuccess(statuses=(),
                            command_exec_info=None,
                            environ=dict(),
-                           overrides=UserConfigOverrides()),
+                           overrides=UserConfigOverrides(),
+                           env_spec_name='foo'),
             [])
 
         def last(stage):
@@ -500,7 +503,8 @@ def test_run_after_success_function_when_second_stage_succeeds():
                 PrepareSuccess(statuses=(),
                                command_exec_info=None,
                                environ=dict(),
-                               overrides=UserConfigOverrides()),
+                               overrides=UserConfigOverrides(),
+                               env_spec_name='bar'),
                 [])
             return None
 
@@ -732,8 +736,13 @@ icon: foo.png
 
 
 def test_prepare_success_properties():
-    result = PrepareSuccess(statuses=(), command_exec_info=None, environ=dict(), overrides=UserConfigOverrides())
+    result = PrepareSuccess(statuses=(),
+                            command_exec_info=None,
+                            environ=dict(),
+                            overrides=UserConfigOverrides(),
+                            env_spec_name='foo')
     assert result.statuses == ()
     assert result.status_for('FOO') is None
     assert result.status_for(EnvVarRequirement) is None
     assert result.overrides is not None
+    assert result.env_spec_name == 'foo'

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -70,12 +70,13 @@ def test_single_env_var_requirement():
     def check_some_env_var(dirname):
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
-        assert 2 == len(project.requirements)
-        assert "FOO" == project.requirements[0].env_var
-        assert dict() == project.requirements[0].options
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 2 == len(requirements)
+        assert "FOO" == requirements[0].env_var
+        assert dict() == requirements[0].options
 
         conda_env_var = conda_api.conda_prefix_variable()
-        assert conda_env_var == project.requirements[1].env_var
+        assert conda_env_var == requirements[1].env_var
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
@@ -88,14 +89,15 @@ def test_single_env_var_requirement_with_description():
     def check_some_env_var(dirname):
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
-        assert 2 == len(project.requirements)
-        assert "FOO" == project.requirements[0].env_var
-        assert {'description': "Set FOO to the value of your foo"} == project.requirements[0].options
-        assert "Set FOO to the value of your foo" == project.requirements[0].description
-        assert "FOO" == project.requirements[0].title
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 2 == len(requirements)
+        assert "FOO" == requirements[0].env_var
+        assert {'description': "Set FOO to the value of your foo"} == requirements[0].options
+        assert "Set FOO to the value of your foo" == requirements[0].description
+        assert "FOO" == requirements[0].title
 
         conda_env_var = conda_api.conda_prefix_variable()
-        assert conda_env_var == project.requirements[1].env_var
+        assert conda_env_var == requirements[1].env_var
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
@@ -108,14 +110,15 @@ def test_single_env_var_requirement_null_for_default():
     def check_some_env_var(dirname):
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
-        assert 3 == len(project.requirements)
-        assert "FOO" == project.requirements[0].env_var
-        assert dict() == project.requirements[0].options
-        assert "BAR" == project.requirements[1].env_var
-        assert dict() == project.requirements[1].options
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 3 == len(requirements)
+        assert "FOO" == requirements[0].env_var
+        assert dict() == requirements[0].options
+        assert "BAR" == requirements[1].env_var
+        assert dict() == requirements[1].options
 
         conda_env_var = conda_api.conda_prefix_variable()
-        assert conda_env_var == project.requirements[2].env_var
+        assert conda_env_var == requirements[2].env_var
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
@@ -129,12 +132,13 @@ def test_single_env_var_requirement_string_for_default():
     def check_some_env_var(dirname):
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
-        assert 2 == len(project.requirements)
-        assert "FOO" == project.requirements[0].env_var
-        assert dict(default='hello') == project.requirements[0].options
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 2 == len(requirements)
+        assert "FOO" == requirements[0].env_var
+        assert dict(default='hello') == requirements[0].options
 
         conda_env_var = conda_api.conda_prefix_variable()
-        assert conda_env_var == project.requirements[1].env_var
+        assert conda_env_var == requirements[1].env_var
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
@@ -147,12 +151,13 @@ def test_single_env_var_requirement_number_for_default():
     def check_some_env_var(dirname):
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
-        assert 2 == len(project.requirements)
-        assert "FOO" == project.requirements[0].env_var
-        assert dict(default='42') == project.requirements[0].options
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 2 == len(requirements)
+        assert "FOO" == requirements[0].env_var
+        assert dict(default='42') == requirements[0].options
 
         conda_env_var = conda_api.conda_prefix_variable()
-        assert conda_env_var == project.requirements[1].env_var
+        assert conda_env_var == requirements[1].env_var
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
@@ -165,12 +170,13 @@ def test_single_env_var_requirement_default_is_in_dict():
     def check_some_env_var(dirname):
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
-        assert 2 == len(project.requirements)
-        assert "FOO" == project.requirements[0].env_var
-        assert dict(default='42') == project.requirements[0].options
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 2 == len(requirements)
+        assert "FOO" == requirements[0].env_var
+        assert dict(default='42') == requirements[0].options
 
         conda_env_var = conda_api.conda_prefix_variable()
-        assert conda_env_var == project.requirements[1].env_var
+        assert conda_env_var == requirements[1].env_var
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
@@ -182,7 +188,8 @@ variables:
 def test_problem_in_project_file():
     def check_problem(dirname):
         project = project_no_dedicated_env(dirname)
-        assert 0 == len(project.requirements)
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 0 == len(requirements)
         assert 1 == len(project.problems)
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: """
@@ -242,7 +249,8 @@ def test_project_dir_does_not_exist():
         project = Project(project_dir)
         assert not os.path.isdir(project_dir)
         assert ["Project directory '%s' does not exist." % project_dir] == project.problems
-        assert 0 == len(project.requirements)
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 0 == len(requirements)
 
     with_directory_contents(dict(), check_does_not_exist)
 
@@ -267,12 +275,13 @@ def test_project_dir_not_readable(monkeypatch):
 def test_single_env_var_requirement_with_options():
     def check_some_env_var(dirname):
         project = project_no_dedicated_env(dirname)
-        assert 2 == len(project.requirements)
-        assert "FOO" == project.requirements[0].env_var
-        assert dict(default="hello") == project.requirements[0].options
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 2 == len(requirements)
+        assert "FOO" == requirements[0].env_var
+        assert dict(default="hello") == requirements[0].options
 
         conda_env_var = conda_api.conda_prefix_variable()
-        assert conda_env_var == project.requirements[1].env_var
+        assert conda_env_var == requirements[1].env_var
 
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
@@ -438,9 +447,11 @@ def test_get_package_requirements_from_project_file():
         assert set(["foo", "hello", "world"]) == env.conda_package_names_set
         assert set(["pip1", "pip2", "pip3"]) == env.pip_package_names_set
 
+        requirements = project.requirements(project.default_env_spec_name)
+
         # find CondaEnvRequirement
         conda_env_req = None
-        for r in project.requirements:
+        for r in requirements:
             if isinstance(r, CondaEnvRequirement):
                 assert conda_env_req is None  # only one
                 conda_env_req = r
@@ -856,7 +867,7 @@ def test_load_list_of_variables_requirements():
         assert os.path.exists(filename)
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
-        requirements = project.requirements
+        requirements = project.requirements(project.default_env_spec_name)
         assert 3 == len(requirements)
         assert isinstance(requirements[0], EnvVarRequirement)
         assert 'FOO' == requirements[0].env_var
@@ -865,7 +876,7 @@ def test_load_list_of_variables_requirements():
         assert isinstance(requirements[2], CondaEnvRequirement)
 
         conda_env_var = conda_api.conda_prefix_variable()
-        assert conda_env_var == project.requirements[2].env_var
+        assert conda_env_var == requirements[2].env_var
 
         assert dict() == requirements[2].options
         assert len(project.problems) == 0
@@ -880,7 +891,7 @@ def test_load_dict_of_variables_requirements():
         assert os.path.exists(filename)
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
-        requirements = project.requirements
+        requirements = project.requirements(project.default_env_spec_name)
         assert 3 == len(requirements)
         assert isinstance(requirements[0], EnvVarRequirement)
         assert 'FOO' == requirements[0].env_var
@@ -891,7 +902,7 @@ def test_load_dict_of_variables_requirements():
         assert isinstance(requirements[2], CondaEnvRequirement)
 
         conda_env_var = conda_api.conda_prefix_variable()
-        assert conda_env_var == project.requirements[2].env_var
+        assert conda_env_var == requirements[2].env_var
 
         assert dict() == requirements[2].options
         assert len(project.problems) == 0
@@ -906,7 +917,8 @@ def test_non_string_variables_requirements():
         assert os.path.exists(filename)
         project = project_no_dedicated_env(dirname)
         assert 2 == len(project.problems)
-        assert 0 == len(project.requirements)
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 0 == len(requirements)
         assert "42 is not a string" in project.problems[0]
         assert "43 is not a string" in project.problems[1]
 
@@ -919,7 +931,8 @@ def test_variable_default_cannot_be_bool():
         filename = os.path.join(dirname, DEFAULT_PROJECT_FILENAME)
         assert os.path.exists(filename)
         project = project_no_dedicated_env(dirname)
-        assert [] == project.requirements
+        requirements = project.requirements(project.default_env_spec_name)
+        assert [] == requirements
         assert 1 == len(project.problems)
 
         assert ("default value for variable FOO must be null, a string, or a number, not True.") == project.problems[0]
@@ -932,7 +945,8 @@ def test_variable_default_cannot_be_list():
         filename = os.path.join(dirname, DEFAULT_PROJECT_FILENAME)
         assert os.path.exists(filename)
         project = project_no_dedicated_env(dirname)
-        assert [] == project.requirements
+        requirements = project.requirements(project.default_env_spec_name)
+        assert [] == requirements
         assert 1 == len(project.problems)
 
         assert ("default value for variable FOO must be null, a string, or a number, not [].") == project.problems[0]
@@ -945,7 +959,8 @@ def test_variable_default_missing_key_field():
         filename = os.path.join(dirname, DEFAULT_PROJECT_FILENAME)
         assert os.path.exists(filename)
         project = project_no_dedicated_env(dirname)
-        assert [] == project.requirements
+        requirements = project.requirements(project.default_env_spec_name)
+        assert [] == requirements
         assert 1 == len(project.problems)
 
         assert ("default value for variable FOO must be null, a string, or a number, " +
@@ -965,7 +980,8 @@ def test_variables_requirements_not_a_collection():
         assert os.path.exists(filename)
         project = project_no_dedicated_env(dirname)
         assert 1 == len(project.problems)
-        assert 0 == len(project.requirements)
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 0 == len(requirements)
         assert "variables section contains wrong value type 42" in project.problems[0]
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: "variables:\n  42\n"}, check_file)
@@ -974,7 +990,8 @@ def test_variables_requirements_not_a_collection():
 def test_corrupted_project_file():
     def check_problem(dirname):
         project = project_no_dedicated_env(dirname)
-        assert 0 == len(project.requirements)
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 0 == len(requirements)
         assert 1 == len(project.problems)
         assert 'anaconda-project.yml: Syntax error: ' in project.problems[0]
 
@@ -994,7 +1011,8 @@ variables:
 def test_corrupted_project_lock_file():
     def check_problem(dirname):
         project = project_no_dedicated_env(dirname)
-        assert 0 == len(project.requirements)
+        requirements = project.requirements(project.default_env_spec_name)
+        assert 0 == len(requirements)
         assert 1 == len(project.problems)
         assert 'anaconda-project-lock.yml: Syntax error: ' in project.problems[0]
 
@@ -2135,12 +2153,12 @@ def test_get_publication_info_from_empty_project():
                     'packages': [],
                     'description': 'Default',
                     'locked': False,
-                    'platforms': []
+                    'platforms': [],
+                    'variables': {},
+                    'downloads': {},
+                    'services': {}
                 }
             },
-            'variables': {},
-            'downloads': {},
-            'services': {}
         }
         assert expected == project.publication_info()
 
@@ -2240,42 +2258,102 @@ def test_get_publication_info_from_complex_project():
                                        'env_spec': 'default',
                                        'supports_http_options': True,
                                        'registers_fusion_function': True}},
-            'downloads': {'FOO': {'encrypted': False,
-                                  'title': 'FOO',
-                                  'description': 'A downloaded file which is referenced by FOO.',
-                                  'url': 'https://example.com/blah'}},
-            'env_specs': {'default': {'channels': ['bar'],
-                                      'packages': ['foo', 'notebook'],
-                                      'description': 'Default',
-                                      'locked': False,
-                                      'platforms': ['linux-64', 'osx-64', 'win-64']},
+            'env_specs': {'default':
+                          {'channels': ['bar'],
+                           'packages': ['foo', 'notebook'],
+                           'description': 'Default',
+                           'locked': False,
+                           'platforms': ['linux-64', 'osx-64', 'win-64'],
+                           'downloads': {'FOO': {'encrypted': False,
+                                                 'title': 'FOO',
+                                                 'description': 'A downloaded file which is referenced by FOO.',
+                                                 'url': 'https://example.com/blah'}},
+                           'variables': {'SOMETHING': {'encrypted': False,
+                                                       'title': 'SOMETHING',
+                                                       'description': 'SOMETHING environment variable must be set.'},
+                                         'SOMETHING_ELSE':
+                                         {'encrypted': False,
+                                          'title': 'SOMETHING_ELSE',
+                                          'description': 'SOMETHING_ELSE environment variable must be set.',
+                                          'default': "42"}},
+                           'services': {'REDIS_URL':
+                                        {'title': 'REDIS_URL',
+                                         'description':
+                                         'A running Redis server, located by a redis: URL set as REDIS_URL.',
+                                         'type': 'redis',
+                                         'encrypted': False}}},
                           'lol': {'channels': ['bar'],
                                   'packages': ['foo'],
                                   'description': 'lol',
                                   'locked': False,
-                                  'platforms': ['linux-64', 'osx-64', 'win-64']},
+                                  'platforms': ['linux-64', 'osx-64', 'win-64'],
+                                  'downloads': {'FOO': {'encrypted': False,
+                                                        'title': 'FOO',
+                                                        'description': 'A downloaded file which is referenced by FOO.',
+                                                        'url': 'https://example.com/blah'}},
+                                  'variables': {'SOMETHING':
+                                                {'encrypted': False,
+                                                 'title': 'SOMETHING',
+                                                 'description': 'SOMETHING environment variable must be set.'},
+                                                'SOMETHING_ELSE':
+                                                {'encrypted': False,
+                                                 'title': 'SOMETHING_ELSE',
+                                                 'description': 'SOMETHING_ELSE environment variable must be set.',
+                                                 'default': "42"}},
+                                  'services': {'REDIS_URL':
+                                               {'title': 'REDIS_URL',
+                                                'description':
+                                                'A running Redis server, located by a redis: URL set as REDIS_URL.',
+                                                'type': 'redis',
+                                                'encrypted': False}}},
                           'w00t': {'channels': ['bar'],
                                    'packages': ['foo', 'something'],
                                    'description': 'double 0',
                                    'locked': False,
-                                   'platforms': ['linux-64', 'osx-64', 'win-64']},
+                                   'platforms': ['linux-64', 'osx-64', 'win-64'],
+                                   'downloads': {'FOO': {'encrypted': False,
+                                                         'title': 'FOO',
+                                                         'description': 'A downloaded file which is referenced by FOO.',
+                                                         'url': 'https://example.com/blah'}},
+                                   'variables': {'SOMETHING':
+                                                 {'encrypted': False,
+                                                  'title': 'SOMETHING',
+                                                  'description': 'SOMETHING environment variable must be set.'},
+                                                 'SOMETHING_ELSE':
+                                                 {'encrypted': False,
+                                                  'title': 'SOMETHING_ELSE',
+                                                  'description': 'SOMETHING_ELSE environment variable must be set.',
+                                                  'default': "42"}},
+                                   'services': {'REDIS_URL':
+                                                {'title': 'REDIS_URL',
+                                                 'description':
+                                                 'A running Redis server, located by a redis: URL set as REDIS_URL.',
+                                                 'type': 'redis',
+                                                 'encrypted': False}}},
                           'woot': {'channels': ['bar', 'woohoo'],
                                    'packages': ['foo', 'blah', 'bokeh'],
                                    'description': 'woot',
                                    'locked': False,
-                                   'platforms': ['linux-64', 'osx-64', 'win-64']}},
-            'variables': {'SOMETHING': {'encrypted': False,
-                                        'title': 'SOMETHING',
-                                        'description': 'SOMETHING environment variable must be set.'},
-                          'SOMETHING_ELSE': {'encrypted': False,
-                                             'title': 'SOMETHING_ELSE',
-                                             'description': 'SOMETHING_ELSE environment variable must be set.',
-                                             'default': "42"}},
-            'services': {'REDIS_URL':
-                         {'title': 'REDIS_URL',
-                          'description': 'A running Redis server, located by a redis: URL set as REDIS_URL.',
-                          'type': 'redis',
-                          'encrypted': False}}
+                                   'platforms': ['linux-64', 'osx-64', 'win-64'],
+                                   'downloads': {'FOO': {'encrypted': False,
+                                                         'title': 'FOO',
+                                                         'description': 'A downloaded file which is referenced by FOO.',
+                                                         'url': 'https://example.com/blah'}},
+                                   'variables': {'SOMETHING':
+                                                 {'encrypted': False,
+                                                  'title': 'SOMETHING',
+                                                  'description': 'SOMETHING environment variable must be set.'},
+                                                 'SOMETHING_ELSE':
+                                                 {'encrypted': False,
+                                                  'title': 'SOMETHING_ELSE',
+                                                  'description': 'SOMETHING_ELSE environment variable must be set.',
+                                                  'default': "42"}},
+                                   'services': {'REDIS_URL':
+                                                {'title': 'REDIS_URL',
+                                                 'description':
+                                                 'A running Redis server, located by a redis: URL set as REDIS_URL.',
+                                                 'type': 'redis',
+                                                 'encrypted': False}}}}
         }
 
         assert expected == project.publication_info()
@@ -2292,24 +2370,26 @@ def test_find_requirements():
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
 
-        reqs = project.find_requirements(env_var='SOMETHING')
+        spec_name = project.default_env_spec_name
+
+        reqs = project.find_requirements(spec_name, env_var='SOMETHING')
         assert len(reqs) == 1
         assert reqs[0].env_var == 'SOMETHING'
 
-        reqs = project.find_requirements(klass=CondaEnvRequirement)
+        reqs = project.find_requirements(spec_name, klass=CondaEnvRequirement)
         assert len(reqs) == 1
         assert isinstance(reqs[0], CondaEnvRequirement)
 
-        reqs = project.find_requirements(klass=ServiceRequirement)
+        reqs = project.find_requirements(spec_name, klass=ServiceRequirement)
         assert len(reqs) == 1
         assert isinstance(reqs[0], ServiceRequirement)
 
-        reqs = project.find_requirements(klass=DownloadRequirement)
+        reqs = project.find_requirements(spec_name, klass=DownloadRequirement)
         assert len(reqs) == 1
         assert isinstance(reqs[0], DownloadRequirement)
 
         # the klass and env_var kwargs must be "AND"-ed together
-        reqs = project.find_requirements(klass=CondaEnvRequirement, env_var='SOMETHING')
+        reqs = project.find_requirements(spec_name, klass=CondaEnvRequirement, env_var='SOMETHING')
         assert [] == reqs
 
     with_directory_contents_completing_project_file(
@@ -2323,22 +2403,22 @@ def test_requirements_subsets():
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
 
-        services = project.service_requirements
+        services = project.service_requirements(project.default_env_spec_name)
         assert len(services) == 1
         assert isinstance(services[0], ServiceRequirement)
         assert services[0].env_var == 'REDIS_URL'
 
-        downloads = project.download_requirements
+        downloads = project.download_requirements(project.default_env_spec_name)
         assert len(downloads) == 1
         assert isinstance(downloads[0], DownloadRequirement)
         assert downloads[0].env_var == 'FOO'
 
-        everything = project.all_variable_requirements
+        everything = project.all_variable_requirements(project.default_env_spec_name)
         everything_names = [req.env_var for req in everything]
         # the first element is CONDA_PREFIX, CONDA_ENV_PATH, or CONDA_DEFAULT_ENV
         assert ['FOO', 'REDIS_URL', 'SOMETHING', 'SOMETHING_ELSE'] == sorted(everything_names)[1:]
 
-        plain = project.plain_variable_requirements
+        plain = project.plain_variable_requirements(project.default_env_spec_name)
         plain_names = [req.env_var for req in plain]
         assert ['SOMETHING', 'SOMETHING_ELSE'] == sorted(plain_names)
 
@@ -2353,17 +2433,17 @@ def test_env_var_name_list_properties():
         project = project_no_dedicated_env(dirname)
         assert [] == project.problems
 
-        services = project.services
+        services = project.services(project.default_env_spec_name)
         assert ['REDIS_URL'] == services
 
-        downloads = project.downloads
+        downloads = project.downloads(project.default_env_spec_name)
         assert ['FOO'] == downloads
 
-        everything = project.all_variables
+        everything = project.all_variables(project.default_env_spec_name)
         # the first element is CONDA_PREFIX, CONDA_ENV_PATH, or CONDA_DEFAULT_ENV
         assert ['FOO', 'REDIS_URL', 'SOMETHING', 'SOMETHING_ELSE'] == sorted(everything)[1:]
 
-        plain = project.plain_variables
+        plain = project.plain_variables(project.default_env_spec_name)
         assert ['SOMETHING', 'SOMETHING_ELSE'] == sorted(plain)
 
     with_directory_contents_completing_project_file(

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -311,10 +311,10 @@ def test_add_variables():
         project = project_no_dedicated_env(dirname)
         status = project_ops.add_variables(project, ['foo', 'baz'], dict(foo='bar'))
         assert status
-        req = project.find_requirements(env_var='foo')[0]
+        req = project.find_requirements(project.default_env_spec_name, env_var='foo')[0]
         assert req.options['default'] == 'bar'
 
-        req = project.find_requirements(env_var='baz')[0]
+        req = project.find_requirements(project.default_env_spec_name, env_var='baz')[0]
         assert req.options.get('default') is None
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: ""}, check_add_var)


### PR DESCRIPTION
* [x] add env_spec_name parameter to relevant methods of Project
* [x] add env_spec_name parameter to relevant methods of project_ops.py/api.py
* [x] parse per-env-spec variables/downloads/services and handle inheritance
* [x] add env spec command-line flag to relevant cli commands
* [ ] ~when setting variables in local state file, allow per-env-spec values~ deferred to #80 
* [x] update the docs

This is for #52 

This will be a breaking change, both API/JSON-wise and semantically.
