### PR TITLE
conda: resolve using an underscore prefixed environment

### DIFF
--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -297,7 +297,7 @@ def resolve_dependencies(pkgs, channels=(), platform=None):
 
     # even with --dry-run, conda wants to create the prefix,
     # so we ensure it's somewhere out of the way.
-    prefix = tempfile.mkdtemp(prefix="anaconda_project_resolve_")
+    prefix = tempfile.mkdtemp(prefix="_anaconda_project_resolve_")
 
     # conda 4.1 (and possibly other versions) will complain
     # if the directory already exists. An evil attacker

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -663,6 +663,21 @@ def test_resolve_dependencies_for_bogus_package_with_actual_conda():
     assert 'Package not found' in exc_str or 'Package missing' in exc_str
 
 
+@pytest.mark.slow
+def test_resolve_dependencies_with_actual_conda_depending_on_conda():
+    try:
+        result = conda_api.resolve_dependencies(['conda=4.3.21'], platform=None)
+    except conda_api.CondaError as e:
+        pprint(e.json)
+        raise e
+
+    names = [pkg[0] for pkg in result]
+    assert 'conda' in names
+    names_and_versions = [(pkg[0], pkg[1]) for pkg in result]
+    assert ('conda', '4.3.21') in names_and_versions
+    assert len(result) > 1  # conda has some dependencies so should be >1
+
+
 def test_resolve_dependencies_ignores_rmtree_failure(monkeypatch):
     def mock_call_conda(extra_args, json_mode, platform, stdout_callback=None, stderr_callback=None):
         return json.dumps({'actions': [{'LINK': [{'base_url': None,


### PR DESCRIPTION
This allows conda to be resolved as a dependency, in case
there is an environment spec that depends on it. That environment
will still fail to install unless it *also* starts with an
underscore.