### PR TITLE
Ignore all ipynb_checkpoints directories

### DIFF
--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -44,7 +44,7 @@ __pycache__/
 *.pyd
 
 # Notebook stuff
-/.ipynb_checkpoints
+.ipynb_checkpoints/
 
 # Spyder stuff
 /.spyderproject

--- a/anaconda_project/test/test_bundler.py
+++ b/anaconda_project/test/test_bundler.py
@@ -98,7 +98,7 @@ def test_parse_default_ignore_file():
         pattern_strings = [pattern.pattern for pattern in patterns]
 
         assert pattern_strings == [
-            '/anaconda-project-local.yml', '__pycache__/', '*.pyc', '*.pyo', '*.pyd', '/.ipynb_checkpoints',
+            '/anaconda-project-local.yml', '__pycache__/', '*.pyc', '*.pyo', '*.pyd', '.ipynb_checkpoints/',
             '/.spyderproject'
         ]
 

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -4309,7 +4309,7 @@ name: archivedproj
         """,
             "foo.py": "print('hello')\n",
             "foo.pyc": "",
-            ".ipynb_checkpoints": "",
+            ".ipynb_checkpoints/bleh": "",
             "bar/blah.pyc": ""
         }, check)
 


### PR DESCRIPTION
During an attempt to create a project from an AENv4 project I noticed that it scanned `.ipynb_checkpoints` directories that were not in the project root. It seems safe to avoid doing this.