### PR TITLE
Wait for and sys.exit with subprocess return on windows

### DIFF
--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -268,9 +268,9 @@ class CommandExecInfo(object):
                 # jumps through some funky hoops setting flags on
                 # the Windows API calls. We need to do that, rather
                 # than calling os.execvpe which doesn't let us set those
-                # flags. So we spawn the child and then exit.
-                self.popen()
-                sys.exit(0)
+                # flags. So we spawn the child and then exit with its
+                # return code.
+                sys.exit(self.popen().wait())
             else:
                 # this is all shell=True does on unix
                 args = ['/bin/sh', '-c'] + args


### PR DESCRIPTION
Not sure how this made it through this long, but the current behavior is a pretty awful experience: random interleaved outputs (#154), broken usage when scripted, and failures not being caught.

Can work up a proper test if necessary... basically a project file like:
```yaml
commands:
  a:
    windows: timeout 1 && echo a
  b:
    windows: echo b
```
then
```bat
anaconda-project run a
anaconda-project run b
```
would yield
```
b # immediately
a # after a second
```

and should yield

```
a # after a second
b # immediately
```