### PR TITLE
Add command specific variables and define variable priority order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ htmlcov
 /examples/movies/movies.db
 *.orig
 CHANGELOG.temp
+
+examples/*/envs

--- a/anaconda_project/internal/cli/test/test_prepare.py
+++ b/anaconda_project/internal/cli/test/test_prepare.py
@@ -258,6 +258,45 @@ env_specs:
     assert err == ""
 
 
+def test_prepare_command_default_environment_refresh(capsys, monkeypatch):
+    def mock_conda_create(prefix, pkgs, channels, stdout_callback, stderr_callback):
+        from anaconda_project.internal.makedirs import makedirs_ok_if_exists
+        metadir = os.path.join(prefix, "conda-meta")
+        makedirs_ok_if_exists(metadir)
+        for p in pkgs:
+            pkgmeta = os.path.join(metadir, "%s-0.1-pyNN.json" % p)
+            open(pkgmeta, 'a').close()
+
+    monkeypatch.setattr('anaconda_project.internal.conda_api.create', mock_conda_create)
+
+    def check_prepare_choose_environment(dirname):
+        default_envdir = os.path.join(dirname, "envs", "default")
+        result = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'prepare', '--directory', dirname, '--env-spec', 'default'])
+        assert result == 0
+
+        result = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'prepare', '--directory', dirname, '--env-spec', 'default', '--refresh'])
+        assert result == 0
+
+        assert os.path.isdir(default_envdir)
+
+        foo_package_json = os.path.join(default_envdir, "conda-meta", "nonexistent_foo-0.1-pyNN.json")
+        assert os.path.isfile(foo_package_json)
+
+    with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: """
+packages:
+    - nonexistent_foo
+"""}, check_prepare_choose_environment)
+
+    out, err = capsys.readouterr()
+    assert out == ("The project is ready to run commands.\n" +
+                   "Use `anaconda-project list-commands` to see what's available.\n" +
+                   "The project is ready to run commands.\n" +
+                   "Use `anaconda-project list-commands` to see what's available.\n")
+    assert err == ""
+
+
 def test_prepare_command_choose_environment_does_not_exist(capsys):
     def check_prepare_choose_environment_does_not_exist(dirname):
         project_dir_disable_dedicated_env(dirname)

--- a/anaconda_project/internal/cli/test/test_run.py
+++ b/anaconda_project/internal/cli/test/test_run.py
@@ -335,7 +335,10 @@ def test_run_command_verbose(monkeypatch, capsys):
 
         # conda info is cached so may not be here depending on
         # which other tests run
-        log_lines = ["$ conda info --json", "$ %s --version" % executed['args'][0]]
+        log_lines = [
+            "$ %s info --json" % executed['env']['CONDA_EXE'],
+            "$ %s env config vars list -p %s --json" % (executed['env']['CONDA_EXE'], executed['env']['CONDA_PREFIX']),
+            "$ %s --version" % executed['args'][0]]
         log_lines_without_conda_info = log_lines[1:]
 
         def nl(lines):

--- a/anaconda_project/internal/cli/test/test_run.py
+++ b/anaconda_project/internal/cli/test/test_run.py
@@ -338,7 +338,8 @@ def test_run_command_verbose(monkeypatch, capsys):
         log_lines = [
             "$ %s info --json" % executed['env']['CONDA_EXE'],
             "$ %s env config vars list -p %s --json" % (executed['env']['CONDA_EXE'], executed['env']['CONDA_PREFIX']),
-            "$ %s --version" % executed['args'][0]]
+            "$ %s --version" % executed['args'][0]
+        ]
         log_lines_without_conda_info = log_lines[1:]
 
         def nl(lines):
@@ -607,3 +608,236 @@ commands:
     conda_app_entry: python --version bar
 """
         }, check_run_main)
+
+
+def _test_run_with_env_vars(command_line, monkeypatch, capsys, file_assertion=_is_python_exe):
+    executed = {}
+
+    def mock_execvpe(file, args, env):
+        executed['file'] = file
+        executed['args'] = args
+        executed['env'] = env
+
+    monkeypatch.setattr('os.execvpe', mock_execvpe)
+
+    def check_run_main(dirname):
+        from os.path import abspath as real_abspath
+
+        def mock_abspath(path):
+            if path == ".":
+                return dirname
+            else:
+                return real_abspath(path)
+
+        monkeypatch.setattr('os.path.abspath', mock_abspath)
+
+        project_dir_disable_dedicated_env(dirname)
+
+        for n, i in enumerate(command_line):
+            if i == '<DIRNAME>':
+                command_line[n] = dirname
+
+        result = _parse_args_and_run_subcommand(command_line)
+
+        assert 1 == result
+        assert 'file' in executed
+        assert 'args' in executed
+        assert 'env' in executed
+        file_assertion(executed['file'])
+
+        out, err = capsys.readouterr()
+        assert "" == out
+        assert "" == err
+
+        return executed['env']
+
+    return with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME:
+            """
+variables:
+  MY_VARIABLE: "project"
+commands:
+  default:
+    conda_app_entry: python --version
+  foo:
+    variables:
+      MY_VARIABLE: "command"
+    conda_app_entry: python --version foo
+  bar:
+    conda_app_entry: python --version bar
+"""
+        }, check_run_main)
+
+
+def test_run_command_vars_project(monkeypatch, capsys):
+    env = _test_run_with_env_vars(['anaconda-project', 'run', '--directory', '<DIRNAME>', 'default'], monkeypatch,
+                                  capsys)
+    assert "MY_VARIABLE" in env
+    assert env['MY_VARIABLE'] == 'project'
+
+
+def test_run_command_vars_command_override_project(monkeypatch, capsys):
+    env = _test_run_with_env_vars(['anaconda-project', 'run', '--directory', '<DIRNAME>', 'foo'], monkeypatch, capsys)
+    assert "MY_VARIABLE" in env
+    assert env['MY_VARIABLE'] == 'command'
+
+
+def _test_run_with_conda_vars(command_line, monkeypatch, capsys, file_assertion=_is_python_exe, conda_env_var=False):
+    executed = {}
+
+    def mock_get_env_vars(prefix):
+        return {'MY_VARIABLE': 'conda'}
+
+    def mock_execvpe(file, args, env):
+        executed['file'] = file
+        executed['args'] = args
+        executed['env'] = env
+
+    mock_environ = deepcopy(os.environ)
+    mock_environ['CONDA_PREFIX'] = os.environ['CONDA_PREFIX']
+
+    monkeypatch.setattr('os.environ', mock_environ)
+    monkeypatch.setattr('anaconda_project.internal.conda_api.get_env_vars', mock_get_env_vars)
+    monkeypatch.setattr('os.execvpe', mock_execvpe)
+
+    def check_run_main(dirname):
+        from os.path import abspath as real_abspath
+
+        def mock_abspath(path):
+            if path == ".":
+                return dirname
+            else:
+                return real_abspath(path)
+
+        monkeypatch.setattr('os.path.abspath', mock_abspath)
+
+        project_dir_disable_dedicated_env(dirname)
+
+        for n, i in enumerate(command_line):
+            if i == '<DIRNAME>':
+                command_line[n] = dirname
+
+        result = _parse_args_and_run_subcommand(command_line)
+
+        assert 1 == result
+        assert 'file' in executed
+        assert 'args' in executed
+        assert 'env' in executed
+        file_assertion(executed['file'])
+
+        out, err = capsys.readouterr()
+        assert "" == out
+        assert "" == err
+
+        return executed['env']
+
+    return with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME:
+            """
+commands:
+  default:
+    conda_app_entry: python --version
+  foo:
+    variables:
+      MY_VARIABLE: "command"
+    conda_app_entry: python --version foo
+  bar:
+    conda_app_entry: python --version bar
+"""
+        }, check_run_main)
+
+
+def test_run_command_vars_conda(monkeypatch, capsys):
+    env = _test_run_with_conda_vars(['anaconda-project', 'run', '--directory', '<DIRNAME>', 'default'], monkeypatch,
+                                    capsys)
+    assert "MY_VARIABLE" in env
+    assert env['MY_VARIABLE'] == 'conda'
+
+
+def test_run_command_vars_cmd_override_conda(monkeypatch, capsys):
+    env = _test_run_with_conda_vars(['anaconda-project', 'run', '--directory', '<DIRNAME>', 'foo'], monkeypatch, capsys)
+    assert "MY_VARIABLE" in env
+    assert env['MY_VARIABLE'] == 'command'
+
+
+def _test_run_with_environ_vars(command_line, monkeypatch, capsys, file_assertion=_is_python_exe, conda_env_var=False):
+    executed = {}
+
+    def mock_get_env_vars(prefix):
+        return {'MY_VARIABLE': 'conda'}
+
+    def mock_execvpe(file, args, env):
+        executed['file'] = file
+        executed['args'] = args
+        executed['env'] = env
+
+    mock_environ = deepcopy(os.environ)
+    mock_environ['CONDA_PREFIX'] = os.environ['CONDA_PREFIX']
+    mock_environ['MY_VARIABLE'] = 'environ'
+
+    monkeypatch.setattr('os.environ', mock_environ)
+    monkeypatch.setattr('anaconda_project.internal.conda_api.get_env_vars', mock_get_env_vars)
+    monkeypatch.setattr('os.execvpe', mock_execvpe)
+
+    def check_run_main(dirname):
+        from os.path import abspath as real_abspath
+
+        def mock_abspath(path):
+            if path == ".":
+                return dirname
+            else:
+                return real_abspath(path)
+
+        monkeypatch.setattr('os.path.abspath', mock_abspath)
+
+        project_dir_disable_dedicated_env(dirname)
+
+        for n, i in enumerate(command_line):
+            if i == '<DIRNAME>':
+                command_line[n] = dirname
+
+        result = _parse_args_and_run_subcommand(command_line)
+
+        assert 1 == result
+        assert 'file' in executed
+        assert 'args' in executed
+        assert 'env' in executed
+        file_assertion(executed['file'])
+
+        out, err = capsys.readouterr()
+        assert "" == out
+        assert "" == err
+
+        return executed['env']
+
+    return with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME:
+            """
+commands:
+  default:
+    conda_app_entry: python --version
+  foo:
+    variables:
+      MY_VARIABLE: "command"
+    conda_app_entry: python --version foo
+  bar:
+    conda_app_entry: python --version bar
+"""
+        }, check_run_main)
+
+
+def test_run_command_vars_environ(monkeypatch, capsys):
+    env = _test_run_with_environ_vars(['anaconda-project', 'run', '--directory', '<DIRNAME>', 'default'], monkeypatch,
+                                      capsys)
+    assert "MY_VARIABLE" in env
+    assert env['MY_VARIABLE'] == 'environ'
+
+
+def test_run_command_vars_environ_override_cmd(monkeypatch, capsys):
+    env = _test_run_with_environ_vars(['anaconda-project', 'run', '--directory', '<DIRNAME>', 'foo'], monkeypatch,
+                                      capsys)
+    assert "MY_VARIABLE" in env
+    assert env['MY_VARIABLE'] == 'environ'

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -189,7 +189,8 @@ def get_env_vars(env_prefix):
     """Return a dictionary of environment variables.
 
     These are Conda Environment variables that have been
-    set using `conda env config vars`."""
+    set using `conda env config vars`.
+    """
 
     return _call_and_parse_json(['env', 'config', 'vars', 'list', '-p', env_prefix, '--json'])
 

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -185,6 +185,15 @@ def info(platform=None):
     return _call_and_parse_json(['info', '--json'], platform=platform)
 
 
+def get_env_vars(env_prefix):
+    """Return a dictionary of environment variables.
+
+    These are Conda Environment variables that have been
+    set using `conda env config vars`."""
+
+    return _call_and_parse_json(['env', 'config', 'vars', 'list', '-p', env_prefix, '--json'])
+
+
 def resolve_env_to_prefix(name_or_prefix):
     """Convert an env name or path into a canonical prefix path.
 

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -192,7 +192,14 @@ def get_env_vars(env_prefix):
     set using `conda env config vars`.
     """
 
-    return _call_and_parse_json(['env', 'config', 'vars', 'list', '-p', env_prefix, '--json'])
+    try:
+        return _call_and_parse_json(['env', 'config', 'vars', 'list', '-p', env_prefix, '--json'])
+    except CondaError as e:
+        # conda env config was introduced in version 4.8
+        if 'invalid choice' not in str(e).lower():
+            raise
+        else:
+            return {}
 
 
 def resolve_env_to_prefix(name_or_prefix):

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -290,14 +290,16 @@ class CommandExecInfo(object):
             Does not return. May raise an OSError though.
         """
 
-        # make sure to add any Conda Environment variables to the environ
-        conda_env_vars = conda_api.get_env_vars(self.env['CONDA_PREFIX'])
-        for k, v in conda_env_vars.items():
-            # by only updating non-existant variables
-            # the variables in anaconda-project.yml take
-            # precedence over any that were set in the env itself.
-            if k not in self.env:
-                self.env[k] = v
+        conda_prefix = self.env.get('CONDA_PREFIX', False)
+        if conda_prefix:
+            # make sure to add any Conda Environment variables to the environ
+            conda_env_vars = conda_api.get_env_vars(self.env['CONDA_PREFIX'])
+            for k, v in conda_env_vars.items():
+                # by only updating non-existant variables
+                # the variables in anaconda-project.yml take
+                # precedence over any that were set in the env itself.
+                if k not in self.env:
+                    self.env[k] = v
 
         args = copy(self._args)
         if self._shell:

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -293,7 +293,7 @@ class CommandExecInfo(object):
         conda_prefix = self.env.get('CONDA_PREFIX', False)
         if conda_prefix:
             # make sure to add any Conda Environment variables to the environ
-            conda_env_vars = conda_api.get_env_vars(self.env['CONDA_PREFIX'])
+            conda_env_vars = conda_api.get_env_vars(conda_prefix)
             for k, v in conda_env_vars.items():
                 # by only updating non-existant variables
                 # the variables in anaconda-project.yml take

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -289,6 +289,15 @@ class CommandExecInfo(object):
         Returns:
             Does not return. May raise an OSError though.
         """
+        # make sure to add any Conda Environment variables to the environ
+        extra_variables = conda_api.get_env_vars(self._env['CONDA_PREFIX'])
+        for k, v in extra_variables.items():
+            # by only updating non-existant variables
+            # the variables in anaconda-project.yml take
+            # precedence over any that were set in the env itself.
+            if k not in self._env:
+                self._env[k] = v
+
         args = copy(self._args)
         if self._shell:
             assert len(args) == 1
@@ -522,6 +531,7 @@ class ProjectCommand(object):
         Returns:
             argv as list of strings
         """
+        print('where am i?')
         conda_var = conda_api.conda_prefix_variable()
         for name in (conda_var, 'PATH', 'PROJECT_DIR'):
             if name not in environ:

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -5008,6 +5008,19 @@ def test_download(monkeypatch):
         }, check)
 
 
+def test_download_unpack(monkeypatch):
+    def check(dirname):
+        with fake_server(monkeypatch, expected_basename='fake_project.zip'):
+            status = project_ops.download('fake_username/fake_project', unpack=True, site='unit_test')
+            assert status
+
+    with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME: "name: foo\n",
+            "foo.py": "print('hello')\n"
+        }, check)
+
+
 def test_download_missing(monkeypatch):
     def check(dirname):
         with fake_server(monkeypatch, expected_basename='fake_project.zip'):

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,3 +22,13 @@ versionfile_source = anaconda_project/_version.py
 versionfile_build = anaconda_project/_version.py
 tag_prefix = v
 parentdir_prefix = anaconda_project-
+
+[tool:pytest]
+norecursedirs= .* *.egg* build bin dist conda.recipe scripts examples
+addopts =
+    -vrfe
+    --durations=10
+    --cov-config=.coveragerc
+    --cov-report=xml:cov.xml
+    --cov-report=term-missing
+    --cov=anaconda_project


### PR DESCRIPTION
There are now 5 places where environment variables can be set for use in `anaconda-project run`. The order listed here is highest priority first, meaning that variables set in any location override the same variable name if exists lower on the list. 

1. Command line invocation
    `MY_VAR='on cli' anaconda-project run`
1. Shell export

    ```
    MY_VAR='exported'
   anaconda-project run
    ```


1. Set within the `anaconda-project.yml` file defined for the command to be run

    ```yaml
    name: project-with-vars
    packages:
      - python=3.7
    commands:
      default:
        variables:
          MY_VAR: 'default command'
        unix: env | grep MY_VAR
    ```

1. Set within the `anaconda-project.yml` at the top level

    ```yaml
    name: project-with-vars
    packages:
      - python=3.7
    variables:
        MY_VAR: 'project'
    commands:
      default:
        unix: env | grep MY_VAR
    ```

1. Within the Conda environment after running `anaconda-project prepare`
    * Using [`conda env config vars`](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#setting-environment-variables) or through https://github.com/conda/conda/pull/10169 coupled with #275 


## Variable priority examples

The examples here are presented in reverse order from above to demonstrate the override. Each example builds from the previous state.

### Conda env config vars

```yaml
name: vars

packages:
- python=3.7
channels:
- defaults

commands:
  default:
    unix: env | grep MY_VARIABLE
```

```
> anaconda-project prepare
> conda env config vars set MY_VARIABLE='set in conda-meta/state' -p ./envs/default
> anaconda-project run default
MY_VARIABLE=set in conda-meta/state
```

### Top-level project key

Adding `variables` to the project file overrides the Conda env.

```yaml
name: vars

packages:
- python=3.7
channels:
- defaults

variables:
  MY_VARIABLE: 'set in project'

commands:
  default:
    unix: env | grep MY_VARIABLE
```

```
> anaconda-project run default
MY_VARIABLE=set in project
```

### Command-specific variable

```yaml
name: vars

packages:
- python=3.7
channels:
- defaults

variables:
  MY_VARIABLE: 'set in project'

commands:
  default:
    unix: env | grep MY_VARIABLE
  cmd:
    unix: env | grep MY_VARIABLE
    variables:
      MY_VARIABLE: 'set in command: cmd'
```

```
> anaconda-project run default
MY_VARIABLE=set in project
> anaconda-project run cmd
MY_VARIABLE=set in command: cmd
```

### Exported in shell

```
> export MY_VARIABLE='exported'
> anaconda-project run default
MY_VARIABLE=exported
> anaconda-project run cmd
MY_VARIABLE=exported
```

### Set on shell command

```
> MY_VARIABLE='on shell cmd' anaconda-project run default
MY_VARIABLE=on shell cmd
>MY_VARIABLE='on shell cmd' anaconda-project run cmd
MY_VARIABLE=on shell cmd
```