### PR TITLE
Allow environments to be readonly if they have no deviations

### DIFF
--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -187,7 +187,7 @@ class DefaultCondaManager(CondaManager):
                 # file to bump its mtime if it already exists...
                 f.write('{"anaconda_project_version": "%s"}\n' % version)
             return True
-        except (IOError, OSError) as exc:
+        except (IOError, OSError):
             # ignore errors because this is just an optimization, if we
             # fail we will survive
             return False
@@ -365,7 +365,8 @@ class DefaultCondaManager(CondaManager):
             wrong_version_packages=conda_wrong_version,
             missing_pip_packages=pip_missing,
             wrong_version_pip_packages=(),
-            broken=broken, unfixable=unfixable)
+            broken=broken,
+            unfixable=unfixable)
 
     def fix_environment_deviations(self, prefix, spec, deviations=None, create=True):
         if deviations is None:

--- a/anaconda_project/internal/test/test_default_conda_manager.py
+++ b/anaconda_project/internal/test/test_default_conda_manager.py
@@ -243,6 +243,16 @@ def test_conda_create_and_install_and_remove(monkeypatch):
         assert deviations.missing_packages == ()
         assert deviations.wrong_version_packages == ()
 
+        # fix_environment_deviations should be a no-op on readonly envs
+        # with no deviations, in particular the time stamp file should
+        # not be changed and therefore not be up to date
+        is_readonly['readonly'] = True
+        manager.fix_environment_deviations(envdir, spec, deviations)
+        assert not manager._timestamp_file_up_to_date(envdir, spec)
+
+        # when the environment is readwrite, the timestamp file should
+        # be updated
+        is_readonly['readonly'] = False
         manager.fix_environment_deviations(envdir, spec, deviations)
         assert manager._timestamp_file_up_to_date(envdir, spec)
 

--- a/anaconda_project/internal/test/test_default_conda_manager.py
+++ b/anaconda_project/internal/test/test_default_conda_manager.py
@@ -145,10 +145,12 @@ def test_conda_create_and_install_and_remove(monkeypatch):
         manager = DefaultCondaManager(frontend=NullFrontend())
 
         is_readonly = dict(readonly=False)
+
         def mock_open(*args, **kwargs):
             if is_readonly['readonly']:
                 raise IOError("did not open")
             return real_open(*args, **kwargs)
+
         monkeypatch.setattr('codecs.open', mock_open)
 
         assert not os.path.isdir(envdir)


### PR DESCRIPTION
A-P should allow environments to be readonly as long as it does not require any changes to be made. But it expects to be able to write a timestamp file. The authors seemed to have attempted to make it fail silently if the timestamp write fails, but they didn't account for the possibility that creating the directory could fail, too.

We've created a writability test, and mark environments "unfixable" if they have deviations _and_ they are readonly. And we've discarded the requirement that the timestamp write succeeds.