### PR TITLE
[PROPOSAL] conda project cli

### DIFF
--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -39,7 +39,7 @@ import anaconda_project.internal.cli.command_commands as command_commands
 
 
 def _parse_args_and_run_subcommand(argv):
-    parser = ArgumentParser(prog="anaconda-project", description="Actions on projects (runnable projects).")
+    parser = ArgumentParser(prog="conda-project", description="Actions on projects (runnable projects).")
 
     subparsers = parser.add_subparsers(help="Sub-commands")
 
@@ -57,7 +57,7 @@ def _parse_args_and_run_subcommand(argv):
                             metavar='ENVIRONMENT_SPEC_NAME',
                             default=None,
                             action='store',
-                            help="An environment spec name from anaconda-project.yml")
+                            help="An environment spec name from conda-project.yml")
 
     def add_prepare_args(preset, include_command=True):
         add_directory_arg(preset)
@@ -77,7 +77,7 @@ def _parse_args_and_run_subcommand(argv):
                 metavar='COMMAND_NAME',
                 default=None,
                 action='store',
-                help="A command name from anaconda-project.yml (env spec for this command will be used)")
+                help="A command name from conda-project.yml (env spec for this command will be used)")
 
     def add_env_spec_name_arg(preset, required):
         preset.add_argument('-n',
@@ -85,7 +85,7 @@ def _parse_args_and_run_subcommand(argv):
                             metavar='ENVIRONMENT_SPEC_NAME',
                             required=required,
                             action='store',
-                            help="Name of the environment spec from anaconda-project.yml")
+                            help="Name of the environment spec from conda-project.yml")
 
     preset = subparsers.add_parser('init', help="Initialize a directory with default project configuration")
     add_directory_arg(preset)
@@ -102,7 +102,7 @@ def _parse_args_and_run_subcommand(argv):
                         metavar='COMMAND_NAME',
                         default=None,
                         nargs='?',
-                        help="A command name from anaconda-project.yml")
+                        help="A command name from conda-project.yml")
     preset.add_argument('extra_args_for_command', metavar='EXTRA_ARGS_FOR_COMMAND', default=None, nargs=REMAINDER)
     preset.set_defaults(main=run.main)
 
@@ -187,14 +187,14 @@ def _parse_args_and_run_subcommand(argv):
     preset.set_defaults(main=variable_commands.main_list)
 
     preset = subparsers.add_parser('set-variable',
-                                   help="Set an environment variable value in anaconda-project-local.yml")
+                                   help="Set an environment variable value in conda-project-local.yml")
     add_env_spec_arg(preset)
     preset.add_argument('vars_and_values', metavar='VARS_AND_VALUES', default=None, nargs=REMAINDER)
     add_directory_arg(preset)
     preset.set_defaults(main=variable_commands.main_set)
 
     preset = subparsers.add_parser('unset-variable',
-                                   help="Unset an environment variable value from anaconda-project-local.yml")
+                                   help="Unset an environment variable value from conda-project-local.yml")
     add_env_spec_arg(preset)
     add_directory_arg(preset)
     preset.add_argument('vars_to_unset', metavar='VARS_TO_UNSET', default=None, nargs=REMAINDER)
@@ -403,4 +403,4 @@ def main():
     Conda expects us to take no args and return an exit code.
     """
     details = {'version': version}
-    return handle_bugs(_main_without_bug_handler, program_name='anaconda-project', details_dict=details)
+    return handle_bugs(_main_without_bug_handler, program_name='conda-project', details_dict=details)

--- a/anaconda_project/project_file.py
+++ b/anaconda_project/project_file.py
@@ -15,7 +15,9 @@ from anaconda_project.env_spec import EnvSpec
 import anaconda_project.internal.conda_api as conda_api
 
 # these are in the order we'll use them if multiple are present
-possible_project_file_names = ("anaconda-project.yml", "anaconda-project.yaml", "kapsel.yml", "kapsel.yaml")
+possible_project_file_names = ("conda-project.yml", "conda-project.yaml",
+                               "anaconda-project.yml", "anaconda-project.yaml",
+                               "kapsel.yml", "kapsel.yaml")
 
 DEFAULT_PROJECT_FILENAME = possible_project_file_names[0]
 

--- a/anaconda_project/project_file.py
+++ b/anaconda_project/project_file.py
@@ -15,7 +15,8 @@ from anaconda_project.env_spec import EnvSpec
 import anaconda_project.internal.conda_api as conda_api
 
 # these are in the order we'll use them if multiple are present
-possible_project_file_names = ("conda-project.yml", "conda-project.yaml",
+possible_project_file_names = ('project.yml', 'project.yaml',
+                               "conda-project.yml", "conda-project.yaml",
                                "anaconda-project.yml", "anaconda-project.yaml",
                                "kapsel.yml", "kapsel.yaml")
 

--- a/anaconda_project/project_lock_file.py
+++ b/anaconda_project/project_lock_file.py
@@ -13,20 +13,21 @@ import os
 from anaconda_project.yaml_file import YamlFile, _CommentedMap, _block_style_all_nodes
 
 # these are in the order we'll use them if multiple are present
-possible_project_lock_file_names = ("conda-project-lock.yml", "conda-project-lock.yaml",
+possible_project_lock_file_names = ("project-lock.yml", 'project-lock.yaml',
+                                    "conda-project-lock.yml", "conda-project-lock.yaml",
                                     "anaconda-project-lock.yml", "anaconda-project-lock.yaml")
 
 DEFAULT_PROJECT_LOCK_FILENAME = possible_project_lock_file_names[0]
 
 
 class ProjectLockFile(YamlFile):
-    """Represents the ``anaconda-project-lock.yml`` file which describes locked package versions."""
+    """Represents the ``project-lock.yml`` file which describes locked package versions."""
 
     template = '''
-# This is an Anaconda project lock file.
+# This is a Conda project lock file.
 # The lock file locks down exact versions of all your dependencies.
 #
-# In most cases, this file is automatically maintained by the `anaconda-project` command or GUI tools.
+# In most cases, this file is automatically maintained by the `conda-project` command or GUI tools.
 # It's best to keep this file in revision control (such as git or svn).
 # The file is in YAML format, please see http://www.yaml.org/start.html for more.
 #

--- a/anaconda_project/project_lock_file.py
+++ b/anaconda_project/project_lock_file.py
@@ -13,7 +13,8 @@ import os
 from anaconda_project.yaml_file import YamlFile, _CommentedMap, _block_style_all_nodes
 
 # these are in the order we'll use them if multiple are present
-possible_project_lock_file_names = ("anaconda-project-lock.yml", "anaconda-project-lock.yaml")
+possible_project_lock_file_names = ("conda-project-lock.yml", "conda-project-lock.yaml",
+                                    "anaconda-project-lock.yml", "anaconda-project-lock.yaml")
 
 DEFAULT_PROJECT_LOCK_FILENAME = possible_project_lock_file_names[0]
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set data = load_setup_py_data() %}
 
 package:
-  name: anaconda-project
+  name: conda-project
   version: {{ data.get('version') }}
 
 source:
@@ -12,7 +12,7 @@ build:
   noarch: python
   script: pip install . --no-deps --ignore-installed --no-cache-dir
   entry_points:
-    - anaconda-project = anaconda_project.cli:main
+    - conda-project = anaconda_project.cli:main
   script_env:
     - COVERAGE_DIR
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import versioneer
 import io
 
 setuptools.setup(
-    name='anaconda-project',
+    name='conda-project',
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     keywords=["conda anaconda project reproducible data science"],
@@ -26,7 +26,7 @@ setuptools.setup(
     zip_safe=False,
     install_requires=['anaconda-client', 'requests', 'ruamel_yaml', 'tornado>=4.2', 'jinja2'],
     entry_points={'console_scripts': [
-        'anaconda-project = anaconda_project.cli:main',
+        'conda-project = anaconda_project.cli:main',
     ]},
     packages=setuptools.find_packages(exclude=['contrib', 'docs', 'tests*']),
     include_package_data=True,


### PR DESCRIPTION
This is meant to demonstrate and seek feedback for `conda project` with minimal changes.

* anaconda-project entry point renamed to conda-project
    * conda searches for `conda-*` executables in the PATH to enable `conda project`
    * `conda --help` will display commands from other projects installed into the base env

* `conda-project.yml` is preferred but `anaconda-project.yml` is still supported

* cli help updated to reflect `conda-project`

* conda recipe updated to build `conda-project` as the package name