### PR TITLE
prepare --all

### DIFF
--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -108,6 +108,7 @@ def _parse_args_and_run_subcommand(argv):
     preset.set_defaults(main=run.main)
 
     preset = subparsers.add_parser('prepare', help="Set up the project requirements, but does not run the project")
+    preset.add_argument('--all', action='store_true', help="Prepare all environments", default=None)
     add_prepare_args(preset)
     preset.set_defaults(main=prepare.main)
 

--- a/anaconda_project/internal/cli/prepare.py
+++ b/anaconda_project/internal/cli/prepare.py
@@ -13,7 +13,7 @@ from anaconda_project.internal.cli.prepare_with_mode import prepare_with_ui_mode
 from anaconda_project.internal.cli.project_load import load_project
 
 
-def prepare_command(project_dir, ui_mode, conda_environment, command_name, all):
+def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=False):
     """Configure the project to run.
 
     Returns:

--- a/anaconda_project/internal/cli/prepare.py
+++ b/anaconda_project/internal/cli/prepare.py
@@ -13,7 +13,7 @@ from anaconda_project.internal.cli.prepare_with_mode import prepare_with_ui_mode
 from anaconda_project.internal.cli.project_load import load_project
 
 
-def prepare_command(project_dir, ui_mode, conda_environment, command_name):
+def prepare_command(project_dir, ui_mode, conda_environment, command_name, all):
     """Configure the project to run.
 
     Returns:
@@ -22,15 +22,21 @@ def prepare_command(project_dir, ui_mode, conda_environment, command_name):
     project = load_project(project_dir)
     if console_utils.print_project_problems(project):
         return False
-    result = prepare_with_ui_mode_printing_errors(
-        project, env_spec_name=conda_environment, ui_mode=ui_mode, command_name=command_name)
+    if all:
+        result = []
+        for k, v in project.env_specs.items():
+            result = prepare_with_ui_mode_printing_errors(
+                project, env_spec_name=k, ui_mode=ui_mode, command_name=command_name)
+    else:
+        result = prepare_with_ui_mode_printing_errors(
+            project, env_spec_name=conda_environment, ui_mode=ui_mode, command_name=command_name)
 
     return result
 
 
 def main(args):
     """Start the prepare command and return exit status code."""
-    if prepare_command(args.directory, args.mode, args.env_spec, args.command):
+    if prepare_command(args.directory, args.mode, args.env_spec, args.command, args.all):
         print("The project is ready to run commands.")
         print("Use `anaconda-project list-commands` to see what's available.")
         return 0

--- a/anaconda_project/internal/cli/test/test_prepare.py
+++ b/anaconda_project/internal/cli/test/test_prepare.py
@@ -176,8 +176,7 @@ def test_prepare_command_all_environments(capsys, monkeypatch):
     def check_prepare_choose_environment(dirname):
         foo_envdir = os.path.join(dirname, "envs", "foo")
         bar_envdir = os.path.join(dirname, "envs", "bar")
-        result = _parse_args_and_run_subcommand(
-            ['anaconda-project', 'prepare', '--directory', dirname, '--all'])
+        result = _parse_args_and_run_subcommand(['anaconda-project', 'prepare', '--directory', dirname, '--all'])
         assert result == 0
 
         assert os.path.isdir(foo_envdir)

--- a/anaconda_project/internal/cli/test/test_prepare.py
+++ b/anaconda_project/internal/cli/test/test_prepare.py
@@ -96,6 +96,7 @@ def test_main_fails_to_redis(monkeypatch, capsys):
     def _mock_prepare_do_not_keep_going(project,
                                         environ=None,
                                         ui_mode=UI_MODE_TEXT_ASSUME_YES_DEVELOPMENT,
+                                        all=False,
                                         extra_command_args=None):
         return real_prepare(project, environ, ui_mode=ui_mode, extra_command_args=extra_command_args)
 
@@ -104,7 +105,7 @@ def test_main_fails_to_redis(monkeypatch, capsys):
 
     def main_redis_url(dirname):
         project_dir_disable_dedicated_env(dirname)
-        code = main(Args(directory=dirname))
+        code = main(Args(directory=dirname, all=False))
         assert 1 == code
 
     with_directory_contents_completing_project_file({

--- a/anaconda_project/internal/cli/test/test_prepare.py
+++ b/anaconda_project/internal/cli/test/test_prepare.py
@@ -162,6 +162,52 @@ env_specs:
     assert err == ""
 
 
+def test_prepare_command_all_environments(capsys, monkeypatch):
+    def mock_conda_create(prefix, pkgs, channels, stdout_callback, stderr_callback):
+        from anaconda_project.internal.makedirs import makedirs_ok_if_exists
+        metadir = os.path.join(prefix, "conda-meta")
+        makedirs_ok_if_exists(metadir)
+        for p in pkgs:
+            pkgmeta = os.path.join(metadir, "%s-0.1-pyNN.json" % p)
+            open(pkgmeta, 'a').close()
+
+    monkeypatch.setattr('anaconda_project.internal.conda_api.create', mock_conda_create)
+
+    def check_prepare_choose_environment(dirname):
+        foo_envdir = os.path.join(dirname, "envs", "foo")
+        bar_envdir = os.path.join(dirname, "envs", "bar")
+        result = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'prepare', '--directory', dirname, '--all'])
+        assert result == 0
+
+        assert os.path.isdir(foo_envdir)
+        assert os.path.isdir(bar_envdir)
+
+        foo_package_json = os.path.join(foo_envdir, "conda-meta", "nonexistent_foo-0.1-pyNN.json")
+        assert os.path.isfile(foo_package_json)
+
+        bar_package_json = os.path.join(bar_envdir, "conda-meta", "nonexistent_bar-0.1-pyNN.json")
+        assert os.path.isfile(bar_package_json)
+
+    with_directory_contents_completing_project_file({
+        DEFAULT_PROJECT_FILENAME:
+        """
+env_specs:
+  foo:
+    packages:
+        - nonexistent_foo
+  bar:
+    packages:
+        - nonexistent_bar
+"""
+    }, check_prepare_choose_environment)
+
+    out, err = capsys.readouterr()
+    assert out == (
+        "The project is ready to run commands.\n" + "Use `anaconda-project list-commands` to see what's available.\n")
+    assert err == ""
+
+
 def test_prepare_command_choose_environment_does_not_exist(capsys):
     def check_prepare_choose_environment_does_not_exist(dirname):
         project_dir_disable_dedicated_env(dirname)

--- a/anaconda_project/requirements_registry/providers/test/test_conda_env.py
+++ b/anaconda_project/requirements_registry/providers/test/test_conda_env.py
@@ -81,7 +81,7 @@ def test_prepare_and_unprepare_project_scoped_env(monkeypatch):
 
         # Now unprepare
         status = unprepare(project, result)
-        assert status
+        assert status, status.errors
         assert status.status_description == ('Deleted environment files in %s.' % (expected_env))
         assert status.errors == []
         assert not os.path.exists(expected_env)

--- a/anaconda_project/requirements_registry/providers/test/test_conda_env.py
+++ b/anaconda_project/requirements_registry/providers/test/test_conda_env.py
@@ -179,6 +179,7 @@ def test_prepare_project_scoped_env_with_packages(monkeypatch):
         project = Project(dirname)
         environ = minimal_environ(PROJECT_DIR=dirname)
         result = prepare_without_interaction(project, environ=environ)
+        print(result.errors)
         assert result
 
         prefix = result.environ[conda_env_var]
@@ -221,6 +222,7 @@ packages:
     - python=3.7
     - ipython
     - numpy=1.15
+    - pip
     - pip:
       - flake8
 """

--- a/anaconda_project/requirements_registry/providers/test/test_conda_env.py
+++ b/anaconda_project/requirements_registry/providers/test/test_conda_env.py
@@ -179,7 +179,6 @@ def test_prepare_project_scoped_env_with_packages(monkeypatch):
         project = Project(dirname)
         environ = minimal_environ(PROJECT_DIR=dirname)
         result = prepare_without_interaction(project, environ=environ)
-        print(result.errors)
         assert result
 
         prefix = result.environ[conda_env_var]


### PR DESCRIPTION
This allows for the `--all` flag for prepare that will iteratively create each environment in a project yaml, given that there is more than one.