### PR TITLE
fix versioneer tag_prefix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,5 +21,5 @@ VCS = git
 style = pep440
 versionfile_source = anaconda_project/_version.py
 versionfile_build = anaconda_project/_version.py
-tag_prefix =
+tag_prefix = v
 parentdir_prefix = anaconda_project-


### PR DESCRIPTION
I noticed that tags in this repo begin with `'v'` and I guess it should be set as the tag_prefix.