### PR TITLE
Fix small typo so default var renders correctly

### DIFF
--- a/docs/source/user-guide/reference.rst
+++ b/docs/source/user-guide/reference.rst
@@ -564,7 +564,7 @@ in the environment or in ``anaconda-project-local.yml`` overrides
 these defaults. To omit a default for a variable, set
 its value to either ``null`` or ``{}``.
 
-For example::
+For example:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
This fixes a minor typo so that the yaml source code renders directly. See screenshot below for current version on the left, the fixed version on the right:

![image](https://user-images.githubusercontent.com/937871/52165587-7d310980-270b-11e9-9ccb-2f22552fc520.png)
