### PR TITLE
Use pins to fix version constraint misses

### DIFF
--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -364,14 +364,18 @@ class DefaultCondaManager(CondaManager):
                 specs = spec.specs_for_conda_package_names(to_update)
                 assert len(specs) == len(to_update)
                 try:
-                    conda_api.install(
-                        prefix=prefix,
-                        pkgs=specs,
-                        channels=spec.channels,
-                        stdout_callback=self._on_stdout,
-                        stderr_callback=self._on_stderr)
-                except conda_api.CondaError as e:
-                    raise CondaManagerError("Failed to install packages: {}: {}".format(", ".join(specs), str(e)))
+                    spec.apply_pins(prefix)
+                    try:
+                        conda_api.install(
+                            prefix=prefix,
+                            pkgs=specs,
+                            channels=spec.channels,
+                            stdout_callback=self._on_stdout,
+                            stderr_callback=self._on_stderr)
+                    except conda_api.CondaError as e:
+                        raise CondaManagerError("Failed to install packages: {}: {}".format(", ".join(specs), str(e)))
+                finally:
+                    spec.remove_pins(prefix)
         elif create:
             # Create environment from scratch
 

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -363,19 +363,16 @@ class DefaultCondaManager(CondaManager):
             if len(to_update) > 0:
                 specs = spec.specs_for_conda_package_names(to_update)
                 assert len(specs) == len(to_update)
+                spec.apply_pins(prefix)
                 try:
-                    spec.apply_pins(prefix)
-                    try:
-                        conda_api.install(
-                            prefix=prefix,
-                            pkgs=specs,
-                            channels=spec.channels,
-                            stdout_callback=self._on_stdout,
-                            stderr_callback=self._on_stderr)
-                    except conda_api.CondaError as e:
-                        raise CondaManagerError("Failed to install packages: {}: {}".format(", ".join(specs), str(e)))
-                finally:
-                    spec.remove_pins(prefix)
+                    conda_api.install(
+                        prefix=prefix,
+                        pkgs=specs,
+                        channels=spec.channels,
+                        stdout_callback=self._on_stdout,
+                        stderr_callback=self._on_stderr)
+                except conda_api.CondaError as e:
+                    raise CondaManagerError("Failed to install packages: {}: {}".format(", ".join(specs), str(e)))
         elif create:
             # Create environment from scratch
 
@@ -391,6 +388,7 @@ class DefaultCondaManager(CondaManager):
                     channels=spec.channels,
                     stdout_callback=self._on_stdout,
                     stderr_callback=self._on_stderr)
+                spec.apply_pins(prefix)
             except conda_api.CondaError as e:
                 raise CondaManagerError("Failed to create environment at %s: %s" % (prefix, str(e)))
         else:

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1520,11 +1520,12 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
 
     def check(dirname):
         project = Project(dirname)
-        for spec in ('numpy<1.11.3', 'pandas'):
-            if spec == 'pandas':
-                status = project_ops.add_packages(project, 'foo', packages=[spec], channels=[])
-            else:
+        specs = ('numpy<1.11.3', 'pandas')
+        for spec in specs:
+            if spec == specs[0]:
                 status = project_ops.add_env_spec(project, name='foo', packages=[spec], channels=[])
+            else:
+                status = project_ops.add_packages(project, 'foo', packages=[spec], channels=[])
             if not status:
                 print(status.status_description)
                 print(repr(status.errors))
@@ -1543,6 +1544,9 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
             # ensure numpy <1.11.3 is present in both passes
             meta_path = os.path.join(dirname, 'envs', 'foo', 'conda-meta')
             assert os.path.isdir(meta_path)
+            pinned = os.path.join(meta_path, 'pinned')
+            assert os.path.exists(pinned)
+            assert open(pinned, 'r').read() == specs[0]
             files = glob.glob(os.path.join(meta_path, 'numpy-1.*-*'))
             assert len(files) == 1, files
             version = os.path.basename(files[0]).split('-', 2)[1]

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -14,6 +14,7 @@ import platform
 import pytest
 import tarfile
 import zipfile
+import glob
 
 from anaconda_project import project_ops
 from anaconda_project.conda_manager import (CondaManager, CondaEnvironmentDeviations, CondaLockSet, CondaManagerError,
@@ -1506,7 +1507,12 @@ env_specs:
 
 
 # the other add_env_spec tests use a mock CondaManager, but we want to have
-# one test that does the real thing to be sure it works.
+# one test that does the real thing to be sure it works. Furthermore, we want
+# to exercise the logic that ensures anaconda-project can properly pin package
+# versions during intermediate install steps. To do so, we purposefully install
+# a version of numpy that is incompatible with the latest version of pandas, and
+# then we add a latest version of pandas. If anaconda-project does the right thing,
+# conda will install an earlier version of pandas to respect the numpy version pin.
 @pytest.mark.slow
 def test_add_env_spec_with_real_conda_manager(monkeypatch):
     monkeypatch_conda_not_to_use_links(monkeypatch)
@@ -1514,22 +1520,33 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
 
     def check(dirname):
         project = Project(dirname)
-        status = project_ops.add_env_spec(project, name='foo', packages=['numpy=1.15.4'], channels=[])
-        if not status:
-            print(status.status_description)
-            print(repr(status.errors))
-        assert status
+        for spec in ('numpy<1.11.3', 'pandas'):
+            if spec == 'pandas':
+                status = project_ops.add_packages(project, 'foo', packages=[spec], channels=[])
+            else:
+                status = project_ops.add_env_spec(project, name='foo', packages=[spec], channels=[])
+            if not status:
+                print(status.status_description)
+                print(repr(status.errors))
+            assert status
 
-        assert 'foo' in project.env_specs
-        env = project.env_specs['foo']
-        assert env.lock_set.enabled
-        assert os.path.isfile(os.path.join(dirname, DEFAULT_PROJECT_LOCK_FILENAME))
+            assert 'foo' in project.env_specs
+            env = project.env_specs['foo']
+            assert env.lock_set.enabled
+            assert os.path.isfile(os.path.join(dirname, DEFAULT_PROJECT_LOCK_FILENAME))
 
-        # be sure it was really done
-        project2 = Project(dirname)
-        env_commented_map = project2.project_file.get_value(['env_specs', 'foo'])
-        assert dict(packages=['numpy=1.15.4'], channels=[]) == dict(env_commented_map)
-        assert os.path.isdir(os.path.join(dirname, 'envs', 'foo', 'conda-meta'))
+            # be sure it was really done
+            project2 = Project(dirname)
+            env_commented_map = project2.project_file.get_value(['env_specs', 'foo'])
+            assert spec in env_commented_map['packages'], env_commented_map['packages']
+
+            # ensure numpy <1.11.3 is present in both passes
+            meta_path = os.path.join(dirname, 'envs', 'foo', 'conda-meta')
+            assert os.path.isdir(meta_path)
+            files = glob.glob(os.path.join(meta_path, 'numpy-1.*-*'))
+            assert len(files) == 1, files
+            version = os.path.basename(files[0]).split('-', 2)[1]
+            assert tuple(map(int, version.split('.'))) < (1, 11, 3), files[0]
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_LOCK_FILENAME: "locking_enabled: true\n"}, check)
 


### PR DESCRIPTION
Attempts to fix #202 by creating a `conda-meta/pinned` file for all version-pinned constraints when correcting environment deficiencies. This is only used when _correcting_ an environment, not creating one for the first time.

Will have to think about how best to test this, but it is already being exercised by the code, so that's good.