### PR TITLE
Wait for subprocess and exit with same return code

### DIFF
--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -262,8 +262,7 @@ class CommandExecInfo(object):
                 # the Windows API calls. We need to do that, rather
                 # than calling os.execvpe which doesn't let us set those
                 # flags. So we spawn the child and then exit.
-                self.popen()
-                sys.exit(0)
+                sys.exit(self.popen().wait())
             else:
                 # this is all shell=True does on unix
                 args = ['/bin/sh', '-c'] + args

--- a/anaconda_project/test/test_project_commands.py
+++ b/anaconda_project/test/test_project_commands.py
@@ -49,6 +49,12 @@ def test_execvpe_with_shell_on_windows(monkeypatch):
         executed['cwd'] = cwd
         executed['shell'] = shell
 
+        class MockProcess(object):
+            def wait(self):
+                return 0
+
+        return MockProcess()
+
     monkeypatch.setattr('subprocess.Popen', mock_popen)
 
     info = CommandExecInfo(cwd='/somewhere', args=['foo bar'], shell=True, env=dict(FOO='bar'))


### PR DESCRIPTION
Fixes #154.
Rebases #158; original text from there:

-------

Not sure how this made it through this long, but the current behavior is a pretty awful experience: random interleaved outputs (#154), broken usage when scripted, and failures not being caught.

Can work up a proper test if necessary... basically a project file like:
```yaml
commands:
  a:
    windows: timeout 1 && echo a
  b:
    windows: echo b
```
then
```bat
anaconda-project run a
anaconda-project run b
```
would yield
```
b # immediately
a # after a second
```

and should yield

```
a # after a second
b # immediately
```