### PR TITLE
Command Plugins 

### DIFF
--- a/anaconda_project/internal/plugins.py
+++ b/anaconda_project/internal/plugins.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2017, Continuum Analytics, Inc. All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+
+try:
+    from entrypoints import get_group_named
+except ImportError:  # py 2.7
+    from pkg_resources import iter_entry_points
+
+    def get_group_named(group_name):
+        """Facade function to align old entry_points api to new one."""
+        return {plugin.name: plugin for plugin in iter_entry_points(group_name)}
+
+
+def _get_entry_points_plugins(entry_point_group):
+    """Return all the entry points plugins registered."""
+    return {name: plugin.load() for name, plugin in sorted(get_group_named(entry_point_group).items())}
+
+
+def get_plugins(plugin_hook_type):
+    """Return all the entry points plugins registered that implement that hook.
+
+    The function will return all the plugins that implement the specified
+    type of hook.
+
+    Args:
+
+        - plugin_hook_type(str): type of hook
+
+    Output:
+        (dict) with plugin name as key and plugin generator function as value
+    """
+    command_type = 'anaconda_project.plugins.%s' % plugin_hook_type
+    entry_point_plugins = _get_entry_points_plugins(entry_point_group=command_type)
+    return entry_point_plugins

--- a/anaconda_project/plugins.py
+++ b/anaconda_project/plugins.py
@@ -9,38 +9,6 @@ import os
 from os.path import join
 from anaconda_project.project_commands import (_ArgsTransformer, ProjectCommand, _http_specs)
 
-try:
-    from entrypoints import get_group_named
-except ImportError:  # py 2.7
-    from pkg_resources import iter_entry_points
-
-    def get_group_named(group_name):
-        """Facade function to align old entry_points api to new one."""
-        return {plugin.name: plugin for plugin in iter_entry_points(group_name)}
-
-
-def _get_entry_points_plugins(entry_point_group):
-    """Return all the entry points plugins registered."""
-    return {name: plugin.load() for name, plugin in sorted(get_group_named(entry_point_group).items())}
-
-
-def get_plugins(plugin_hook_type):
-    """Return all the entry points plugins registered that implement that hook.
-
-    The function will return all the plugins that implement the specified
-    type of hook.
-
-    Args:
-
-        - plugin_hook_type(str): type of hook
-
-    Output:
-        (dict) with plugin name as key and plugin generator function as value
-    """
-    command_type = 'anaconda_project.plugins.%s' % plugin_hook_type
-    entry_point_plugins = _get_entry_points_plugins(entry_point_group=command_type)
-    return entry_point_plugins
-
 
 class ArgsTrasformerTemplate(_ArgsTransformer):
     """Template class for plugins args trasformers.

--- a/anaconda_project/plugins.py
+++ b/anaconda_project/plugins.py
@@ -82,7 +82,14 @@ class ArgsTrasformerTemplate(_ArgsTransformer):
 class CommandTemplate(ProjectCommand):
     """Represents a command from the project file."""
 
+    # ArgsTransformer to be used to parse args before forwarding them
+    # to the actual command args and shell builder (choose_args_and_shell)
     args_transformer_cls = None
+
+    # Base command to be executed. This should be overwritten by the
+    # child class. I.e. command=`python` for a hypotetical python
+    # command
+    command = None
 
     def __init__(self, name, attributes):
         """Construct a command with the given attributes.

--- a/anaconda_project/plugins.py
+++ b/anaconda_project/plugins.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2016, Continuum Analytics, Inc. All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+"""Plugins base classes and functions."""
+import os
+from os.path import join
+from anaconda_project.project_commands import (_ArgsTransformer, ProjectCommand, _http_specs)
+
+from entrypoints import get_group_named
+
+
+def _get_entry_points_plugins(entry_points_group):
+    """Return all the entry points plugins registered."""
+    return {name: plugin.load() 
+        for name, plugin in sorted(get_group_named(entry_points_group).items())
+    }
+
+
+def get_plugins(entry_points_group='anaconda_project.plugins'):
+    """Return all the entry points plugins registered.
+    
+    Inputs:
+    
+        - entry_points_group(str): name of the entry point group to look for
+            plugins. Default: 'anaconda_project.plugins'
+            
+    Output:
+        (dict) with plugin name as key and plugin generator function as value
+    
+    """
+    entry_point_plugins = _get_entry_points_plugins(entry_points_group)
+    return entry_point_plugins
+
+
+class ArgsTrasformerTemplate(_ArgsTransformer):
+    """Template class for plugins args trasformers.
+    Plugins args transformers should subclass it and redefine add_class
+    to implement custom arguments mapping.
+    """
+    def __init__(self, command, specs=None):
+        """Construct an ArgTransformer for the given command.
+
+        Args:
+            command (ProjectCommand): command that maps to the ArgsTransformer
+        """
+        # TODO: document specs
+        # TODO: decide the best way to let users define specs for their
+        #       transformers! Most likely specs should go on the command
+        #       itself?
+        super(ArgsTrasformerTemplate, self).__init__(_http_specs)
+        self.command = command
+
+    def add_args(self, results, args):
+        """Overwrite this method to add custom arguments transformation.
+        It should forwarding the arguments that are custom to the
+        specific command served by this trasformer (
+            i.e., '--anaconda-project-host' --> 'host'
+        )
+
+        Inputs:
+            - results [list(tuples)]: list of 2 element tuples the following:
+                           * option (str): name of the option
+                            * values (lst(str)): list of the values passed
+                                        for the option
+            - args [list]: list of the args already passed in
+
+        Returns:
+            (list) list of the transformed args (that should include args)
+        """
+        raise RuntimeError("not implemented")  # pragma: no cover
+
+
+class CommandTemplate(ProjectCommand):
+    """Represents a command from the project file."""
+
+    args_transformer_cls = None
+
+    def __init__(self, name, attributes):
+        """Construct a command with the given attributes.
+
+        Args:
+            name (str): name of the command
+            attributes (dict): named attributes of the command
+        """
+        super(CommandTemplate, self).__init__(name=name, attributes=attributes)
+        self._args_transformer = self.args_transformer_cls(self)
+
+    @property
+    def command_with_conda_prefix(self):
+        """Full command path pointing to <conda prefix>/bin."""
+        return join(os.environ['CONDA_PREFIX'], 'bin', self.command)
+
+    def _choose_args_and_shell(self, environ, extra_args=None):
+        """Prepare extra args calling class _args_trasform.transform_args."""
+        extra_args = self._args_transformer.transform_args(extra_args)
+        return self.choose_args_and_shell(environ, extra_args=extra_args)
+
+    def choose_args_and_shell(self, environ, extra_args=None):
+        """Overwrite this method to implement custom plugin logic."""
+        raise NotImplementedError()

--- a/anaconda_project/plugins.py
+++ b/anaconda_project/plugins.py
@@ -11,7 +11,7 @@ from anaconda_project.project_commands import (_ArgsTransformer, ProjectCommand,
 
 try:
     from entrypoints import get_group_named
-except ImportError: # py 2.7
+except ImportError:  # py 2.7
     from pkg_resources import iter_entry_points as get_group_named
 
 
@@ -20,18 +20,21 @@ def _get_entry_points_plugins(entry_point_group):
     return {name: plugin.load() for name, plugin in sorted(get_group_named(entry_point_group).items())}
 
 
-def get_plugins(entry_point_group='anaconda_project.plugins'):
-    """Return all the entry points plugins registered.
+def get_plugins(plugin_hook_type):
+    """Return all the entry points plugins registered that implement that hook.
 
-    Inputs:
+    The function will return all the plugins that implement the specified
+    type of hook.
 
-        - entry_points_group(str): name of the entry point group to look for
-            plugins. Default: 'anaconda_project.plugins'
+    Args:
+
+        - plugin_hook_type(str): type of hook
 
     Output:
         (dict) with plugin name as key and plugin generator function as value
     """
-    entry_point_plugins = _get_entry_points_plugins(entry_point_group)
+    command_type = 'anaconda_project.plugins.%s' % plugin_hook_type
+    entry_point_plugins = _get_entry_points_plugins(entry_point_group=command_type)
     return entry_point_plugins
 
 

--- a/anaconda_project/plugins.py
+++ b/anaconda_project/plugins.py
@@ -12,7 +12,11 @@ from anaconda_project.project_commands import (_ArgsTransformer, ProjectCommand,
 try:
     from entrypoints import get_group_named
 except ImportError:  # py 2.7
-    from pkg_resources import iter_entry_points as get_group_named
+    from pkg_resources import iter_entry_points
+
+    def get_group_named(group_name):
+        """Facade function to align old entry_points api to new one."""
+        return {plugin.name: plugin for plugin in iter_entry_points(group_name)}
 
 
 def _get_entry_points_plugins(entry_point_group):

--- a/anaconda_project/plugins.py
+++ b/anaconda_project/plugins.py
@@ -49,16 +49,12 @@ class ArgsTrasformerTemplate(_ArgsTransformer):
     to implement custom arguments mapping.
     """
 
-    def __init__(self, command, specs=None):
+    def __init__(self, command):
         """Construct an ArgTransformer for the given command.
 
         Args:
             command (ProjectCommand): command that maps to the ArgsTransformer
         """
-        # TODO: document specs
-        # TODO: decide the best way to let users define specs for their
-        #       transformers! Most likely specs should go on the command
-        #       itself?
         super(ArgsTrasformerTemplate, self).__init__(_http_specs)
         self.command = command
 
@@ -71,7 +67,7 @@ class ArgsTrasformerTemplate(_ArgsTransformer):
         )
 
         Inputs:
-            - results [list(tuples)]: list of 2 element tuples the following:
+            - results [list(tuples)]: list of 2 element tuples (option, values):
                            * option (str): name of the option
                             * values (lst(str)): list of the values passed
                                         for the option

--- a/anaconda_project/plugins.py
+++ b/anaconda_project/plugins.py
@@ -9,7 +9,10 @@ import os
 from os.path import join
 from anaconda_project.project_commands import (_ArgsTransformer, ProjectCommand, _http_specs)
 
-from entrypoints import get_group_named
+try:
+    from entrypoints import get_group_named
+except ImportError: # py 2.7
+    from pkg_resources import iter_entry_points as get_group_named
 
 
 def _get_entry_points_plugins(entry_point_group):

--- a/anaconda_project/plugins.py
+++ b/anaconda_project/plugins.py
@@ -12,34 +12,33 @@ from anaconda_project.project_commands import (_ArgsTransformer, ProjectCommand,
 from entrypoints import get_group_named
 
 
-def _get_entry_points_plugins(entry_points_group):
+def _get_entry_points_plugins(entry_point_group):
     """Return all the entry points plugins registered."""
-    return {name: plugin.load() 
-        for name, plugin in sorted(get_group_named(entry_points_group).items())
-    }
+    return {name: plugin.load() for name, plugin in sorted(get_group_named(entry_point_group).items())}
 
 
-def get_plugins(entry_points_group='anaconda_project.plugins'):
+def get_plugins(entry_point_group='anaconda_project.plugins'):
     """Return all the entry points plugins registered.
-    
+
     Inputs:
-    
+
         - entry_points_group(str): name of the entry point group to look for
             plugins. Default: 'anaconda_project.plugins'
-            
+
     Output:
         (dict) with plugin name as key and plugin generator function as value
-    
     """
-    entry_point_plugins = _get_entry_points_plugins(entry_points_group)
+    entry_point_plugins = _get_entry_points_plugins(entry_point_group)
     return entry_point_plugins
 
 
 class ArgsTrasformerTemplate(_ArgsTransformer):
     """Template class for plugins args trasformers.
+
     Plugins args transformers should subclass it and redefine add_class
     to implement custom arguments mapping.
     """
+
     def __init__(self, command, specs=None):
         """Construct an ArgTransformer for the given command.
 
@@ -55,6 +54,7 @@ class ArgsTrasformerTemplate(_ArgsTransformer):
 
     def add_args(self, results, args):
         """Overwrite this method to add custom arguments transformation.
+
         It should forwarding the arguments that are custom to the
         specific command served by this trasformer (
             i.e., '--anaconda-project-host' --> 'host'

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -32,7 +32,7 @@ from anaconda_project.internal.slugify import slugify
 import anaconda_project.internal.notebook_analyzer as notebook_analyzer
 import anaconda_project.internal.conda_api as conda_api
 import anaconda_project.internal.pip_api as pip_api
-from anaconda_project import plugins as plugins_api
+from anaconda_project.internal import plugins as plugins_api
 
 # These strings are used in the command line options to anaconda-project,
 # so changing them has back-compat consequences.
@@ -853,7 +853,7 @@ class _ConfigCache(object):
         commands_section = project_file.get_value('commands', None)
 
         plugins = plugins_api.get_plugins('command_run')
-        all_known_command_attributes_extented = all_known_command_attributes + \
+        all_known_command_attributes_extended = all_known_command_attributes + \
             tuple(plugins.keys())
 
         if commands_section is not None and not is_dict(commands_section):
@@ -878,7 +878,7 @@ class _ConfigCache(object):
                     failed = True
                     continue
 
-                _unknown_field_suggestions(project_file, problems, attrs, all_known_command_attributes_extented)
+                _unknown_field_suggestions(project_file, problems, attrs, all_known_command_attributes_extended)
 
                 if 'description' in attrs and not is_string(attrs['description']):
                     _file_problem(problems, project_file,

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -852,7 +852,7 @@ class _ConfigCache(object):
         commands = dict()
         commands_section = project_file.get_value('commands', None)
 
-        plugins = plugins_api.get_all()
+        plugins = plugins_api.get_plugins()
         all_known_command_attributes_extented = all_known_command_attributes + \
             tuple(plugins.keys())
 

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -32,6 +32,7 @@ from anaconda_project.internal.slugify import slugify
 import anaconda_project.internal.notebook_analyzer as notebook_analyzer
 import anaconda_project.internal.conda_api as conda_api
 import anaconda_project.internal.pip_api as pip_api
+from anaconda_project import plugins as plugins_api
 
 # These strings are used in the command line options to anaconda-project,
 # so changing them has back-compat consequences.
@@ -850,6 +851,11 @@ class _ConfigCache(object):
         first_command_name = None
         commands = dict()
         commands_section = project_file.get_value('commands', None)
+
+        plugins = plugins_api.get_all()
+        all_known_command_attributes_extented = all_known_command_attributes + \
+            tuple(plugins.keys())
+
         if commands_section is not None and not is_dict(commands_section):
             _file_problem(problems, project_file,
                           "'commands:' section should be a dictionary from command names to attributes, not %r" %
@@ -872,7 +878,7 @@ class _ConfigCache(object):
                     failed = True
                     continue
 
-                _unknown_field_suggestions(project_file, problems, attrs, all_known_command_attributes)
+                _unknown_field_suggestions(project_file, problems, attrs, all_known_command_attributes_extented)
 
                 if 'description' in attrs and not is_string(attrs['description']):
                     _file_problem(problems, project_file,
@@ -907,9 +913,13 @@ class _ConfigCache(object):
                     copied_attrs['env_spec'] = self.default_env_spec_name
 
                 command_types = []
-                for attr in ALL_COMMAND_TYPES:
+                ProjectCommandClass = ProjectCommand
+                for attr in ALL_COMMAND_TYPES + tuple(plugins.keys()):
                     if attr not in copied_attrs:
                         continue
+                    else:
+                        if attr in plugins:
+                            ProjectCommandClass = plugins[attr]
 
                     # be sure we add this even if the command is broken, since it's
                     # confusing to say "does not have a command line in it" below
@@ -937,7 +947,7 @@ class _ConfigCache(object):
 
                 # note that once one command fails, we don't add any more
                 if not failed:
-                    commands[name] = ProjectCommand(name=name, attributes=copied_attrs)
+                    commands[name] = ProjectCommandClass(name=name, attributes=copied_attrs)
 
         self._verify_notebook_commands(commands, problems, requirements, project_file)
 

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -852,7 +852,7 @@ class _ConfigCache(object):
         commands = dict()
         commands_section = project_file.get_value('commands', None)
 
-        plugins = plugins_api.get_plugins()
+        plugins = plugins_api.get_plugins('command_run')
         all_known_command_attributes_extented = all_known_command_attributes + \
             tuple(plugins.keys())
 

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -408,6 +408,8 @@ class ProjectCommand(object):
             description = self._attributes.get('windows', None)
         if description is None:
             description = self._attributes.get('conda_app_entry', None)
+        if description is None:
+            description = getattr(self, 'command', None)
         # we should have validated that there was a command in here
         assert description is not None
         return description

--- a/anaconda_project/test/test_plugins.py
+++ b/anaconda_project/test/test_plugins.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Copyright © 2016, Continuum Analytics, Inc. All rights reserved.
+#
+# The full license is in the file LICENSE.txt, distributed with this software.
+# ----------------------------------------------------------------------------
+import os
+from os.path import join
+
+from anaconda_project.test.environ_utils import minimal_environ
+from anaconda_project.test.project_utils import project_no_dedicated_env
+from anaconda_project.prepare import (prepare_without_interaction)
+from anaconda_project.internal.test.tmpfile_utils import (with_directory_contents_completing_project_file)
+from anaconda_project.project_file import DEFAULT_PROJECT_FILENAME
+from anaconda_project import project
+
+from anaconda_project.plugins import CommandTemplate, ArgsTrasformerTemplate
+
+def test_prepare_plugin_command(monkeypatch, tmpdir):
+    called_with = {}
+    cmd_name = 'custom-cmd'
+
+    def get_plugins_mock():
+        return {'valid_package_plugin': plugin_init_mock}
+
+    class TestTransformer(ArgsTrasformerTemplate):
+        def add_args(self, results, args):
+            return ['--show']
+
+    class TestCmd(CommandTemplate):
+        args_transformer_cls = TestTransformer
+        command = cmd_name
+
+        def choose_args_and_shell(self, environ, extra_args=None):
+            assert extra_args is None or isinstance(extra_args, list)
+
+            shell = False
+            args = [self.command_with_conda_prefix, 'custom-sub-cmd', '--%s.TESTARG' % self.command]
+
+            return args + extra_args, shell
+
+    def plugin_init_mock(*args, **kws):
+        called_with['args'] = args
+        called_with['kws'] = kws
+        return TestCmd(*args, **kws)
+
+    def check(dirname):
+        # monkeypatch.setattr(project.plugins_api, 'get_all', get_plugins_mock)
+        project.plugins_api.get_all = get_plugins_mock
+        _project = project_no_dedicated_env(dirname)
+        environ = minimal_environ()
+        result = prepare_without_interaction(_project, environ=environ, command_name='foo')
+
+        cmd_path = join(os.environ['CONDA_PREFIX'], 'bin', cmd_name)
+        expected = [cmd_path, 'custom-sub-cmd', '--%s.TESTARG' % cmd_name, '--show']
+        assert result.errors == []
+        assert result
+        assert result.command_exec_info.args == expected
+
+    with_directory_contents_completing_project_file(
+        {DEFAULT_PROJECT_FILENAME: """
+commands:
+    foo:
+       valid_package_plugin: foo.py
+packages:
+  - notebook
+""",
+         "foo.py": "# foo", }, check)

--- a/anaconda_project/test/test_plugins.py
+++ b/anaconda_project/test/test_plugins.py
@@ -16,6 +16,7 @@ from anaconda_project import project
 
 from anaconda_project.plugins import CommandTemplate, ArgsTrasformerTemplate
 
+
 def test_prepare_plugin_command(monkeypatch, tmpdir):
     called_with = {}
     cmd_name = 'custom-cmd'
@@ -45,8 +46,11 @@ def test_prepare_plugin_command(monkeypatch, tmpdir):
         return TestCmd(*args, **kws)
 
     def check(dirname):
-        # monkeypatch.setattr(project.plugins_api, 'get_all', get_plugins_mock)
-        project.plugins_api.get_all = get_plugins_mock
+        # do not use monkeypatch
+        # since with_directory_contents_completing_project_file
+        # monkeypatches zipfile as, that is use by entry_points
+        project.plugins_api.get_plugins = get_plugins_mock
+
         _project = project_no_dedicated_env(dirname)
         environ = minimal_environ()
         result = prepare_without_interaction(_project, environ=environ, command_name='foo')

--- a/anaconda_project/test/test_plugins.py
+++ b/anaconda_project/test/test_plugins.py
@@ -20,6 +20,7 @@ from anaconda_project.plugins import CommandTemplate, ArgsTrasformerTemplate
 def test_prepare_plugin_command(monkeypatch, tmpdir):
     called_with = {}
     cmd_name = 'custom-cmd'
+    assert hasattr(project.plugins_api, 'get_plugins')
 
     def get_plugins_mock(cmd_type):
         return {'valid_package_plugin': plugin_init_mock}

--- a/anaconda_project/test/test_plugins.py
+++ b/anaconda_project/test/test_plugins.py
@@ -21,7 +21,7 @@ def test_prepare_plugin_command(monkeypatch, tmpdir):
     called_with = {}
     cmd_name = 'custom-cmd'
 
-    def get_plugins_mock():
+    def get_plugins_mock(cmd_type):
         return {'valid_package_plugin': plugin_init_mock}
 
     class TestTransformer(ArgsTrasformerTemplate):

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -31,7 +31,7 @@ from anaconda_project.internal.test.test_conda_api import monkeypatch_conda_not_
 from anaconda_project.test.fake_server import fake_server
 import anaconda_project.internal.keyring as keyring
 import anaconda_project.internal.conda_api as conda_api
-import anaconda_project.plugins as plugins_api
+import anaconda_project.internal.plugins as plugins_api
 
 
 def test_create(monkeypatch):

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -31,6 +31,7 @@ from anaconda_project.internal.test.test_conda_api import monkeypatch_conda_not_
 from anaconda_project.test.fake_server import fake_server
 import anaconda_project.internal.keyring as keyring
 import anaconda_project.internal.conda_api as conda_api
+import anaconda_project.plugins as plugins_api
 
 
 def test_create(monkeypatch):
@@ -3692,6 +3693,10 @@ def test_archive_cannot_write_destination_path(monkeypatch):
             raise IOError("NOPE")
 
         monkeypatch.setattr('zipfile.ZipFile', mock_ZipFile)
+
+        # need to mock plugins since entry_points uses zipfile.ZipFile that
+        # we are mocking for this test
+        monkeypatch.setattr(plugins_api, 'get_plugins', lambda x='fake': {})
 
         def check(dirname):
             # be sure we ignore this


### PR DESCRIPTION
This partially implements #89  (at lease for packaged command plugins).

This is a second pass on #94, trimming everything related to "drop in" plugins and just keeping a clean PR for plugins registered using entry_points.