### PR TITLE
Upload zipfile; fixes issue #204

### DIFF
--- a/anaconda_project/api.py
+++ b/anaconda_project/api.py
@@ -740,7 +740,8 @@ class AnacondaProject(object):
         return project_ops.unarchive(
             filename=filename, project_dir=project_dir, parent_dir=parent_dir, frontend=frontend)
 
-    def upload(self, project, private=None, site=None, username=None, token=None, log_level=None):
+    def upload(self, project, private=None, site=None,
+               username=None, token=None, suffix='.tar.bz2', log_level=None):
         """Upload the project to the Anaconda server.
 
         Args:
@@ -755,4 +756,5 @@ class AnacondaProject(object):
             a ``Status``, if failed has ``errors``
         """
         return project_ops.upload(
-            project=project, private=private, site=site, username=username, token=token, log_level=log_level)
+            project=project, private=private, site=site, username=username,
+            token=token, suffix=suffix, log_level=log_level)

--- a/anaconda_project/api.py
+++ b/anaconda_project/api.py
@@ -740,8 +740,7 @@ class AnacondaProject(object):
         return project_ops.unarchive(
             filename=filename, project_dir=project_dir, parent_dir=parent_dir, frontend=frontend)
 
-    def upload(self, project, private=None, site=None,
-               username=None, token=None, suffix='.tar.bz2', log_level=None):
+    def upload(self, project, private=None, site=None, username=None, token=None, suffix='.tar.bz2', log_level=None):
         """Upload the project to the Anaconda server.
 
         Args:
@@ -756,5 +755,10 @@ class AnacondaProject(object):
             a ``Status``, if failed has ``errors``
         """
         return project_ops.upload(
-            project=project, private=private, site=site, username=username,
-            token=token, suffix=suffix, log_level=log_level)
+            project=project,
+            private=private,
+            site=site,
+            username=username,
+            token=token,
+            suffix=suffix,
+            log_level=log_level)

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -141,6 +141,10 @@ def _parse_args_and_run_subcommand(argv):
     preset.add_argument('-s', '--site', metavar='SITE', help='Select site to use')
     preset.add_argument('-t', '--token', metavar='TOKEN', help='Auth token or a path to a file containing a token')
     preset.add_argument('-u', '--user', metavar='USERNAME', help='User account, defaults to the current user')
+    preset.add_argument('--suffix', metavar='SUFFIX',
+                        help='Project archive suffix (.tar.gz, .tar.bz2, .zip)',
+                        default='.tar.bz2',
+                        choices=['.tar.gz', '.tar.bz2', '.zip'])
     preset.set_defaults(main=upload.main)
 
     preset = subparsers.add_parser('add-variable', help="Add a required environment variable to the project")

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -141,10 +141,12 @@ def _parse_args_and_run_subcommand(argv):
     preset.add_argument('-s', '--site', metavar='SITE', help='Select site to use')
     preset.add_argument('-t', '--token', metavar='TOKEN', help='Auth token or a path to a file containing a token')
     preset.add_argument('-u', '--user', metavar='USERNAME', help='User account, defaults to the current user')
-    preset.add_argument('--suffix', metavar='SUFFIX',
-                        help='Project archive suffix (.tar.gz, .tar.bz2, .zip)',
-                        default='.tar.bz2',
-                        choices=['.tar.gz', '.tar.bz2', '.zip'])
+    preset.add_argument(
+        '--suffix',
+        metavar='SUFFIX',
+        help='Project archive suffix (.tar.gz, .tar.bz2, .zip)',
+        default='.tar.bz2',
+        choices=['.tar.gz', '.tar.bz2', '.zip'])
     preset.set_defaults(main=upload.main)
 
     preset = subparsers.add_parser('add-variable', help="Add a required environment variable to the project")

--- a/anaconda_project/internal/cli/test/test_upload.py
+++ b/anaconda_project/internal/cli/test/test_upload.py
@@ -69,3 +69,57 @@ def test_upload_command_with_token_and_user(capsys, monkeypatch):
         assert params['kwargs']['username'] == 'foo'
 
     with_directory_contents_completing_project_file(dict(), check)
+
+
+def test_upload_command_with_suffix_zip(capsys, monkeypatch):
+    params = _monkeypatch_upload(monkeypatch)
+
+    def check(dirname):
+        code = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'upload', '--directory', dirname,
+             '--suffix', '.zip'])
+        assert code == 0
+
+        out, err = capsys.readouterr()
+        assert 'Hello\nYay\n' == out
+        assert '' == err
+
+        assert params['kwargs']['suffix'] == '.zip'
+
+    with_directory_contents_completing_project_file(dict(), check)
+
+
+def test_upload_command_with_suffix_tarbz2(capsys, monkeypatch):
+    params = _monkeypatch_upload(monkeypatch)
+
+    def check(dirname):
+        code = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'upload', '--directory', dirname,
+             '--suffix', '.tar.bz2'])
+        assert code == 0
+
+        out, err = capsys.readouterr()
+        assert 'Hello\nYay\n' == out
+        assert '' == err
+
+        assert params['kwargs']['suffix'] == '.tar.bz2'
+
+    with_directory_contents_completing_project_file(dict(), check)
+
+
+def test_upload_command_with_suffix_targz(capsys, monkeypatch):
+    params = _monkeypatch_upload(monkeypatch)
+
+    def check(dirname):
+        code = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'upload', '--directory', dirname,
+             '--suffix', '.tar.gz'])
+        assert code == 0
+
+        out, err = capsys.readouterr()
+        assert 'Hello\nYay\n' == out
+        assert '' == err
+
+        assert params['kwargs']['suffix'] == '.tar.gz'
+
+    with_directory_contents_completing_project_file(dict(), check)

--- a/anaconda_project/internal/cli/test/test_upload.py
+++ b/anaconda_project/internal/cli/test/test_upload.py
@@ -76,8 +76,7 @@ def test_upload_command_with_suffix_zip(capsys, monkeypatch):
 
     def check(dirname):
         code = _parse_args_and_run_subcommand(
-            ['anaconda-project', 'upload', '--directory', dirname,
-             '--suffix', '.zip'])
+            ['anaconda-project', 'upload', '--directory', dirname, '--suffix', '.zip'])
         assert code == 0
 
         out, err = capsys.readouterr()
@@ -94,8 +93,7 @@ def test_upload_command_with_suffix_tarbz2(capsys, monkeypatch):
 
     def check(dirname):
         code = _parse_args_and_run_subcommand(
-            ['anaconda-project', 'upload', '--directory', dirname,
-             '--suffix', '.tar.bz2'])
+            ['anaconda-project', 'upload', '--directory', dirname, '--suffix', '.tar.bz2'])
         assert code == 0
 
         out, err = capsys.readouterr()
@@ -112,8 +110,7 @@ def test_upload_command_with_suffix_targz(capsys, monkeypatch):
 
     def check(dirname):
         code = _parse_args_and_run_subcommand(
-            ['anaconda-project', 'upload', '--directory', dirname,
-             '--suffix', '.tar.gz'])
+            ['anaconda-project', 'upload', '--directory', dirname, '--suffix', '.tar.gz'])
         assert code == 0
 
         out, err = capsys.readouterr()

--- a/anaconda_project/internal/cli/upload.py
+++ b/anaconda_project/internal/cli/upload.py
@@ -20,8 +20,7 @@ def upload_command(project_dir, private, site, username, token, suffix):
         exit code
     """
     project = load_project(project_dir)
-    status = project_ops.upload(project, private=private, site=site,
-                                username=username, token=token, suffix=suffix)
+    status = project_ops.upload(project, private=private, site=site, username=username, token=token, suffix=suffix)
     if status:
         print(status.status_description)
         return 0
@@ -32,5 +31,4 @@ def upload_command(project_dir, private, site, username, token, suffix):
 
 def main(args):
     """Start the upload command and return exit status code."""
-    return upload_command(args.directory, args.private, args.site,
-                          args.user, args.token, args.suffix)
+    return upload_command(args.directory, args.private, args.site, args.user, args.token, args.suffix)

--- a/anaconda_project/internal/cli/upload.py
+++ b/anaconda_project/internal/cli/upload.py
@@ -13,14 +13,15 @@ from anaconda_project.internal.cli import console_utils
 import anaconda_project.project_ops as project_ops
 
 
-def upload_command(project_dir, private, site, username, token):
+def upload_command(project_dir, private, site, username, token, suffix):
     """Upload project to Anaconda.
 
     Returns:
         exit code
     """
     project = load_project(project_dir)
-    status = project_ops.upload(project, private=private, site=site, username=username, token=token)
+    status = project_ops.upload(project, private=private, site=site,
+                                username=username, token=token, suffix=suffix)
     if status:
         print(status.status_description)
         return 0
@@ -31,4 +32,5 @@ def upload_command(project_dir, private, site, username, token):
 
 def main(args):
     """Start the upload command and return exit status code."""
-    return upload_command(args.directory, args.private, args.site, args.user, args.token)
+    return upload_command(args.directory, args.private, args.site,
+                          args.user, args.token, args.suffix)

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -1721,7 +1721,8 @@ def unarchive(filename, project_dir, parent_dir=None, frontend=None):
     return archiver._unarchive_project(filename, project_dir=project_dir, parent_dir=parent_dir, frontend=frontend)
 
 
-def upload(project, private=None, site=None, username=None, token=None, log_level=None):
+def upload(project, private=None, site=None, username=None, token=None,
+           suffix='.tar.bz2', log_level=None):
     """Upload the project to the Anaconda server.
 
     The returned status; if successful, has a 'url' attribute with the project URL.
@@ -1732,6 +1733,7 @@ def upload(project, private=None, site=None, username=None, token=None, log_leve
         site (str): site alias from Anaconda config
         username (str): Anaconda username
         token (str): Anaconda auth token
+        suffix (str): project archive suffix
         log_level (str): Anaconda log level
 
     Returns:
@@ -1740,8 +1742,6 @@ def upload(project, private=None, site=None, username=None, token=None, log_leve
     failed = _check_problems(project)
     if failed is not None:
         return failed
-
-    suffix = ".tar.bz2"
 
     # delete=True breaks on windows if you use tmp_tarfile.name to re-open the file,
     # so don't use delete=True.

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -1721,8 +1721,7 @@ def unarchive(filename, project_dir, parent_dir=None, frontend=None):
     return archiver._unarchive_project(filename, project_dir=project_dir, parent_dir=parent_dir, frontend=frontend)
 
 
-def upload(project, private=None, site=None, username=None, token=None,
-           suffix='.tar.bz2', log_level=None):
+def upload(project, private=None, site=None, username=None, token=None, suffix='.tar.bz2', log_level=None):
     """Upload the project to the Anaconda server.
 
     The returned status; if successful, has a 'url' attribute with the project URL.

--- a/anaconda_project/test/test_api.py
+++ b/anaconda_project/test/test_api.py
@@ -665,7 +665,8 @@ def test_upload(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.upload', mock_upload)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, private=True, site=123, token=456, username=789, log_level='LOTS')
+    kwargs = dict(project=43, private=True, site=123, token=456, username=789,
+                  suffix='.zip', log_level='LOTS')
     result = p.upload(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']

--- a/anaconda_project/test/test_api.py
+++ b/anaconda_project/test/test_api.py
@@ -665,8 +665,7 @@ def test_upload(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.upload', mock_upload)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, private=True, site=123, token=456, username=789,
-                  suffix='.zip', log_level='LOTS')
+    kwargs = dict(project=43, private=True, site=123, token=456, username=789, suffix='.zip', log_level='LOTS')
     result = p.upload(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']


### PR DESCRIPTION
Adds `anaconda-project upload --suffix <archive-suffix>`

Only the following suffixes are allowed
* `.zip`
* `.tar.gz`
* `.tar.bz2` (default)