### PR TITLE
Fix prepare action when using global "dependencies:"

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-omit = */test/*,*/windows_cmdline.py
+omit = */test/*,*/windows_cmdline.py,anaconda_project/_version.py
 
 [report]
 precision=2

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -573,7 +573,8 @@ class _ConfigCache(object):
             return self._parse_platforms(problems, project_file, parent_dict)
 
         def _parse_packages(parent_dict):
-            return self._parse_packages(problems, project_file, 'packages', parent_dict)
+            pkg_key = 'dependencies' if project_file.get_value('dependencies') else 'packages'
+            return self._parse_packages(problems, project_file, pkg_key, parent_dict)
 
         (shared_deps, shared_pip_deps) = _parse_packages(project_file.root)
         shared_channels = _parse_channels(project_file.root)

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -573,6 +573,8 @@ class _ConfigCache(object):
             return self._parse_platforms(problems, project_file, parent_dict)
 
         def _parse_packages(parent_dict):
+            # dependencies allows environment.yml-like project files. It is not
+            # expected to have both dependencies and packages
             pkg_key = 'dependencies' if project_file.get_value('dependencies') else 'packages'
             return self._parse_packages(problems, project_file, pkg_key, parent_dict)
 

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -500,6 +500,47 @@ icon: foo.png
         "bar.png": ""
     }, check_set_icon)
 
+def test_get_dependencies_requirements_from_project_file():
+    def check_get_packages(dirname):
+        project = project_no_dedicated_env(dirname)
+        env = project.env_specs['default']
+        assert env.name == 'default'
+        assert ("mtv", "hbo") == env.channels
+        assert ("foo", "hello >= 1.0", "world") == env.conda_packages
+        assert ("pip1", "pip2==1.3", "pip3") == env.pip_packages
+        assert set(["foo", "hello", "world"]) == env.conda_package_names_set
+        assert set(["pip1", "pip2", "pip3"]) == env.pip_package_names_set
+
+        requirements = project.requirements(project.default_env_spec_name)
+
+        # find CondaEnvRequirement
+        conda_env_req = None
+        for r in requirements:
+            if isinstance(r, CondaEnvRequirement):
+                assert conda_env_req is None  # only one
+                conda_env_req = r
+        assert len(conda_env_req.env_specs) == 1
+        assert 'default' in conda_env_req.env_specs
+        assert conda_env_req.env_specs['default'] is env
+
+    with_directory_contents_completing_project_file({
+        DEFAULT_PROJECT_FILENAME:
+        """
+dependencies:
+  - foo
+  - hello >= 1.0
+  - world
+  - pip:
+     - pip1
+     - pip2==1.3
+  - pip:
+     - pip3
+
+channels:
+  - mtv
+  - hbo
+    """
+    }, check_get_packages)
 
 def test_get_package_requirements_from_project_file():
     def check_get_packages(dirname):

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -500,6 +500,7 @@ icon: foo.png
         "bar.png": ""
     }, check_set_icon)
 
+
 def test_get_dependencies_requirements_from_project_file():
     def check_get_packages(dirname):
         project = project_no_dedicated_env(dirname)
@@ -541,6 +542,7 @@ channels:
   - hbo
     """
     }, check_get_packages)
+
 
 def test_get_package_requirements_from_project_file():
     def check_get_packages(dirname):

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ matrix:
 
 environment:
   PYTHONUNBUFFERED: 1
-  COVERAGE_DIR: C:\\Users\\appveyor\\htmlcov
+  COVERAGE_DIR: ""
   MINICONDA: C:\\Miniconda3-x64
   matrix:
     - PYTHON_VERSION: 3.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,18 +19,32 @@ environment:
     - PYTHON_VERSION: 2.7
 
 install:
-  # conda 4.5.11 seems to expect that this directory exists already
-  - mkdir C:\Users\appveyor\.conda
-  - call %MINICONDA%\Scripts\activate.bat
-  # The safety checks are simply intended to ensure that there is enough disk space
-  # and the user has the necessary permissions to make environment changes. In a CI
-  # environment these are not necessary and slow things down noticeably on Windows.
-  - conda config --set always_yes yes --set changeps1 no --set auto_update_conda no --set safety_checks disabled
-  - conda install -q conda=4.6 conda-build conda-verify
-  - conda info -a
+  - appveyor DownloadFile https://repo.anaconda.com/pkgs/misc/conda-execs/conda-latest-win-64.exe -FileName loner_conda.exe
+  - set "CONDA_PKGS_DIRS=C:\condacache\pkgs"
+  - set "CONDA_ALWAYS_YES=true"
+  - set "CONDA_AUTO_UPDATE_CONDA=false"
+  - if "%CONDA_CANARY%" == "" (
+      loner_conda.exe create -q -p C:\test_conda python=%PYTHON_VERSION% conda=%CONDA_VERSION%
+      ) else (
+      loner_conda.exe create -q -p C:\test_conda -c conda-canary conda python=%PYTHON_VERSION%
+      )
+  # Install run dependencies
+  - loner_conda.exe install -q -p C:\test_conda conda-build=3.18.10 conda-verify
+  # so that the tests see the standalone conda that they need
+  - mkdir C:\test_conda\standalone_conda
+  - copy loner_conda.exe C:\test_conda\standalone_conda\conda.exe
+  - call C:\test_conda\Scripts\activate
+  # Install this package
+  - python setup.py develop
+  # Install conda canary before running tests, ensure conda is updated
+  - conda info
+  - conda init
+  - call C:\test_conda\Scripts\activate
+  - conda list
 
 # Not a .NET project, we build in the install step instead
 build: false
 
 test_script:
+  - call C:\test_conda\Scripts\activate
   - conda build conda.recipe --python=%PYTHON_VERSION%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ matrix:
 
 environment:
   PYTHONUNBUFFERED: 1
-  COVERAGE_DIR: "C:\Users\appveyor\htmlcov"
+  COVERAGE_DIR: C:\\Users\\appveyor\\htmlcov
   MINICONDA: C:\\Miniconda3-x64
   matrix:
     - PYTHON_VERSION: 3.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ matrix:
 
 environment:
   PYTHONUNBUFFERED: 1
-  COVERAGE_DIR: ""
+  COVERAGE_DIR: "C:\Users\appveyor\htmlcov"
   MINICONDA: C:\\Miniconda3-x64
   matrix:
     - PYTHON_VERSION: 3.7


### PR DESCRIPTION
I caught a problem where running `anaconda-project prepare` on the following spec would install a Python 3.8 environment. This happened because while `dependencies:` was an allowed key it was ignored.

```yaml
name: test-deps

dependencies:
  - python=3.7
channels:
  - defaults

env_specs:
  default: {}
```

This PR also adds a test that will fail on the master branch.