### PR TITLE
Special-case missing lock sets in lock file, update them when locking

### DIFF
--- a/anaconda_project/conda_manager.py
+++ b/anaconda_project/conda_manager.py
@@ -256,7 +256,7 @@ def _pretty_diff(old_list, new_list, indent):
 class CondaLockSet(object):
     """Represents a locked set of package versions."""
 
-    def __init__(self, package_specs_by_platform, platforms, enabled=True, env_spec_hash=None):
+    def __init__(self, package_specs_by_platform, platforms, enabled=True, env_spec_hash=None, missing=False):
         """Construct a ``CondaLockSet``.
 
         The passed-in dict should be like:
@@ -277,6 +277,7 @@ class CondaLockSet(object):
         self._platforms = tuple(conda_api.sort_platform_list(platforms))
         self._enabled = enabled
         self._env_spec_hash = env_spec_hash
+        self._missing = missing
 
     @property
     def platforms(self):
@@ -295,6 +296,15 @@ class CondaLockSet(object):
         (yes, this is just "not enabled" but this can be more readable sometimes)
         """
         return not self._enabled
+
+    @property
+    def missing(self):
+        """Whether a lock set existed in the lock file.
+
+        This says whether the lock set was loaded from anaconda-project-lock.yml
+        or was just a default we made up on the fly.
+        """
+        return self._missing
 
     @property
     def env_spec_hash(self):

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -602,7 +602,8 @@ class _ConfigCache(object):
                 if lock_set is None:
                     lock_set = CondaLockSet(package_specs_by_platform=dict(),
                                             platforms=[],
-                                            enabled=self.locking_globally_enabled)
+                                            enabled=self.locking_globally_enabled,
+                                            missing=True)
 
                 env_spec_attrs[name] = dict(name=name,
                                             conda_packages=deps,

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -815,7 +815,7 @@ def _update_and_lock(project, env_spec_name, update):
     # note that "envs" are frozen from the original project state,
     # and won't update as we go through them
     for env in envs:
-        if update or env.lock_set.disabled:
+        if update or env.lock_set.disabled or env.lock_set.missing:
             try:
                 project.frontend.info("Updating locked dependencies for env spec %s..." % env.name)
                 lock_set = conda.resolve_dependencies(env.conda_packages, env.channels, env.platforms)


### PR DESCRIPTION
This makes `anaconda-project lock` create lock sets for env specs that
lack them, like `anaconda-project update`. This may "do what I mean"
if I manually add an env spec and then try to lock it.