### PR TITLE
Remove pins when not used

### DIFF
--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -418,6 +418,18 @@ class EnvSpec(object):
             if new_list:
                 os.rename(fname + '.__ap_new', fname)
 
+    def remove_pins(self, prefix):
+        """Remove the pinned file."""
+        conda_meta_path = os.path.join(prefix, 'conda-meta')
+        if not os.path.isdir(conda_meta_path):
+            raise RuntimeError('Expected path {} to exist'.format(conda_meta_path))
+        fname = os.path.join(conda_meta_path, 'pinned')
+        if os.path.exists(fname):
+            if os.path.exists(fname + '.__ap_orig'):
+                os.rename(fname, fname + '.__ap_orig')
+            else:
+                os.remove(fname)
+
     def save_environment_yml(self, filename):
         """Save as an environment.yml file."""
         # here we want to flatten the env spec to include all inherited stuff

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -426,7 +426,7 @@ class EnvSpec(object):
         fname = os.path.join(conda_meta_path, 'pinned')
         if os.path.exists(fname):
             if os.path.exists(fname + '.__ap_orig'):
-                os.rename(fname, fname + '.__ap_orig')
+                os.rename(fname + '.__ap_orig', fname)
             else:
                 os.remove(fname)
 

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -371,7 +371,7 @@ class DefaultCondaManager(CondaManager):
                         channels=spec.channels,
                         stdout_callback=self._on_stdout,
                         stderr_callback=self._on_stderr)
-                    spec.apply_pins(prefix)
+                    spec.remove_pins(prefix)
                 except conda_api.CondaError as e:
                     raise CondaManagerError("Failed to install packages: {}: {}".format(", ".join(specs), str(e)))
         elif create:
@@ -389,7 +389,6 @@ class DefaultCondaManager(CondaManager):
                     channels=spec.channels,
                     stdout_callback=self._on_stdout,
                     stderr_callback=self._on_stderr)
-                spec.apply_pins(prefix)
             except conda_api.CondaError as e:
                 raise CondaManagerError("Failed to create environment at %s: %s" % (prefix, str(e)))
         else:

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -371,9 +371,10 @@ class DefaultCondaManager(CondaManager):
                         channels=spec.channels,
                         stdout_callback=self._on_stdout,
                         stderr_callback=self._on_stderr)
-                    spec.remove_pins(prefix)
                 except conda_api.CondaError as e:
                     raise CondaManagerError("Failed to install packages: {}: {}".format(", ".join(specs), str(e)))
+                finally:
+                    spec.remove_pins(prefix)
         elif create:
             # Create environment from scratch
 

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1543,10 +1543,11 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
 
             # ensure numpy <1.11.3 is present in both passes
             meta_path = os.path.join(dirname, 'envs', 'foo', 'conda-meta')
+            # pinned file no longer present between environment preparation steps
             assert os.path.isdir(meta_path)
             pinned = os.path.join(meta_path, 'pinned')
-            assert os.path.exists(pinned)
-            assert open(pinned, 'r').read() == specs[0]
+            assert not os.path.exists(pinned)
+            # assert open(pinned, 'r').read() == specs[0]
             files = glob.glob(os.path.join(meta_path, 'numpy-1.*-*'))
             assert len(files) == 1, files
             version = os.path.basename(files[0]).split('-', 2)[1]


### PR DESCRIPTION
@AlbertDeFusco for consideration in our afternoon call.

Currently anaconda-project is creating a `pinned` file to ensure that its version specifications are enforced when new packages are added to the environment. This was necessary to address the `anaconda-project prepare` issue whereby dependency versions were allowed to change, in violation of the YAML spec. But currently the code _leaves_ the `pinned` file in place so that even direct calls to `conda` enforce those requirements.

That may be overkill for users. If so this PR would insert the `pinned` file only temporarily, after every invocation of anaconda-project's environment preparation runs, and remove it afterward. 