### PR TITLE
Honor supports_http_options: false by dropping them when found

### DIFF
--- a/anaconda_project/plugins.py
+++ b/anaconda_project/plugins.py
@@ -8,10 +8,10 @@
 """Plugins base classes and functions."""
 import os
 from os.path import join
-from anaconda_project.project_commands import (_ArgsTransformer, ProjectCommand, _http_specs)
+from anaconda_project.project_commands import (_ArgsTransformer, ProjectCommand)
 
 
-class ArgsTrasformerTemplate(_ArgsTransformer):
+class ArgsTransformerTemplate(_ArgsTransformer):
     """Template class for plugins args trasformers.
 
     Plugins args transformers should subclass it and redefine add_class
@@ -24,7 +24,6 @@ class ArgsTrasformerTemplate(_ArgsTransformer):
         Args:
             command (ProjectCommand): command that maps to the ArgsTransformer
         """
-        super(ArgsTrasformerTemplate, self).__init__(_http_specs)
         self.command = command
 
     def add_args(self, results, args):

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -95,7 +95,8 @@ class _ArgsTransformer(object):
         return self.add_args(results_list, with_removed)
 
     def add_args(self, results, args):
-        raise RuntimeError("not implemented")  # pragma: no cover
+        # default implementation: drop all http-related args
+        return args
 
 
 class _BokehArgsTransformer(_ArgsTransformer):
@@ -123,7 +124,7 @@ class _BokehArgsTransformer(_ArgsTransformer):
                 # bokeh doesn't have a way to set this
                 pass
             else:
-                raise RuntimeError("unhandled http option for notebook")  # pragma: no cover
+                raise RuntimeError("unhandled http option for bokeh app")  # pragma: no cover
 
         return added + args
 
@@ -445,6 +446,9 @@ class ProjectCommand(object):
 
         if self.args is not None:
             args = self.args
+            if not self.supports_http_options:
+                # drop the http arguments
+                extra_args = _ArgsTransformer().transform_args(extra_args)
 
         if args is not None:
             if extra_args is not None:

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -43,14 +43,14 @@ def _is_windows():
 
 _ArgSpec = namedtuple('_ArgSpec', ['option', 'has_value'])
 
-_http_specs = (_ArgSpec('--anaconda-project-host', True), _ArgSpec('--anaconda-project-address', True),
-               _ArgSpec('--anaconda-project-port', True), _ArgSpec('--anaconda-project-url-prefix', True),
-               _ArgSpec('--anaconda-project-no-browser', False), _ArgSpec('--anaconda-project-iframe-hosts', True),
-               _ArgSpec('--anaconda-project-use-xheaders', False))
+HTTP_SPECS = (_ArgSpec('--anaconda-project-host', True), _ArgSpec('--anaconda-project-address', True),
+              _ArgSpec('--anaconda-project-port', True), _ArgSpec('--anaconda-project-url-prefix', True),
+              _ArgSpec('--anaconda-project-no-browser', False), _ArgSpec('--anaconda-project-iframe-hosts', True),
+              _ArgSpec('--anaconda-project-use-xheaders', False))
 
 
 class _ArgsTransformer(object):
-    specs = _http_specs
+    specs = HTTP_SPECS
 
     def _parse_args_removing_known(self, results, args):
         if not args:
@@ -281,7 +281,7 @@ class CommandExecInfo(object):
 
 
 def _append_extra_args_to_command_line(command, extra_args):
-    if extra_args is None:
+    if not extra_args:
         return command
     else:
         if _is_windows():  # pragma: no cover

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -50,8 +50,7 @@ _http_specs = (_ArgSpec('--anaconda-project-host', True), _ArgSpec('--anaconda-p
 
 
 class _ArgsTransformer(object):
-    def __init__(self, specs):
-        self.specs = specs
+    specs = _http_specs
 
     def _parse_args_removing_known(self, results, args):
         if not args:
@@ -100,9 +99,6 @@ class _ArgsTransformer(object):
 
 
 class _BokehArgsTransformer(_ArgsTransformer):
-    def __init__(self):
-        super(_BokehArgsTransformer, self).__init__(_http_specs)
-
     def add_args(self, results, args):
         added = []
         for (option, values) in results:
@@ -131,7 +127,6 @@ class _BokehArgsTransformer(_ArgsTransformer):
 
 class _NotebookArgsTransformer(_ArgsTransformer):
     def __init__(self, command):
-        super(_NotebookArgsTransformer, self).__init__(_http_specs)
         self.command = command
 
     def add_args(self, results, args):
@@ -432,6 +427,10 @@ class ProjectCommand(object):
         args = None
         shell = False
 
+        if not self.supports_http_options:
+            # drop the http arguments
+            extra_args = _ArgsTransformer().transform_args(extra_args)
+
         if self.notebook is not None:
             path = os.path.join(environ['PROJECT_DIR'], self.notebook)
             args = ['jupyter-notebook', path]
@@ -446,9 +445,6 @@ class ProjectCommand(object):
 
         if self.args is not None:
             args = self.args
-            if not self.supports_http_options:
-                # drop the http arguments
-                extra_args = _ArgsTransformer().transform_args(extra_args)
 
         if args is not None:
             if extra_args is not None:

--- a/anaconda_project/test/test_plugins.py
+++ b/anaconda_project/test/test_plugins.py
@@ -15,7 +15,7 @@ from anaconda_project.internal.test.tmpfile_utils import (with_directory_content
 from anaconda_project.project_file import DEFAULT_PROJECT_FILENAME
 from anaconda_project import project
 
-from anaconda_project.plugins import CommandTemplate, ArgsTrasformerTemplate
+from anaconda_project.plugins import CommandTemplate, ArgsTransformerTemplate
 
 
 def test_prepare_plugin_command(monkeypatch, tmpdir):
@@ -26,7 +26,7 @@ def test_prepare_plugin_command(monkeypatch, tmpdir):
     def get_plugins_mock(cmd_type):
         return {'valid_package_plugin': plugin_init_mock}
 
-    class TestTransformer(ArgsTrasformerTemplate):
+    class TestTransformer(ArgsTransformerTemplate):
         def add_args(self, results, args):
             return ['--show']
 

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1497,9 +1497,7 @@ def test_notebook_command_disabled_project_http_args():
         jupyter_notebook = _assert_find_executable('jupyter-notebook', path)
         assert cmd_exec.args == [
             jupyter_notebook,
-            os.path.join(dirname, 'test.ipynb'), 'foo', 'bar', '--anaconda-project-url-prefix', 'blah',
-            '--anaconda-project-port', '1234', '--anaconda-project-host', 'example.com',
-            '--anaconda-project-no-browser', '--anaconda-project-use-xheaders', '--anaconda-project-address', '1.2.3.4'
+            os.path.join(dirname, 'test.ipynb'), 'foo', 'bar'
         ]
         assert cmd_exec.shell is False
 

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1495,10 +1495,7 @@ def test_notebook_command_disabled_project_http_args():
             ])
         path = os.pathsep.join([environ['PROJECT_DIR'], environ['PATH']])
         jupyter_notebook = _assert_find_executable('jupyter-notebook', path)
-        assert cmd_exec.args == [
-            jupyter_notebook,
-            os.path.join(dirname, 'test.ipynb'), 'foo', 'bar'
-        ]
+        assert cmd_exec.args == [jupyter_notebook, os.path.join(dirname, 'test.ipynb'), 'foo', 'bar']
         assert cmd_exec.shell is False
 
     with_directory_contents_completing_project_file({
@@ -2013,12 +2010,7 @@ def test_bokeh_command_with_disabled_project_http_args():
             ])
         path = os.pathsep.join([environ['PROJECT_DIR'], environ['PATH']])
         bokeh = _assert_find_executable('bokeh', path)
-        assert cmd_exec.args == [
-            bokeh, 'serve',
-            os.path.join(dirname, 'test.py'), '--foo', '--anaconda-project-url-prefix', 'blah',
-            '--anaconda-project-port', '1234', '--anaconda-project-host', 'example.com',
-            '--anaconda-project-no-browser', '--anaconda-project-use-xheaders'
-        ]
+        assert cmd_exec.args == [bokeh, 'serve', os.path.join(dirname, 'test.py'), '--foo']
         assert cmd_exec.shell is False
 
     with_directory_contents_completing_project_file(


### PR DESCRIPTION
As currently implemented, the `supports_http_options` flag has no useful impact.

For notebooks and bokeh apps, `supports_http_options` defaults to `true`, which allows the code to translate these options to a form that these types of applications can understand. Overriding this default, and setting `supports_http_options` to `false`, would break both of these apps. It would be better therefore if this option is not available for these cases.

On the other hand, for scripts (e.g., `windows` and `unix`), the flag has no effect whatsoever. If the HTTP options are passed to an `anaconda-project run` command, they are passed through unchanged, no matter what the value of this setting is.

This simple PR solves the second case, but not the first. It causes `anaconda-project` to properly respect an `supports_http_options: false` setting for scripts, by stripping those options out before constructing the full shell command.. 