### PR TITLE
avoid crash in prepare/update if env_specs is missing

### DIFF
--- a/anaconda_project/internal/cli/test/test_project_load.py
+++ b/anaconda_project/internal/cli/test/test_project_load.py
@@ -52,7 +52,7 @@ def test_interactively_fix_project(monkeypatch, capsys):
         assert project.problems == []
 
         out, err = capsys.readouterr()
-        assert out == ("%s: The env_specs section is empty.\nAdd an environment spec to anaconda-project.yml? " %
+        assert out == ("%s: The env_specs section is missing.\nAdd an environment spec to anaconda-project.yml? " %
                        DEFAULT_PROJECT_FILENAME)
         assert err == ""
 
@@ -73,10 +73,10 @@ def test_interactively_no_fix_project(monkeypatch, capsys):
         _monkeypatch_input(monkeypatch, ["n"])
 
         project = load_project(dirname)
-        assert project.problems == ["%s: The env_specs section is empty." % DEFAULT_PROJECT_FILENAME]
+        assert project.problems == ["%s: The env_specs section is missing." % DEFAULT_PROJECT_FILENAME]
 
         out, err = capsys.readouterr()
-        assert out == ("%s: The env_specs section is empty.\nAdd an environment spec to anaconda-project.yml? " %
+        assert out == ("%s: The env_specs section is missing.\nAdd an environment spec to anaconda-project.yml? " %
                        DEFAULT_PROJECT_FILENAME)
         assert err == ""
 

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -1099,6 +1099,10 @@ class _ConfigCache(object):
 
     def _verify_command_dependencies(self, problems, project_file):
         for command in self.commands.values():
+            if command.default_env_spec_name not in self.env_specs:
+                # The missing environment will already have been flagged as a problem
+                # in _update_commands, so we can just return
+                return
             env_spec = self.env_specs[command.default_env_spec_name]
             missing = command.missing_packages(env_spec)
             if len(missing) > 0:


### PR DESCRIPTION
Go to `examples/stocks` and remove the `env_specs` section from the YAML file. This will cause an error like this:
```
$ anaconda-project prepare
An unexpected error occurred, most likely a bug in anaconda-project.
    (The error was: KeyError: None)
Details about the error were saved to /var/folders/nx/cwnch48d6l30h8sf79t598mh0000gp/T/bug_details_anaconda-project_2018-12-07_g98rau6e.txt
```
What you should get is something like this:
```
$ anaconda-project prepare
anaconda-project.yml: The env_specs section is empty.
Add an environment spec to anaconda-project.yml? 
```
This fixes that, by allowing `_verify_command_requirements` to silently fail if the command environment is entirely missing. That fact is detected elsewhere so nothing is lost by doing so.