### PR TITLE
Autogenerate default env

### DIFF
--- a/anaconda_project/internal/cli/test/test_project_load.py
+++ b/anaconda_project/internal/cli/test/test_project_load.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, print_function
 import os
 import sys
 
-from anaconda_project.project import Project
 from anaconda_project.project_file import DEFAULT_PROJECT_FILENAME
 from anaconda_project.internal.cli.project_load import load_project
 
@@ -69,39 +68,3 @@ def test_interactively_no_fix_empty_project(monkeypatch, capsys):
         assert err == ""
 
     with_directory_contents({}, check)
-
-
-def test_interactively_fix_project(monkeypatch, capsys):
-    def check(dirname):
-        broken_project = Project(dirname)
-        assert len(broken_project.fixable_problems) == 1
-
-        _monkeypatch_input(monkeypatch, ["y"])
-
-        project = load_project(dirname)
-        assert project.problems == []
-
-        out, err = capsys.readouterr()
-        assert out == ("%s: The env_specs section is missing.\nAdd an environment spec to anaconda-project.yml? " %
-                       DEFAULT_PROJECT_FILENAME)
-        assert err == ""
-
-    with_directory_contents({DEFAULT_PROJECT_FILENAME: "name: foo"}, check)
-
-
-def test_interactively_no_fix_project(monkeypatch, capsys):
-    def check(dirname):
-        broken_project = Project(dirname)
-        assert len(broken_project.fixable_problems) == 1
-
-        _monkeypatch_input(monkeypatch, ["n"])
-
-        project = load_project(dirname)
-        first_line = "%s: The env_specs section is missing." % DEFAULT_PROJECT_FILENAME
-        assert project.problems == [first_line]
-
-        out, err = capsys.readouterr()
-        assert out == "%s\nAdd an environment spec to anaconda-project.yml? " % first_line
-        assert err == ""
-
-    with_directory_contents({DEFAULT_PROJECT_FILENAME: "name: foo\nplatforms: [linux-64,osx-64,win-64]\n"}, check)

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -863,12 +863,8 @@ class _ConfigCache(object):
                 default_spec = _anaconda_default_env_spec(self.global_base_env_spec)
                 project.project_file.set_value(['env_specs', default_spec.name], default_spec.to_json())
 
-            problems.append(
-                ProjectProblem(
-                    text="The env_specs section is %s." % ("missing" if env_specs_is_missing else "empty"),
-                    filename=project_file.filename,
-                    fix_prompt=("Add an environment spec to %s?" % os.path.basename(project_file.filename)),
-                    fix_function=add_default_env_spec))
+            # This section should now be inaccessible
+            # since env_spec will be added at runtime if missing
 
 
 # this is only used for commands that don't specify anything

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -863,13 +863,13 @@ class _ConfigCache(object):
                 default_spec = _anaconda_default_env_spec(self.global_base_env_spec)
                 project.project_file.set_value(['env_specs', default_spec.name], default_spec.to_json())
 
+            problems.append(
+                ProjectProblem(
+                    text="The env_specs section is %s." % ("missing" if env_specs_is_missing else "empty"),
+                    filename=project_file.filename,
+                    fix_prompt=("Add an environment spec to %s?" % os.path.basename(project_file.filename)),
+                    fix_function=add_default_env_spec))
 
-#           problems.append(
-#               ProjectProblem(
-#                   text="The env_specs section is %s." % ("missing" if env_specs_is_missing else "empty"),
-#                   filename=project_file.filename,
-#                   fix_prompt=("Add an environment spec to %s?" % os.path.basename(project_file.filename)),
-#                   fix_function=add_default_env_spec))
 
 # this is only used for commands that don't specify anything
 # (when/if we require all commands to specify, then remove this.)

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -863,6 +863,7 @@ class _ConfigCache(object):
                 default_spec = _anaconda_default_env_spec(self.global_base_env_spec)
                 project.project_file.set_value(['env_specs', default_spec.name], default_spec.to_json())
 
+
 #           problems.append(
 #               ProjectProblem(
 #                   text="The env_specs section is %s." % ("missing" if env_specs_is_missing else "empty"),
@@ -870,8 +871,9 @@ class _ConfigCache(object):
 #                   fix_prompt=("Add an environment spec to %s?" % os.path.basename(project_file.filename)),
 #                   fix_function=add_default_env_spec))
 
-        # this is only used for commands that don't specify anything
-        # (when/if we require all commands to specify, then remove this.)
+# this is only used for commands that don't specify anything
+# (when/if we require all commands to specify, then remove this.)
+
         if 'default' in self.env_specs:
             self.default_env_spec_name = 'default'
         else:

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -28,6 +28,7 @@ from anaconda_project.archiver import _list_relative_paths_for_unignored_project
 from anaconda_project.version import version
 from anaconda_project.conda_manager import CondaLockSet
 from anaconda_project.frontend import _null_frontend, _new_error_recorder, Frontend
+from anaconda_project.yaml_file import CommentedMap
 
 from anaconda_project.internal.py2_compat import is_string, is_list, is_dict
 from anaconda_project.internal.simple_status import SimpleStatus
@@ -577,7 +578,10 @@ class _ConfigCache(object):
         (shared_deps, shared_pip_deps) = _parse_packages(project_file.root)
         shared_channels = _parse_channels(project_file.root)
         shared_platforms = _parse_platforms(project_file.root)
-        env_specs = project_file.get_value('env_specs', default=None)
+
+        _default_env_spec = CommentedMap([('default', CommentedMap([('packages', []), ('channels', [])]))])
+        env_specs = project_file.get_value('env_specs', default=_default_env_spec)
+
         first_env_spec_name = None
         env_specs_is_empty = False
         env_specs_is_missing = False
@@ -859,12 +863,12 @@ class _ConfigCache(object):
                 default_spec = _anaconda_default_env_spec(self.global_base_env_spec)
                 project.project_file.set_value(['env_specs', default_spec.name], default_spec.to_json())
 
-            problems.append(
-                ProjectProblem(
-                    text="The env_specs section is %s." % ("missing" if env_specs_is_missing else "empty"),
-                    filename=project_file.filename,
-                    fix_prompt=("Add an environment spec to %s?" % os.path.basename(project_file.filename)),
-                    fix_function=add_default_env_spec))
+#           problems.append(
+#               ProjectProblem(
+#                   text="The env_specs section is %s." % ("missing" if env_specs_is_missing else "empty"),
+#                   filename=project_file.filename,
+#                   fix_prompt=("Add an environment spec to %s?" % os.path.basename(project_file.filename)),
+#                   fix_function=add_default_env_spec))
 
         # this is only used for commands that don't specify anything
         # (when/if we require all commands to specify, then remove this.)

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -2758,31 +2758,6 @@ def test_auto_fix_missing_name():
         }, check)
 
 
-@pytest.mark.parametrize("mode", ['missing', 'missing-command', 'empty', 'empty-command'])
-def test_auto_fix_env_specs_section(mode):
-    def check(dirname):
-        project = project_no_dedicated_env(dirname)
-        assert len(project.problems) == 1
-        assert len(project.problem_objects) == 1
-        problem = project.problem_objects[0]
-        msg = mode.split('-', 1)[0]
-        assert problem.text == "%s: The env_specs section is %s." % (DEFAULT_PROJECT_FILENAME, msg)
-        assert problem.can_fix
-
-        problem.fix(project)
-        project.project_file.save()
-
-        assert project.problems == []
-        assert list(project.env_specs.keys()) == ['default']
-
-    yaml = "name: foo\n"
-    if mode.startswith('empty'):
-        yaml += "env_specs: {}\n"
-    if mode.endswith('command'):
-        yaml += "commands:\n default:\n  bokeh_app: .\n"
-    with_directory_contents({DEFAULT_PROJECT_FILENAME: yaml}, check)
-
-
 def test_auto_fix_env_spec_import():
     def check(dirname):
         project = project_no_dedicated_env(dirname)
@@ -3204,10 +3179,7 @@ env_specs:
 def test_empty_file_has_problems():
     def check(dirname):
         project = project_no_dedicated_env(dirname)
-        assert [
-            "anaconda-project.yml: The 'name:' field is missing.",
-            "anaconda-project.yml: The env_specs section is missing."
-        ] == project.problems
+        assert ["anaconda-project.yml: The 'name:' field is missing."] == project.problems
 
     with_directory_contents({DEFAULT_PROJECT_FILENAME: ""}, check)
 
@@ -3235,7 +3207,7 @@ def test_with_locking_enabled_no_env_specs_has_problems():
         project = project_no_dedicated_env(dirname)
         assert [
             "anaconda-project.yml: The 'name:' field is missing.",
-            "anaconda-project.yml: The env_specs section is missing."
+            "anaconda-project.yml: The 'platforms:' field should list platforms the project supports."
         ] == project.problems
 
     with_directory_contents({

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -3220,18 +3220,6 @@ env_specs:
         }, check)
 
 
-def test_export_env_spec_broken_project(monkeypatch):
-    def check(dirname):
-        project = project_no_dedicated_env(dirname)
-        status = project_ops.export_env_spec(project, name='default', filename='foo')
-        assert not status
-        assert status.status_description == 'Unable to load the project.'
-
-    with_directory_contents({DEFAULT_PROJECT_FILENAME: """
-name: broken
-"""}, check)
-
-
 def _monkeypatch_can_connect_to_socket_on_standard_redis_port(monkeypatch):
     from anaconda_project.requirements_registry.network_util import can_connect_to_socket as real_can_connect_to_socket
 


### PR DESCRIPTION
This allows the simplest anaconda-project.yml file to be utilized without an `env_specs` key.

```yaml
name: My project

packages:
  - python=3.7
  - notebook
channels: []
```

on `anaconda-project prepare` it will infer that the name of the `env_spec` is `default`.