### PR TITLE
Prepare update env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ install:
   - source "$HOME"/miniconda/etc/profile.d/conda.sh
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda false
   # yapf is pinned to help make sure we get the same results here as a user does locally.
-  - conda install -q $CONDA_CANARY -c defaults -c conda-forge conda=4.6 conda-build conda-verify codecov flake8 pep257 yapf==0.25.0
+# - conda install -q $CONDA_CANARY -c defaults -c conda-forge conda=4.6 conda-build conda-verify codecov flake8 pep257 yapf==0.25.0
+  - conda install -q $CONDA_CANARY -c defaults -c conda-forge conda-build conda-verify codecov flake8 pep257 yapf==0.25.0
   - conda info -a
   - export LANG=en_US.UTF-8
   - export COVERAGE_DIR=":$HOME/htmlcov"

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -109,6 +109,7 @@ def _parse_args_and_run_subcommand(argv):
 
     preset = subparsers.add_parser('prepare', help="Set up the project requirements, but does not run the project")
     preset.add_argument('--all', action='store_true', help="Prepare all environments", default=None)
+    preset.add_argument('--refresh', action='store_true', help='Remove and recreate the environment', default=None)
     add_prepare_args(preset)
     preset.set_defaults(main=prepare.main)
 

--- a/anaconda_project/internal/cli/prepare.py
+++ b/anaconda_project/internal/cli/prepare.py
@@ -37,7 +37,6 @@ def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=F
         result = prepare_with_ui_mode_printing_errors(
             project, env_spec_name=conda_environment, ui_mode=ui_mode, command_name=command_name)
 
-
     return result
 
 

--- a/anaconda_project/internal/cli/prepare.py
+++ b/anaconda_project/internal/cli/prepare.py
@@ -11,9 +11,10 @@ from __future__ import absolute_import, print_function
 import anaconda_project.internal.cli.console_utils as console_utils
 from anaconda_project.internal.cli.prepare_with_mode import prepare_with_ui_mode_printing_errors
 from anaconda_project.internal.cli.project_load import load_project
+from anaconda_project.requirements_registry.providers.conda_env import _remove_env_path
 
 
-def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=False):
+def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=False, refresh=False):
     """Configure the project to run.
 
     Returns:
@@ -25,18 +26,24 @@ def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=F
     if all:
         result = []
         for k, v in project.env_specs.items():
+            if refresh:
+                _remove_env_path(v.path(project.directory_path))
             result = prepare_with_ui_mode_printing_errors(
                 project, env_spec_name=k, ui_mode=ui_mode, command_name=command_name)
     else:
+        if refresh:
+            conda_environment = 'default' if conda_environment is None else conda_environment
+            _remove_env_path(project.env_specs[conda_environment].path(project.directory_path))
         result = prepare_with_ui_mode_printing_errors(
             project, env_spec_name=conda_environment, ui_mode=ui_mode, command_name=command_name)
+
 
     return result
 
 
 def main(args):
     """Start the prepare command and return exit status code."""
-    if prepare_command(args.directory, args.mode, args.env_spec, args.command, args.all):
+    if prepare_command(args.directory, args.mode, args.env_spec, args.command, args.all, args.refresh):
         print("The project is ready to run commands.")
         print("Use `anaconda-project list-commands` to see what's available.")
         return 0

--- a/anaconda_project/internal/cli/test/test_prepare.py
+++ b/anaconda_project/internal/cli/test/test_prepare.py
@@ -105,7 +105,7 @@ def test_main_fails_to_redis(monkeypatch, capsys):
 
     def main_redis_url(dirname):
         project_dir_disable_dedicated_env(dirname)
-        code = main(Args(directory=dirname, all=False))
+        code = main(Args(directory=dirname, all=False, refresh=False))
         assert 1 == code
 
     with_directory_contents_completing_project_file({
@@ -253,7 +253,8 @@ env_specs:
 
     out, err = capsys.readouterr()
     assert out == (
-        "The project is ready to run commands.\n" + "Use `anaconda-project list-commands` to see what's available.\n")
+        "The project is ready to run commands.\n" + "Use `anaconda-project list-commands` to see what's available.\n" +
+    "The project is ready to run commands.\n" + "Use `anaconda-project list-commands` to see what's available.\n")
     assert err == ""
 
 

--- a/anaconda_project/internal/cli/test/test_prepare.py
+++ b/anaconda_project/internal/cli/test/test_prepare.py
@@ -225,8 +225,8 @@ def test_prepare_command_all_environments_refresh(capsys, monkeypatch):
         result = _parse_args_and_run_subcommand(['anaconda-project', 'prepare', '--directory', dirname, '--all'])
         assert result == 0
 
-        result = _parse_args_and_run_subcommand(['anaconda-project', 'prepare', '--directory', dirname, '--all',
-                                                 '--refresh'])
+        result = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'prepare', '--directory', dirname, '--all', '--refresh'])
         assert result == 0
 
         assert os.path.isdir(foo_envdir)
@@ -254,7 +254,7 @@ env_specs:
     out, err = capsys.readouterr()
     assert out == (
         "The project is ready to run commands.\n" + "Use `anaconda-project list-commands` to see what's available.\n" +
-    "The project is ready to run commands.\n" + "Use `anaconda-project list-commands` to see what's available.\n")
+        "The project is ready to run commands.\n" + "Use `anaconda-project list-commands` to see what's available.\n")
     assert err == ""
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,8 @@ install:
   # and the user has the necessary permissions to make environment changes. In a CI
   # environment these are not necessary and slow things down noticeably on Windows.
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no --set safety_checks disabled
-  - conda install -q conda=4.6 conda-build conda-verify
+# - conda install -q conda=4.6 conda-build conda-verify
+  - conda install -q conda-build conda-verify
   - conda info -a
 
 # Not a .NET project, we build in the install step instead


### PR DESCRIPTION
This adds the option to provide a `--refresh` flag. With this option enabled `anaconda-project prepare` will remove the environments and recreate them with the current project spec.

https://github.com/Anaconda-Platform/anaconda-project/issues/173