### PR TITLE
noarch: python

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   script: pip install . --no-deps --ignore-installed --no-cache-dir
   entry_points:
     - anaconda-project = anaconda_project.cli:main


### PR DESCRIPTION
The recipe on pkgs/main is noarch. Is there a reason for it *not* to be noarch in the repository as well?