### PR TITLE
PR: Update/test conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,13 +66,13 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       OS_PACKAGES=libffi ;
     fi ;
-    conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" pip redis notebook bokeh ruamel_yaml anaconda-client requests psutil $OS_PACKAGES
+    conda create -q -n test-environment python="$TRAVIS_PYTHON_VERSION" coverage tornado keyring pytest pytest-cov pip redis notebook bokeh ruamel_yaml anaconda-client requests psutil $OS_PACKAGES
   - source activate test-environment
   - printenv | sort
   - unset CONDA_ENV_PATH # because the older conda in miniconda sets this, confusing some tests
   - export PATH=`echo "$PATH" | sed -e s@"$HOME"/miniconda/bin:@@g`
   - printenv | sort
-  - pip install coverage flake8==2.6.2 pep257 pytest pytest-cov yapf==0.6.2 tornado pytest-xdist keyring
+  - pip install flake8==2.6.2 pep257 yapf==0.6.2 ruamel.yaml
 
 script:
   - if test "$TEST_TARGET" = tests; then LANG=en_US.UTF-8 python setup.py test -a '-vv'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,10 @@ install:
   - unset CONDA_ENV_PATH # because the older conda in miniconda sets this, confusing some tests
   - export PATH=`echo "$PATH" | sed -e s@"$HOME"/miniconda/bin:@@g`
   - printenv | sort
-  - pip install flake8==2.6.2 pep257 yapf==0.6.2 ruamel.yaml
+  - pip install flake8==2.6.2 pep257 yapf==0.6.2
+  - if [[ "$TRAVIS_PYTHON_VERSION" != "2.7" ]]; then
+      pip install ruamel.yaml;
+    fi ;
 
 script:
   - if test "$TEST_TARGET" = tests; then LANG=en_US.UTF-8 python setup.py test -a '-vv'; fi

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -660,7 +660,8 @@ def test_resolve_dependencies_for_bogus_package_with_actual_conda():
     if hasattr(excinfo.value, 'json'):
         pprint(excinfo.value.json)
     exc_str = str(excinfo.value)
-    assert 'Package not found' in exc_str or 'Package missing' in exc_str
+    valid_strings = ('Package not found', 'Package missing', 'Packages missing')
+    assert any(s in exc_str for s in valid_strings)
 
 
 @pytest.mark.slow

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -107,9 +107,10 @@ def test_conda_create_no_packages():
 def _assert_packages_not_found(e):
     # conda has changed this message several times
     ok = False
-    for message in ('No packages found', 'Package missing in current', 'Package not found'):
-        if message in str(e):
-            ok = True
+    valid_strings = ('No packages found', 'Package missing in current', 'Package missing in current',
+                     'PackageNotFoundError:', 'Package not found')
+
+    ok = any(s in str(e) for s in valid_strings)
     if not ok:
         # pytest truncates the exception message sometimes?
         print("Not the exception we wanted: %r" % e)

--- a/anaconda_project/internal/test/test_default_conda_manager.py
+++ b/anaconda_project/internal/test/test_default_conda_manager.py
@@ -38,7 +38,6 @@ else:
     FLAKE8_BINARY = "bin/flake8"
     # Use a different package from the test env due to weird CI path/env errors
     PYINSTRUMENT_BINARY = "bin/pyinstrument"
-    
 
 test_spec = EnvSpec(name='myenv', conda_packages=['ipython'], pip_packages=['pyinstrument'], channels=[])
 

--- a/anaconda_project/internal/test/test_default_conda_manager.py
+++ b/anaconda_project/internal/test/test_default_conda_manager.py
@@ -30,12 +30,17 @@ if platform.system() == 'Windows':
     PYTHON_BINARY = "python.exe"
     IPYTHON_BINARY = "Scripts\ipython.exe"
     FLAKE8_BINARY = "Scripts\\flake8.exe"
+    # Use a different package from the test env due to weird CI path/env errors
+    PYINSTRUMENT_BINARY = "Scripts\\pyinstrument.exe"
 else:
     PYTHON_BINARY = "bin/python"
     IPYTHON_BINARY = "bin/ipython"
     FLAKE8_BINARY = "bin/flake8"
+    # Use a different package from the test env due to weird CI path/env errors
+    PYINSTRUMENT_BINARY = "bin/pyinstrument"
+    
 
-test_spec = EnvSpec(name='myenv', conda_packages=['ipython'], pip_packages=['flake8'], channels=[])
+test_spec = EnvSpec(name='myenv', conda_packages=['ipython'], pip_packages=['pyinstrument'], channels=[])
 
 
 def test_current_platform_unsupported_by_env_spec(monkeypatch):
@@ -97,38 +102,38 @@ def test_conda_create_and_install_and_remove(monkeypatch):
 
     spec = test_spec
     assert spec.conda_packages == ('ipython', )
-    assert spec.pip_packages == ('flake8', )
+    assert spec.pip_packages == ('pyinstrument', )
 
     spec_with_phony_pip_package = EnvSpec(name='myenv',
                                           conda_packages=['ipython'],
-                                          pip_packages=['flake8', 'nope_not_a_thing'],
+                                          pip_packages=['pyinstrument', 'nope_not_a_thing'],
                                           channels=[])
     assert spec_with_phony_pip_package.conda_packages == ('ipython', )
-    assert spec_with_phony_pip_package.pip_packages == ('flake8', 'nope_not_a_thing')
-    assert spec_with_phony_pip_package.pip_package_names_set == set(('flake8', 'nope_not_a_thing'))
+    assert spec_with_phony_pip_package.pip_packages == ('pyinstrument', 'nope_not_a_thing')
+    assert spec_with_phony_pip_package.pip_package_names_set == set(('pyinstrument', 'nope_not_a_thing'))
 
     # package url is supposed to be on a nonexistent port, if it
     # causes a problem we need to mock
     spec_with_bad_url_pip_package = EnvSpec(name='myenv',
                                             conda_packages=['ipython'],
-                                            pip_packages=['flake8', 'https://127.0.0.1:24729/nope#egg=phony'],
+                                            pip_packages=['pyinstrument', 'https://127.0.0.1:24729/nope#egg=phony'],
                                             channels=[])
     assert spec_with_bad_url_pip_package.conda_packages == ('ipython', )
-    assert spec_with_bad_url_pip_package.pip_packages == ('flake8', 'https://127.0.0.1:24729/nope#egg=phony')
-    assert spec_with_bad_url_pip_package.pip_package_names_set == set(('flake8', 'phony'))
+    assert spec_with_bad_url_pip_package.pip_packages == ('pyinstrument', 'https://127.0.0.1:24729/nope#egg=phony')
+    assert spec_with_bad_url_pip_package.pip_package_names_set == set(('pyinstrument', 'phony'))
 
     spec_with_old_ipython = EnvSpec(name='myenv',
                                     conda_packages=['ipython=5.2.2'],
-                                    pip_packages=['flake8'],
+                                    pip_packages=['pyinstrument'],
                                     channels=[])
     assert spec_with_old_ipython.conda_packages == ('ipython=5.2.2', )
 
-    spec_with_bokeh = EnvSpec(name='myenv', conda_packages=['bokeh'], pip_packages=['flake8'], channels=[])
+    spec_with_bokeh = EnvSpec(name='myenv', conda_packages=['bokeh'], pip_packages=['pyinstrument'], channels=[])
     assert spec_with_bokeh.conda_packages == ('bokeh', )
 
     spec_with_bokeh_and_old_ipython = EnvSpec(name='myenv',
                                               conda_packages=['bokeh', 'ipython=5.2.2'],
-                                              pip_packages=['flake8'],
+                                              pip_packages=['pyinstrument'],
                                               channels=[])
     assert spec_with_bokeh_and_old_ipython.conda_packages == ('bokeh', 'ipython=5.2.2', )
 
@@ -145,7 +150,7 @@ def test_conda_create_and_install_and_remove(monkeypatch):
         deviations = manager.find_environment_deviations(envdir, spec)
 
         assert deviations.missing_packages == ('ipython', )
-        assert deviations.missing_pip_packages == ('flake8', )
+        assert deviations.missing_pip_packages == ('pyinstrument', )
 
         # with create=False, we won't create the env
         with pytest.raises(CondaManagerError) as excinfo:
@@ -160,7 +165,7 @@ def test_conda_create_and_install_and_remove(monkeypatch):
         assert os.path.isdir(envdir)
         assert os.path.isdir(os.path.join(envdir, "conda-meta"))
         assert os.path.exists(os.path.join(envdir, IPYTHON_BINARY))
-        assert os.path.exists(os.path.join(envdir, FLAKE8_BINARY))
+        assert os.path.exists(os.path.join(envdir, PYINSTRUMENT_BINARY))
 
         assert manager._timestamp_file_up_to_date(envdir, spec)
         assert not manager._timestamp_file_up_to_date(envdir, spec_with_phony_pip_package)
@@ -291,13 +296,13 @@ def test_timestamp_file_works(monkeypatch):
 
         assert not os.path.isdir(envdir)
         assert not os.path.exists(os.path.join(envdir, IPYTHON_BINARY))
-        assert not os.path.exists(os.path.join(envdir, FLAKE8_BINARY))
+        assert not os.path.exists(os.path.join(envdir, PYINSTRUMENT_BINARY))
         assert not manager._timestamp_file_up_to_date(envdir, spec)
 
         deviations = manager.find_environment_deviations(envdir, spec)
 
         assert deviations.missing_packages == ('ipython', )
-        assert deviations.missing_pip_packages == ('flake8', )
+        assert deviations.missing_pip_packages == ('pyinstrument', )
         assert not deviations.ok
 
         manager.fix_environment_deviations(envdir, spec, deviations)
@@ -307,7 +312,7 @@ def test_timestamp_file_works(monkeypatch):
         assert os.path.isdir(envdir)
         assert os.path.isdir(os.path.join(envdir, "conda-meta"))
         assert os.path.exists(os.path.join(envdir, IPYTHON_BINARY))
-        assert os.path.exists(os.path.join(envdir, FLAKE8_BINARY))
+        assert os.path.exists(os.path.join(envdir, PYINSTRUMENT_BINARY))
 
         assert manager._timestamp_file_up_to_date(envdir, spec)
 

--- a/anaconda_project/internal/test/test_default_conda_manager.py
+++ b/anaconda_project/internal/test/test_default_conda_manager.py
@@ -247,8 +247,9 @@ def test_conda_create_and_install_and_remove(monkeypatch):
             manager.remove_packages(prefix=envdir, packages=['ipython'])
         # different versions of conda word this differently
         message = str(excinfo.value)
-        assert ('no packages found to remove' in message or 'Package not found' in message or
-                "named 'ipython' found to remove" in message)
+        valid_strings = ('no packages found to remove', 'Package not found', "named 'ipython' found to remove",
+                         "is missing from the environment")
+        assert any(s in message for s in valid_strings)
         assert not manager._timestamp_file_up_to_date(envdir, spec)
 
         # test failure to exec pip

--- a/anaconda_project/internal/test/test_pip_api.py
+++ b/anaconda_project/internal/test/test_pip_api.py
@@ -18,8 +18,12 @@ from anaconda_project.internal.test.test_conda_api import monkeypatch_conda_not_
 
 if platform.system() == 'Windows':
     FLAKE8_BINARY = "Scripts\\flake8.exe"
+    # Use a different package from the test env due to weird CI path/env errors
+    PYINSTRUMENT_BINARY = "Scripts\\pyinstrument.exe"
 else:
     FLAKE8_BINARY = "bin/flake8"
+    # Use a different package from the test env due to weird CI path/env errors
+    PYINSTRUMENT_BINARY = "bin/pyinstrument"
 
 
 # lots is in this one big test so we don't have to create
@@ -38,23 +42,23 @@ def test_conda_create_and_install_and_remove_pip_stuff(monkeypatch):
         assert os.path.isdir(os.path.join(envdir, "conda-meta"))
 
         # test that we can install a package via pip
-        assert not os.path.exists(os.path.join(envdir, FLAKE8_BINARY))
-        pip_api.install(prefix=envdir, pkgs=['flake8'])
-        assert os.path.exists(os.path.join(envdir, FLAKE8_BINARY))
+        assert not os.path.exists(os.path.join(envdir, PYINSTRUMENT_BINARY))
+        pip_api.install(prefix=envdir, pkgs=['pyinstrument'])
+        assert os.path.exists(os.path.join(envdir, PYINSTRUMENT_BINARY))
 
         # list what was installed
         installed = pip_api.installed(prefix=envdir)
-        assert 'flake8' in installed
-        assert installed['flake8'][0] == 'flake8'
-        assert installed['flake8'][1] is not None
+        assert 'pyinstrument' in installed
+        assert installed['pyinstrument'][0] == 'pyinstrument'
+        assert installed['pyinstrument'][1] is not None
 
         # test that we can remove it again
-        pip_api.remove(prefix=envdir, pkgs=['flake8'])
-        assert not os.path.exists(os.path.join(envdir, FLAKE8_BINARY))
+        pip_api.remove(prefix=envdir, pkgs=['pyinstrument'])
+        assert not os.path.exists(os.path.join(envdir, PYINSTRUMENT_BINARY))
 
         # no longer in the installed list
         installed = pip_api.installed(prefix=envdir)
-        assert 'flake8' not in installed
+        assert 'pyinstrument' not in installed
 
     with_directory_contents(dict(), do_test)
 
@@ -126,7 +130,7 @@ sys.exit(0)
         pip_api.install(prefix=envdir, pkgs=['flake8'])
 
         # cannot exec pip
-        def mock_popen(args, stdout=None, stderr=None):
+        def mock_popen(args, stdout=None, stderr=None, env=None):
             raise OSError("failed to exec")
 
         monkeypatch.setattr('subprocess.Popen', mock_popen)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - "%CONDA_ROOT%\\Scripts\\activate root"
   - echo CONDA_PREFIX %CONDA_PREFIX%
   - conda info -a
-  - conda create -q -n test-environment python=%PYTHON_VERSION% pip notebook bokeh ruamel_yaml anaconda-client requests tornado coverage pytest pytest-cov
+  - conda create -q -n test-environment python=%PYTHON_VERSION% keyring pip notebook bokeh ruamel_yaml anaconda-client requests tornado coverage pytest pytest-cov
 
 # Not a .NET project, we build in the install step instead
 build: false
@@ -43,7 +43,7 @@ test_script:
   - "%CONDA_ROOT%\\Scripts\\activate test-environment"
   - echo CONDA_PREFIX %CONDA_PREFIX%
   - echo PATH %PATH%
-  - pip install pep257 yapf==0.6.2 pytest-xdist flake8==2.6.2 keyring
+  - pip install pep257 yapf==0.6.2 flake8==2.6.2 ruamel.yaml
   - conda list
   - conda info -a
   - python -c "import sys; print(sys.version)"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,9 @@ test_script:
   - "%CONDA_ROOT%\\Scripts\\activate test-environment"
   - echo CONDA_PREFIX %CONDA_PREFIX%
   - echo PATH %PATH%
-  - pip install pep257 yapf==0.6.2 flake8==2.6.2 ruamel.yaml
+  - pip install pep257 yapf==0.6.2 flake8==2.6.2
+  - if "%PYTHON_VERSION%" == "3.5" pip install ruamel.yaml
+  - if "%PYTHON_VERSION%" == "3.6" pip install ruamel.yaml
   - conda list
   - conda info -a
   - python -c "import sys; print(sys.version)"

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,10 @@ assert VERSION != ''
 PY2 = sys.version_info[0] == 2
 
 REQUIRES = ['tornado >= 4.2']
+REQUIRES = []  # Remove this deps for testing and debugging CI
 
 TEST_REQUIRES = ['coverage', 'flake8 == 2.6.2', 'keyring >= 9.0', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2']
+TEST_REQUIRES = []  # Remove this deps for testing and debugging CI
 
 # clean up leftover trash as best we can
 BUILD_TMP = os.path.join(ROOT, 'build', 'tmp')

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,7 @@ PY2 = sys.version_info[0] == 2
 
 REQUIRES = ['tornado >= 4.2']
 
-TEST_REQUIRES = ['coverage', 'flake8 == 2.6.2', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2', 'pytest-xdist',
-                 'keyring >= 9.0']
+TEST_REQUIRES = ['coverage', 'flake8 == 2.6.2', 'keyring >= 9.0', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2']
 
 # clean up leftover trash as best we can
 BUILD_TMP = os.path.join(ROOT, 'build', 'tmp')

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,7 @@ PY2 = sys.version_info[0] == 2
 
 REQUIRES = ['tornado >= 4.2']
 
-TEST_REQUIRES = ['coverage', 'flake8 == 2.6.2', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2', 'pytest-xdist',
-                 'keyring >= 9.0']
+TEST_REQUIRES = []
 
 # clean up leftover trash as best we can
 BUILD_TMP = os.path.join(ROOT, 'build', 'tmp')

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ PY2 = sys.version_info[0] == 2
 
 REQUIRES = ['tornado >= 4.2']
 
-TEST_REQUIRES = []
+TEST_REQUIRES = ['coverage', 'flake8 == 2.6.2', 'pep257', 'pytest', 'pytest-cov', 'yapf == 0.6.2', 'pytest-xdist',
+                 'keyring >= 9.0']
 
 # clean up leftover trash as best we can
 BUILD_TMP = os.path.join(ROOT, 'build', 'tmp')


### PR DESCRIPTION
Ok @fpliger after several different attempts, I these changes fix all the failing tests and update a bit the CI configuration to move into a direction where we can update to the latest conda more easily.

Many tests are currently failing with conda-canary, and about 3 or 4 fail with latest conda. The next PR will aim to use latest conda and fix failing tests. After that, we should fix all failing things with conda-canary (see #126) .

Any comments @fpliger or is this good to merge? (*only the OSX container on travis has not finished due to the travis queue backlog...* we could disable that container to make our dev process a bit more streamlined, and only run when on master, which means when the PR is merged)  

----

<img width="1137" alt="screen shot 2017-09-27 at 16 02 43" src="https://user-images.githubusercontent.com/3627835/30935005-534d4b3a-a39d-11e7-83d1-6934513667b8.png">
<img width="912" alt="screen shot 2017-09-27 at 16 02 37" src="https://user-images.githubusercontent.com/3627835/30935004-534a9cf0-a39d-11e7-876a-d47fa343f94f.png">

:-)