### PR TITLE
Declared jinja2 as a dependency in meta.yml and setup.py

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - requests
     - ruamel_yaml
     - tornado >=4.2
+    - jinja2
 
 test:
   requires:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
     description='Tool for encapsulating, running, and reproducing data science projects',
     long_description=io.open("README.md", 'r', encoding='utf-8').read(),
     zip_safe=False,
-    install_requires=['anaconda-client', 'requests', 'ruamel_yaml', 'tornado>=4.2'],
+    install_requires=['anaconda-client', 'requests', 'ruamel_yaml', 'tornado>=4.2', 'jinja2'],
     entry_points={'console_scripts': [
         'anaconda-project = anaconda_project.cli:main',
     ]},


### PR DESCRIPTION
Title describes the full set of proposed change: `jinja2` is needed for templating introduced in #244. 

In many situations, `jinja2` is an indirect dependency (which is why the Travis and Appveyor tests passed on that PR) but in some situations (e.g `python setup.py develop` in a clean miniconda environment of Windows), `jinja2` will be unavailable. This PR makes `jinja2` an explicit dependency.