### PR TITLE
Add an --empty-environment flag to init

### DIFF
--- a/anaconda_project/internal/cli/init.py
+++ b/anaconda_project/internal/cli/init.py
@@ -14,7 +14,7 @@ from anaconda_project import project_ops
 from anaconda_project.internal.cli.console_utils import (print_project_problems, console_ask_yes_or_no)
 
 
-def init_command(project_dir, assume_yes):
+def init_command(project_dir, assume_yes, empty_environment):
     """Initialize a new project.
 
     Returns:
@@ -24,6 +24,7 @@ def init_command(project_dir, assume_yes):
     # --yes or we go with the default in project_ops.create
     # (depends on whether project file already exists).
     assert assume_yes is None or assume_yes is True
+    assert empty_environment is None or empty_environment is True
 
     if not os.path.exists(project_dir):
         if assume_yes:
@@ -33,7 +34,8 @@ def init_command(project_dir, assume_yes):
     else:
         make_directory = False
 
-    project = project_ops.create(project_dir, make_directory=make_directory, fix_problems=assume_yes)
+    project = project_ops.create(
+        project_dir, make_directory=make_directory, fix_problems=assume_yes, empty_environment=empty_environment)
     if print_project_problems(project):
         return 1
     else:
@@ -43,4 +45,4 @@ def init_command(project_dir, assume_yes):
 
 def main(args):
     """Start the init command and return exit status code."""
-    return init_command(args.directory, args.yes)
+    return init_command(args.directory, args.yes, args.empty_environment)

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -92,6 +92,11 @@ def _parse_args_and_run_subcommand(argv):
 
     preset = subparsers.add_parser('init', help="Initialize a directory with default project configuration")
     add_directory_arg(preset)
+    preset.add_argument(
+        '--empty-environment',
+        action='store_true',
+        help="Do not add the default package set to the environment.",
+        default=None)
     preset.add_argument('-y', '--yes', action='store_true', help="Assume yes to all confirmation prompts", default=None)
     preset.set_defaults(main=init.main)
 

--- a/anaconda_project/internal/cli/test/test_init.py
+++ b/anaconda_project/internal/cli/test/test_init.py
@@ -53,6 +53,23 @@ def test_init_in_pwd(capsys, monkeypatch):
     with_directory_contents(dict(), check)
 
 
+def test_init_empty_environment(capsys, monkeypatch):
+    def check(dirname):
+        _monkeypatch_pwd(monkeypatch, dirname)
+
+        code = _parse_args_and_run_subcommand(['anaconda-project', 'init', '--empty-environment'])
+        assert code == 0
+
+        assert os.path.isfile(os.path.join(dirname, DEFAULT_PROJECT_FILENAME))
+        assert not os.path.isfile(os.path.join(dirname, DEFAULT_PROJECT_LOCK_FILENAME))
+
+        out, err = capsys.readouterr()
+        assert ("Project configuration is in %s\n" % (os.path.join(dirname, DEFAULT_PROJECT_FILENAME))) == out
+        assert '' == err
+
+    with_directory_contents(dict(), check)
+
+
 def test_init_create_directory(capsys, monkeypatch):
     _monkeypatch_isatty(monkeypatch, True)
 

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -61,7 +61,13 @@ def _add_projectignore_if_none(project_directory):
             pass
 
 
-def create(directory_path, make_directory=False, name=None, icon=None, description=None, fix_problems=None):
+def create(directory_path,
+           make_directory=False,
+           empty_environment=False,
+           name=None,
+           icon=None,
+           description=None,
+           fix_problems=None):
     """Create a project skeleton in the given directory.
 
     Returns a Project instance even if creation fails or the directory
@@ -76,6 +82,7 @@ def create(directory_path, make_directory=False, name=None, icon=None, descripti
     Args:
         directory_path (str): directory to contain anaconda-project.yml
         make_directory (bool): True to create the directory if it doesn't exist
+        empty_environment (bool): True to create an empty base environment
         name (str): Name of the new project or None to leave unset (uses directory name)
         icon (str): Icon for the new project or None to leave unset (uses no icon)
         description (str): Description for the new project or None to leave unset
@@ -96,6 +103,8 @@ def create(directory_path, make_directory=False, name=None, icon=None, descripti
 
     project = Project(directory_path)
 
+    if empty_environment:
+        project.project_file.set_value('packages', [])
     if name is not None:
         project.project_file.set_value('name', name)
     if icon is not None:

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -81,6 +81,12 @@ def test_create(monkeypatch):
         assert spec.pip_packages == ()
         assert spec.channels == ()
 
+        # Test the --empty-environment flag
+        project = project_ops.create(subdir, make_directory=True, empty_environment=True)
+        spec = project.env_specs['default']
+        assert spec.conda_packages == ()
+        assert spec.pip_packages == ()
+
     with_directory_contents(dict(), check_create)
 
 


### PR DESCRIPTION
Sort of a fix to #148. Allows you to say
```
anaconda-project init --empty-environment
```
and start with an empty package set.