### PR TITLE
Add support for old typo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - source "$HOME"/miniconda/etc/profile.d/conda.sh
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda false
   # yapf is pinned to help make sure we get the same results here as a user does locally.
-  - conda install -q $CONDA_CANARY -c defaults -c conda-forge conda conda-build conda-verify codecov flake8 pep257 yapf==0.25.0
+  - conda install -q $CONDA_CANARY -c defaults -c conda-forge conda=4.6 conda-build conda-verify codecov flake8 pep257 yapf==0.25.0
   - conda info -a
   - export LANG=en_US.UTF-8
   - export COVERAGE_DIR=":$HOME/htmlcov"

--- a/anaconda_project/plugins.py
+++ b/anaconda_project/plugins.py
@@ -82,3 +82,7 @@ class CommandTemplate(ProjectCommand):
     def choose_args_and_shell(self, environ, extra_args=None):
         """Overwrite this method to implement custom plugin logic."""
         raise NotImplementedError()
+
+
+# Some other packages depend upon this typo from 0.8.2 and earlier
+ArgsTrasformerTemplate = ArgsTransformerTemplate

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   # and the user has the necessary permissions to make environment changes. In a CI
   # environment these are not necessary and slow things down noticeably on Windows.
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no --set safety_checks disabled
-  - conda install -q conda conda-build conda-verify
+  - conda install -q conda=4.6 conda-build conda-verify
   - conda info -a
 
 # Not a .NET project, we build in the install step instead


### PR DESCRIPTION
Some dependent projects depended on the misspelled class name `ArgsTrasformerTemplate`. Adding that as a synonym back in.