### PR TITLE
'default' is an alias for the actual default command

### DIFF
--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -1524,6 +1524,11 @@ class Project(object):
         Returns:
            a ProjectCommand instance or None
         """
+        commands = self._updated_cache().commands
+        has_default = 'default' in commands
+
+        if (command_name == 'default') and (not has_default):
+            command_name = self._updated_cache().default_command_name
         if command_name is None:
             command_name = self._updated_cache().default_command_name
         if command_name is None:


### PR DESCRIPTION
@bkreider 

This allows us to run a default command (name unkonwn at runtime)
and pass arguments

> anaconda-project run default --anaconda-project-port 8086

The anaconda-project.yml file might look like

```yaml
commands:
  dashboard:
    unix: panel serve main.py
    supports_http_options: true
  api:
    unix: tranquilizer api.py
    supports_http_options: true
```

```
anaconda-project run default # runs panel
anaconda-project run         # runs panel
```

Even though there is not a command called "default" using the
command name default will run the first command, dashboard.

If instead a command is called "default" that will always be
as the default whether the name is included or not (this is
the original behavior and is unchanged)

```yaml
commands:
  dashboard:
    unix: panel serve main.py
    supports_http_options: true
  default:
    unix: tranquilizer api.py
    supports_http_options: true
```

```
anaconda-project run default # runs tranquilizer
anaconda-project run         # runs tranquilizer
```