### PR TITLE
Templating for commands

### DIFF
--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -141,8 +141,11 @@ class _TemplateArgsTransformer(_ArgsTransformer):
         self._parse_args_removing_known(results, extra_args)
         extra_args = _TemplateArgsTransformer().transform_args(extra_args)
         args = _append_extra_args_to_command_line(command, extra_args)
-        args = {self.arg_to_identifier(k):(v[0] if v else True) for k,v in results.items() if v}
-        return [Template(command).render(args)]
+        items = {self.arg_to_identifier(k):(v[0] if v else True)
+                 for k,v in results.items() if v}
+        items.update({self.arg_to_identifier(k):v for k,v in
+                      zip(extra_args[::2], extra_args[1::2])})
+        return [Template(command).render(items)]
 
 
 class _NotebookArgsTransformer(_ArgsTransformer):

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -139,16 +139,18 @@ class _TemplateArgsTransformer(_ArgsTransformer):
         results = {spec.option: [] for spec in self.specs}
         self._parse_args_removing_known(results, extra_args)
         extra_args = _TemplateArgsTransformer().transform_args(extra_args)
-        items = {self.arg_to_identifier(k): (v[0] if v else True) for k, v in results.items() if v}
+        items = {k: (v[0] if v else True) for k, v in results.items() if v}
+        # Aliasing of HTTP options (e.g anaconda_project_port to port)
         replacements = {}
         for k, v in items.items():
-            if k.startswith('anaconda_project_'):
-                replacement = k.replace('anaconda_project_', '')
+            if k.startswith('--anaconda-project-'):
+                replacement = k.replace('--anaconda-project-', '')
                 if replacement not in items:
                     replacements[replacement] = v
         items.update(replacements)
 
-        templated_command = Template(command).render(items)
+        normalized = {self.arg_to_identifier(k): v for k, v in items.items()}
+        templated_command = Template(command).render(normalized)
         return [_append_extra_args_to_command_line(templated_command, extra_args)]
 
 

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -148,11 +148,7 @@ class _TemplateArgsTransformer(_ArgsTransformer):
                 if replacement not in items:
                     replacements[replacement] = v
         items.update(replacements)
-        items.update({'project_dir':environ['PROJECT_DIR'],
-                      'conda_default_env':environ['CONDA_DEFAULT_ENV'],
-                      'conda_prefix':environ['CONDA_PREFIX']})
-        if 'CONDA_ENV_PATH' in environ: # As of 4.1.5, conda no longer defines this
-            items.update({'conda_env_path':environ['CONDA_ENV_PATH']})
+        items.update(environ)
 
         normalized = {self.arg_to_identifier(k): v for k, v in items.items()}
         templated_command = Template(command).render(normalized)

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -139,7 +139,7 @@ class _TemplateArgsTransformer(_ArgsTransformer):
         results = {spec.option: [] for spec in self.specs}
         self._parse_args_removing_known(results, extra_args)
         extra_args = _TemplateArgsTransformer().transform_args(extra_args)
-        items = {k: (v[-1] if len(v)==1 else v) for k, v in results.items() if v}
+        items = {k: (v[-1] if len(v) == 1 else v) for k, v in results.items() if v}
         # Aliasing of HTTP options (e.g anaconda_project_port to port)
         replacements = {}
         for k, v in items.items():

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -139,7 +139,6 @@ class _TemplateArgsTransformer(_ArgsTransformer):
         results = {spec.option: [] for spec in self.specs}
         self._parse_args_removing_known(results, extra_args)
         extra_args = _TemplateArgsTransformer().transform_args(extra_args)
-        _append_extra_args_to_command_line(command, extra_args)
         items = {self.arg_to_identifier(k): (v[0] if v else True) for k, v in results.items() if v}
         replacements = {}
         for k, v in items.items():

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -139,7 +139,7 @@ class _TemplateArgsTransformer(_ArgsTransformer):
         results = {spec.option: [] for spec in self.specs}
         self._parse_args_removing_known(results, extra_args)
         extra_args = _TemplateArgsTransformer().transform_args(extra_args)
-        items = {k: (v[0] if v else True) for k, v in results.items() if v}
+        items = {k: (v[-1] if v else True) for k, v in results.items() if v}
         # Aliasing of HTTP options (e.g anaconda_project_port to port)
         replacements = {}
         for k, v in items.items():

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -143,8 +143,6 @@ class _TemplateArgsTransformer(_ArgsTransformer):
         _append_extra_args_to_command_line(command, extra_args)
         items = {self.arg_to_identifier(k):(v[0] if v else True)
                  for k,v in results.items() if v}
-        items.update({self.arg_to_identifier(k):v for k,v in
-                      zip(extra_args[::2], extra_args[1::2])})
         replacements = {}
         for k,v in items.items():
             if k.startswith('anaconda_project_'):
@@ -152,7 +150,9 @@ class _TemplateArgsTransformer(_ArgsTransformer):
                 if replacement not in items:
                     replacements[replacement] = v
         items.update(replacements)
-        return [Template(command).render(items)]
+
+        templated_command = Template(command).render(items)
+        return [_append_extra_args_to_command_line(templated_command, extra_args)]
 
 
 class _NotebookArgsTransformer(_ArgsTransformer):

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -145,6 +145,13 @@ class _TemplateArgsTransformer(_ArgsTransformer):
                  for k,v in results.items() if v}
         items.update({self.arg_to_identifier(k):v for k,v in
                       zip(extra_args[::2], extra_args[1::2])})
+        replacements = {}
+        for k,v in items.items():
+            if k.startswith('anaconda_project_'):
+                replacement = k.replace('anaconda_project_', '')
+                if replacement not in items:
+                    replacements[replacement] = v
+        items.update(replacements)
         return [Template(command).render(items)]
 
 

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -16,7 +16,6 @@ import platform
 import sys
 from jinja2 import Template
 
-
 from anaconda_project.verbose import _verbose_logger
 from anaconda_project.internal import (conda_api, logged_subprocess, py2_compat)
 
@@ -134,17 +133,16 @@ class _TemplateArgsTransformer(_ArgsTransformer):
 
     def arg_to_identifier(self, arg):
         """Turn a commandline argument into a Python identifier for jinja2."""
-        return arg.replace('--','').replace('-','_')
+        return arg.replace('--', '').replace('-', '_')
 
     def parse_and_template(self, command, extra_args):
         results = {spec.option: [] for spec in self.specs}
         self._parse_args_removing_known(results, extra_args)
         extra_args = _TemplateArgsTransformer().transform_args(extra_args)
         _append_extra_args_to_command_line(command, extra_args)
-        items = {self.arg_to_identifier(k):(v[0] if v else True)
-                 for k,v in results.items() if v}
+        items = {self.arg_to_identifier(k): (v[0] if v else True) for k, v in results.items() if v}
         replacements = {}
-        for k,v in items.items():
+        for k, v in items.items():
             if k.startswith('anaconda_project_'):
                 replacement = k.replace('anaconda_project_', '')
                 if replacement not in items:
@@ -457,8 +455,8 @@ class ProjectCommand(object):
         shell = False
 
         if not self.supports_http_options and (self.notebook or self.bokeh_app):
-           # drop the http arguments
-           extra_args = _ArgsTransformer().transform_args(extra_args)
+            # drop the http arguments
+            extra_args = _ArgsTransformer().transform_args(extra_args)
 
         if self.notebook is not None:
             path = os.path.join(environ['PROJECT_DIR'], self.notebook)
@@ -480,7 +478,6 @@ class ProjectCommand(object):
                 args = args + extra_args
             return args, False
 
-
         command = self._attributes.get(self._shell_field(), None)
         if (command is not None) and self.supports_http_options:
             args = [_append_extra_args_to_command_line(command, extra_args)]
@@ -488,7 +485,6 @@ class ProjectCommand(object):
         elif command:
             shell = True
             args = _TemplateArgsTransformer().parse_and_template(command, extra_args)
-
 
         if args is None:
             # see conda.misc::launch for what we're copying

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -127,20 +127,20 @@ class _BokehArgsTransformer(_ArgsTransformer):
 
 
 class _TemplateArgsTransformer(_ArgsTransformer):
-    "ArgsTransformer that supports jinja2 templating"
+    """ArgsTransformer that supports jinja2 templating."""
 
     def add_args(self, results, args):
         return args
 
     def arg_to_identifier(self, arg):
-        "Turns a commandline argument into a Python identifier for jinja2"
+        """Turn a commandline argument into a Python identifier for jinja2."""
         return arg.replace('--','').replace('-','_')
 
     def parse_and_template(self, command, extra_args):
         results = {spec.option: [] for spec in self.specs}
         self._parse_args_removing_known(results, extra_args)
         extra_args = _TemplateArgsTransformer().transform_args(extra_args)
-        args = _append_extra_args_to_command_line(command, extra_args)
+        _append_extra_args_to_command_line(command, extra_args)
         items = {self.arg_to_identifier(k):(v[0] if v else True)
                  for k,v in results.items() if v}
         items.update({self.arg_to_identifier(k):v for k,v in

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -139,7 +139,7 @@ class _TemplateArgsTransformer(_ArgsTransformer):
         results = {spec.option: [] for spec in self.specs}
         self._parse_args_removing_known(results, extra_args)
         extra_args = _TemplateArgsTransformer().transform_args(extra_args)
-        items = {k: (v[-1] if v else True) for k, v in results.items() if v}
+        items = {k: (v[-1] if len(v)==1 else v) for k, v in results.items() if v}
         # Aliasing of HTTP options (e.g anaconda_project_port to port)
         replacements = {}
         for k, v in items.items():
@@ -147,6 +147,12 @@ class _TemplateArgsTransformer(_ArgsTransformer):
                 replacement = k.replace('--anaconda-project-', '')
                 if replacement not in items:
                     replacements[replacement] = v
+
+        if 'host' in replacements:
+            host = replacements['host']
+            replacements['host'] = host[-1] if isinstance(host, list) else host
+            replacements['hosts'] = host if isinstance(host, list) else [host]
+
         items.update(replacements)
         items.update(environ)
 

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1414,7 +1414,7 @@ def test_windows_template_command():
         project = project_no_dedicated_env(dirname)
         command = project.default_command
         assert command.supports_http_options is False
-        assert command.unix_shell_commandline == None
+        assert command.unix_shell_commandline is None
         assert command.windows_cmd_commandline == 'test {{port}}'
         assert command.conda_app_entry is None
 

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1415,7 +1415,7 @@ def test_windows_template_command():
         command = project.default_command
         assert command.supports_http_options is False
         assert command.unix_shell_commandline == None
-        assert command.windows_cmd_commandline is 'test {{port}}'
+        assert command.windows_cmd_commandline == 'test {{port}}'
         assert command.conda_app_entry is None
 
         environ = minimal_environ(PROJECT_DIR=dirname)

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1410,6 +1410,30 @@ def test_unix_template_command():
         }, check_template_command)
 
 
+def test_unix_template_command_with_extra_args():
+    def check_template_command(dirname):
+        project = project_no_dedicated_env(dirname)
+        command = project.default_command
+        assert command.supports_http_options is False
+        assert command.unix_shell_commandline == 'test {{port}}'
+        assert command.windows_cmd_commandline is None
+        assert command.conda_app_entry is None
+
+        environ = minimal_environ(PROJECT_DIR=dirname)
+        cmd_exec = command.exec_info_for_environment(
+            environ, extra_args=['--anaconda-project-port', '8888', "--extra-arg-example", "foo"])
+        if cmd_exec is not None:
+            assert cmd_exec.args == ['test 8888 --extra-arg-example foo']
+            assert cmd_exec.shell is True
+        else:
+            raise SkipTest
+
+    with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME: "commands:\n default:\n    unix: test {{port}}\n    supports_http_options: false"
+        }, check_template_command)
+
+
 def test_windows_template_command():
     def check_template_command(dirname):
         project = project_no_dedicated_env(dirname)
@@ -1423,6 +1447,30 @@ def test_windows_template_command():
         cmd_exec = command.exec_info_for_environment(environ, extra_args=['--anaconda-project-port', '8888'])
         if cmd_exec is not None:
             assert cmd_exec.args == ['test 8888']
+            assert cmd_exec.shell is True
+        else:
+            raise SkipTest
+
+    with_directory_contents_completing_project_file({
+        DEFAULT_PROJECT_FILENAME:
+        "commands:\n default:\n    windows: test {{port}}\n    supports_http_options: false"
+    }, check_template_command)
+
+
+def test_windows_template_command_with_extra_args():
+    def check_template_command(dirname):
+        project = project_no_dedicated_env(dirname)
+        command = project.default_command
+        assert command.supports_http_options is False
+        assert command.unix_shell_commandline is None
+        assert command.windows_cmd_commandline == 'test {{port}}'
+        assert command.conda_app_entry is None
+
+        environ = minimal_environ(PROJECT_DIR=dirname)
+        cmd_exec = command.exec_info_for_environment(
+            environ, extra_args=['--anaconda-project-port', '8888', '--extra-arg-example', 'foo'])
+        if cmd_exec is not None:
+            assert cmd_exec.args == ['test 8888 --extra-arg-example foo']
             assert cmd_exec.shell is True
         else:
             raise SkipTest

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -17,6 +17,7 @@ import sys
 import time
 
 import pytest
+from unittest import SkipTest
 
 from anaconda_project.env_spec import _load_environment_yml
 from anaconda_project import __version__ as version
@@ -1386,7 +1387,7 @@ def test_non_string_as_value_of_shell():
     }, check_shell_non_dict)
 
 
-def test_template_command():
+def test_unix_template_command():
     def check_template_command(dirname):
         project = project_no_dedicated_env(dirname)
         command = project.default_command
@@ -1400,6 +1401,8 @@ def test_template_command():
         if cmd_exec is not None:
             assert cmd_exec.args == ['test 8888']
             assert cmd_exec.shell is True
+        else:
+            raise SkipTest
 
     with_directory_contents_completing_project_file(
         {

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1397,8 +1397,9 @@ def test_template_command():
 
         environ = minimal_environ(PROJECT_DIR=dirname)
         cmd_exec = command.exec_info_for_environment(environ, extra_args=['--anaconda-project-port', '8888'])
-        assert cmd_exec.args == ['test 8888']
-        assert cmd_exec.shell is True
+        if cmd_exec is not None:
+            assert cmd_exec.args == ['test 8888']
+            assert cmd_exec.shell is True
 
     with_directory_contents_completing_project_file(
         {

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1409,6 +1409,7 @@ def test_unix_template_command():
             DEFAULT_PROJECT_FILENAME: "commands:\n default:\n    unix: test {{port}}\n    supports_http_options: false"
         }, check_template_command)
 
+
 def test_windows_template_command():
     def check_template_command(dirname):
         project = project_no_dedicated_env(dirname)
@@ -1426,10 +1427,10 @@ def test_windows_template_command():
         else:
             raise SkipTest
 
-    with_directory_contents_completing_project_file(
-        {
-            DEFAULT_PROJECT_FILENAME: "commands:\n default:\n    windows: test {{port}}\n    supports_http_options: false"
-        }, check_template_command)
+    with_directory_contents_completing_project_file({
+        DEFAULT_PROJECT_FILENAME:
+        "commands:\n default:\n    windows: test {{port}}\n    supports_http_options: false"
+    }, check_template_command)
 
 
 def test_notebook_command():

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1390,7 +1390,7 @@ def test_template_command():
     def check_template_command(dirname):
         project = project_no_dedicated_env(dirname)
         command = project.default_command
-        assert command.supports_http_options == False
+        assert command.supports_http_options is False
         assert command.unix_shell_commandline == 'test {{port}}'
         assert command.windows_cmd_commandline is None
         assert command.conda_app_entry is None

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1409,6 +1409,28 @@ def test_unix_template_command():
             DEFAULT_PROJECT_FILENAME: "commands:\n default:\n    unix: test {{port}}\n    supports_http_options: false"
         }, check_template_command)
 
+def test_windows_template_command():
+    def check_template_command(dirname):
+        project = project_no_dedicated_env(dirname)
+        command = project.default_command
+        assert command.supports_http_options is False
+        assert command.unix_shell_commandline == None
+        assert command.windows_cmd_commandline is 'test {{port}}'
+        assert command.conda_app_entry is None
+
+        environ = minimal_environ(PROJECT_DIR=dirname)
+        cmd_exec = command.exec_info_for_environment(environ, extra_args=['--anaconda-project-port', '8888'])
+        if cmd_exec is not None:
+            assert cmd_exec.args == ['test 8888']
+            assert cmd_exec.shell is True
+        else:
+            raise SkipTest
+
+    with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME: "commands:\n default:\n    windows: test {{port}}\n    supports_http_options: false"
+        }, check_template_command)
+
 
 def test_notebook_command():
     def check_notebook_command(dirname):

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1386,6 +1386,27 @@ def test_non_string_as_value_of_shell():
     }, check_shell_non_dict)
 
 
+def test_template_command():
+    def check_template_command(dirname):
+        project = project_no_dedicated_env(dirname)
+        command = project.default_command
+        assert command.supports_http_options == False
+        assert command.unix_shell_commandline == 'test {{port}}'
+        assert command.windows_cmd_commandline is None
+        assert command.conda_app_entry is None
+
+        environ = minimal_environ(PROJECT_DIR=dirname)
+        cmd_exec = command.exec_info_for_environment(environ,
+                                extra_args=['--anaconda-project-port', '8888'])
+        assert cmd_exec.args == ['test 8888']
+        assert cmd_exec.shell is True
+
+    with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME: "commands:\n default:\n    unix: test {{port}}\n    supports_http_options: false"
+        }, check_template_command)
+
+
 def test_notebook_command():
     def check_notebook_command(dirname):
         project = project_no_dedicated_env(dirname)

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1396,8 +1396,7 @@ def test_template_command():
         assert command.conda_app_entry is None
 
         environ = minimal_environ(PROJECT_DIR=dirname)
-        cmd_exec = command.exec_info_for_environment(environ,
-                                extra_args=['--anaconda-project-port', '8888'])
+        cmd_exec = command.exec_info_for_environment(environ, extra_args=['--anaconda-project-port', '8888'])
         assert cmd_exec.args == ['test 8888']
         assert cmd_exec.shell is True
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   # and the user has the necessary permissions to make environment changes. In a CI
   # environment these are not necessary and slow things down noticeably on Windows.
   - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no --set safety_checks disabled
-  - conda install -q conda=4.6 conda-build conda-verify
+  - conda install -q conda=4.6 conda-build=3.18.10 conda-verify
   - conda info -a
 
 # Not a .NET project, we build in the install step instead

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,17 +19,32 @@ environment:
     - PYTHON_VERSION: 2.7
 
 install:
-  # conda 4.5.11 seems to expect that this directory exists already
-  - call %MINICONDA%\Scripts\activate.bat
-  # The safety checks are simply intended to ensure that there is enough disk space
-  # and the user has the necessary permissions to make environment changes. In a CI
-  # environment these are not necessary and slow things down noticeably on Windows.
-  - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no --set safety_checks disabled
-  - conda install -q conda=4.6 conda-build=3.18.10 conda-verify
-  - conda info -a
+  - appveyor DownloadFile https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-win-64.exe -FileName loner_conda.exe
+  - set "CONDA_PKGS_DIRS=C:\condacache\pkgs"
+  - set "CONDA_ALWAYS_YES=true"
+  - set "CONDA_AUTO_UPDATE_CONDA=false"
+  - if "%CONDA_CANARY%" == "" (
+      loner_conda.exe create -q -p C:\test_conda python=%PYTHON_VERSION% conda=%CONDA_VERSION%
+      ) else (
+      loner_conda.exe create -q -p C:\test_conda -c conda-canary conda python=%PYTHON_VERSION%
+      )
+  # Install run dependencies
+  - loner_conda.exe install -q -p C:\test_conda conda-build=3.18.10 conda-verify
+  # so that the tests see the standalone conda that they need
+  - mkdir C:\test_conda\standalone_conda
+  - copy loner_conda.exe C:\test_conda\standalone_conda\conda.exe
+  - call C:\test_conda\Scripts\activate
+  # Install this package
+  - python setup.py develop
+  # Install conda canary before running tests, ensure conda is updated
+  - conda info
+  - conda init
+  - call C:\test_conda\Scripts\activate
+  - conda list
 
 # Not a .NET project, we build in the install step instead
 build: false
 
 test_script:
+  - call C:\test_conda\Scripts\activate
   - conda build conda.recipe --python=%PYTHON_VERSION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,6 @@ environment:
 
 install:
   # conda 4.5.11 seems to expect that this directory exists already
-  - mkdir C:\Users\appveyor\.conda
   - call %MINICONDA%\Scripts\activate.bat
   # The safety checks are simply intended to ensure that there is enough disk space
   # and the user has the necessary permissions to make environment changes. In a CI

--- a/docs/source/user-guide/reference.rst
+++ b/docs/source/user-guide/reference.rst
@@ -63,8 +63,8 @@ The file ``anaconda-project.yml`` tells conda how to run your project:
 
   commands:
     default:
-      unix: "python ${PROJECT_DIR}/analyze.py"
-      windows: "python %PROJECT_DIR%\analyze.py"
+      unix: "python analyze.py"
+      windows: "python analyze.py"
 
 There are separate command lines for Unix shells (Linux and
 macOS) and for Windows. You may target only one platform, and
@@ -137,8 +137,8 @@ add a ``description:`` field in ``anaconda-project.yml``, like this:
 
   commands:
     mycommand:
-      unix: "python ${PROJECT_DIR}/analyze.py"
-      windows: "python %PROJECT_DIR%\analyze.py"
+      unix: "python analyze.py"
+      windows: "python analyze.py"
       description: "This command runs the analysis"
 
 Special command types

--- a/docs/source/user-guide/tasks/work-with-variables.rst
+++ b/docs/source/user-guide/tasks/work-with-variables.rst
@@ -84,6 +84,10 @@ The first time a user runs your project, they are prompted to
 provide a value for your custom variable. On subsequent runs,
 the user will not be prompted.
 
+All environment variables are available for `jinja2
+<https://jinja.palletsprojects.com/>`_ templating as shown
+in the :ref:`http-commands` section.
+
 
 .. _encrypted-vars:
 


### PR DESCRIPTION
The primary goal of this PR is to highlight some pain points in the current design of `anaconda-project` and to propose one approach that makes anaconda-project more flexible for users and easier to maintain for maintainers (with an example of solving a concrete problem).

## The problem

Currently anaconda-project supports three types of command: `unix`, `notebook` and `bokeh`. The `unix` command is the simplest of these, allowing any command to be run based on the string in the `anaconda-project.yml`. If any extra arguments are supplied to `anaconda-project run <command>`, these are simply appended to the command.

The `bokeh` and `notebook` commands are aimed to make two particular use cases easier. These commands run servers that need extra information (e.g allowed ports) in order to work correctly across environments. If `supports_http_options` is `True`, these commands convert additional arguments (namely ``-anaconda-project-host'``, ``--anaconda-project-address``, ``--anaconda-project-port``, ``--anaconda-project-url-prefix``, ``--anaconda-project-no-browser``, ``--anaconda-project-iframe-hosts`` and ``--anaconda-project-use-xheaders``) into the appropriate format needed to run the bokeh or notebook server respectively.

Unfortunately, this approach of explicitly supporting different types of tool in `anaconda-project` itself is not maintainable long term. For instance, the `bokeh` command only works for fairly old versions of Bokeh (around 0.6.7?) as the command-line interface for specifying these options has since changed. Even if the `_BokehArgsTransformer` class were updated accordingly to work with recent versions of Bokeh, then older versions of bokeh would no longer be supported as a result. For general support across versions, each version of each command line interface for each supported tool (i.e `notebook` and `bokeh`) would need to have its own unique command name for use in `anaconda-project.yml`.

Right now, there are several ways you can hope to tackle this problem:

1. Add a command for each command-line interface. This seems quite unwieldy and each time a command-line interface changes (or a new type of command is added), users need to wait for a new `anaconda-project` release to be available and installed in all contexts where it needs to be used. It is also a burden for the maintainers of `anaconda-project` to support all the various tools.

2. Assume that the tools themselves will support the arguments supplied by `anaconda-project`. This is how support for older versions of Bokeh operated but in general it is unlikely that external projects will decide to support the necessary flags. As a concrete example, running a [voila](https://github.com/voila-dashboards/voila) server requires the extra HTTP options, but instead of ``--anaconda-project-port``, the required argument is ``--port``. It is unlikely that `voila` will ever support ``--anaconda-project-port``, directly.

3. Use a wrapper script or a command-line trick to munge the arguments into the required format. The appeal of this approach is that users can use this workaround at any time without waiting for any software to be released. Writing a wrapper script is annoying, especially as it means including an extra file in the project to supply the extra level of indirection needed.

   An example of using a special `unix` command can be seen in [this project running voila server](https://examples.pyviz.org/voila_gpx_viewer/voila_gpx_viewer.html). To get this working, I had to develop a rather ugly and fragile `awk` command:
```
commands:
  dashboard:
    unix: awk 'BEGIN{gsub("--anaconda-project-port", "--port ", ARGV[3]); gsub("--anaconda-project-address",
      " --Voila.ip=",ARGV[9]); system("voila " ARGV[3] ARGV[4] ARGV[9] ARGV[10] "
      voila_gpx_viewer.ipynb" )}'
    supports_http_options: true
```

   This command is fragile because it depends on the order of the ``--anaconda-project-X`` arguments and using awk like this is not user friendly. That said, this option is currently the best one as it doesn't require any changes in `voila` or `anaconda-project` and works whether the extra arguments are supplied or not (i.e `anaconda project run dashboard` works fine locally).

## Proposed solution

This PR proposes that the `unix` command support a templating mechanism allowing users to control how their commands are invoked in a flexible way. Initially I considered simple Python format strings for templating but then decided that `jinja2` support would make the templating approach a lot more powerful, primarily because jinja2 supports default values. Templating would help avoid problems 1 and 2 above by formalizing a more user friendly way to take the approach in option 3.

`jinja2` is an obvious choice  as it is probably the most common templating language used in Python (it is already used in parts of the `conda` ecosystem; e.g you can use `jinja2` templating in `conda-build`). Using an existing templating language that is well tested and documented seems to be a much more maintainable approach than inventing a new DSL.

The simplest equivalent to the `awk` command above in `jinja2` would be:

```
commands:
  dashboard:
    unix: voila --port {{anaconda_project_port}} --Voila.ip={{anaconda_project_address}}
```

This is not *quite* as good as the `awk` command in one respect: if you don't supply any arguments (e.g `anaconda run dashboard`), the `--port` and `--Volia.ip` flags will be missing their values. This can be addressed using `jinja2` defaults. You could specify something a little more sophisticated to handle this problem:

```
commands:
  dashboard:
    unix: voila --port {{anaconda_project_port|default(8890)}} --Voila.ip={{anaconda_project_address|default('localhost')}}
```
This is still a lot nicer than the `awk` command and explicit defaults are quite nice for reproducibility (e.g. this allows you to know which default settings are actually being used locally from the `anaconda-project.yml`).

## Approach

This PR supports the `jinja2` examples above but there are a few things that need to be considered carefully:

92d34a6:  In this commit, the existing parsing of the HTTP options (`HTTP_SPECS`) is used so that only these specific arguments can be templated in. Templating currently only occurs for `unix` commands when `supports_http_options` is False. 

   Note that when templating is used, the information is no longer passed to the commands in the form of  flags (it is up to the user to use the information made available in the template if and as they wish).

 A small amount of logic is needed to turn the flags into valid Python identifiers for `jinja2` (removing the `--` prefix and turning dashes into underscores). The HTTP option switches are supported with
``--anaconda-project-no-browser`` and ``--anaconda-project-iframe-hosts`` getting assigned the value of `True` if present (i.e. treated as a boolean flags that can only be True).

d769ead: In this commit unrecognized extra arguments are also made available for templating. Right now the parsing approach is *extremely* simplistic: once the HTTP options are removed, the remaining arguments are expected to come in `--flag value` pairs (i.e. these become `key:value` pairs for templating). These arbitrary flags then become the corresponding identifiers available for `jinja2` templating. Unknown switches (e.g ``--foo`` by itself) are currently not supported.

## Other things you can do with `jinja2` templating

Substitution and default values have already been demonstrated above. Two other use cases I have thought about are:

*Switches*: You can transform the HTTP switches into other switches with something like `{% if anaconda_project_use_xheaders %} --xheaders {% endif %}`

*Inverted switches*: In Bokeh, instead of the `--no-browser` switch, you have the inverse concept , namely `--show`. You can automatically add ``--show`` if the ``--no-browser`` switch is **not** present with something like  `{% if anaconda_project_no_browser is not defined %} --show {% endif %}`

## Future ideas and other considerations

Obviously, if we take this approach, `jinja2` will become a dependency of `anaconda-project`. The PR hasn't yet done anything to reflect this so `jinja2` will need to be installed if you wish to test this PR.

Some other thoughts:

* In future, we might want to supply the template information in alternative formats, such as a JSON dictionary.

* The parsing of the unknown argument flags is currently very simple and does not try to guard against various types of user error. Only flags using a `--` prefix are supported. Having support only for the HTTP option switches is somewhat annoying.

* Templating is only used when `unix` commands are used and `supports_http_options` is False. I believe that templating could remove the need for the `bokeh` and `notebook` commands and remove the need for `supports_http_options` (if the template doesn't use the HTTP arguments, it doesn't matter if they are always supplied or not).

## Outstanding tasks

- [x] Discussion about this approach and whether we want to continue in this direction.
- [x] Documentation and testing.
- [ ] Improved docstrings
- [x] Improved robustness of parsing if we choose to support arbitrary arguments for templating.