### PR TITLE
Allow multiple environment path directories

### DIFF
--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -310,7 +310,7 @@ class EnvSpec(object):
     def path(self, project_dir):
         """The filesystem path to the default conda env containing our packages."""
         if self._path is None:
-            for base in os.environ.get('ANACONDA_PROJECT_ENVS_PATH', '').split(':'):
+            for base in os.environ.get('ANACONDA_PROJECT_ENVS_PATH', '').split(os.pathsep):
                 path = os.path.abspath(os.path.join(project_dir, base or "envs", self.name))
                 found = os.path.isdir(os.path.join(path, 'conda-meta'))
                 if found or self._path is None:

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -308,9 +308,14 @@ class EnvSpec(object):
 
     def path(self, project_dir):
         """The filesystem path to the default conda env containing our packages."""
-        envs_path = os.environ.get('ANACONDA_PROJECT_ENVS_PATH', os.path.join(project_dir, "envs"))
-
-        return os.path.join(envs_path, self.name)
+        paths = os.environ.get('ANACONDA_PROJECT_ENVS_PATH', '').split(':')
+        paths = [path or os.path.join(project_dir, "envs") for path in paths]
+        for path in paths:
+            if os.path.isdir(os.path.join(path, 'conda-meta')):
+                break
+        else:
+            path = paths[0]
+        return os.path.join(path, self.name)
 
     def diff_from(self, old):
         """A string showing the comparison between this env spec and another one."""

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -311,7 +311,8 @@ class EnvSpec(object):
         """The filesystem path to the default conda env containing our packages."""
         if self._path is None:
             for base in os.environ.get('ANACONDA_PROJECT_ENVS_PATH', '').split(os.pathsep):
-                path = os.path.abspath(os.path.join(project_dir, base or "envs", self.name))
+                base = os.path.expanduser(base) if base else 'envs'
+                path = os.path.abspath(os.path.join(project_dir, base, self.name))
                 found = os.path.isdir(os.path.join(path, 'conda-meta'))
                 if found or self._path is None:
                     self._path = path

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -1648,14 +1648,15 @@ def clean(project, prepare_result):
 
     # Clean up the environments only if they are inside the project
     our_root = project.directory_path
-    for path in os.environ.get('ANACONDA_PROJECT_ENVS_PATH', '').split(os.pathsep):
-        apath = os.path.abspath(os.path.join(our_root, path or "envs"))
+    for base in os.environ.get('ANACONDA_PROJECT_ENVS_PATH', '').split(os.pathsep):
+        base = os.path.expanduser(base) if base else 'envs'
+        apath = os.path.abspath(os.path.join(our_root, base))
         if apath == our_root:
             errors.append('Not removing the project directory itself.')
         elif apath.startswith(our_root + os.sep):
             cleanup_dir(apath)
         else:
-            errors.append('Not removing external environment directory: %s' % path)
+            errors.append('Not removing external environment directory: %s' % base)
 
     if status and len(errors) == 0:
         return SimpleStatus(success=True, description="Cleaned.", errors=errors)

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -1648,7 +1648,6 @@ def clean(project, prepare_result):
 
     # Clean up the environments only if they are inside the project
     our_root = project.directory_path
-    default_path = os.path.abspath(os.path.join(our_root, "envs"))
     for path in os.environ.get('ANACONDA_PROJECT_ENVS_PATH', '').split(os.pathsep):
         apath = os.path.abspath(os.path.join(our_root, path or "envs"))
         if apath == our_root:

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -1649,8 +1649,8 @@ def clean(project, prepare_result):
     # Clean up the environments only if they are inside the project
     our_root = project.directory_path
     default_path = os.path.abspath(os.path.join(our_root, "envs"))
-    for path in os.environ.get('ANACONDA_PROJECT_ENVS_PATH', '').split(':'):
-        apath = os.path.abspath(path) if path else default_path
+    for path in os.environ.get('ANACONDA_PROJECT_ENVS_PATH', '').split(os.pathsep):
+        apath = os.path.abspath(os.path.join(our_root, path or "envs"))
         if apath == our_root:
             errors.append('Not removing the project directory itself.')
         elif os.path.commonpath([apath, our_root]) == our_root:

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -1652,7 +1652,7 @@ def clean(project, prepare_result):
         apath = os.path.abspath(os.path.join(our_root, path or "envs"))
         if apath == our_root:
             errors.append('Not removing the project directory itself.')
-        elif os.path.commonpath([apath, our_root]) == our_root:
+        elif apath.startswith(our_root + os.sep):
             cleanup_dir(apath)
         else:
             errors.append('Not removing external environment directory: %s' % path)

--- a/examples/existing/.projectignore
+++ b/examples/existing/.projectignore
@@ -1,0 +1,14 @@
+# project-local contains your personal configuration choices and state
+/anaconda-project-local.yml
+
+# Files autocreated by Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Notebook stuff
+.ipynb_checkpoints/
+
+# Spyder stuff
+/.spyderproject

--- a/examples/existing/anaconda-project.yml
+++ b/examples/existing/anaconda-project.yml
@@ -1,0 +1,17 @@
+name: Simple Project
+description: A simple example project
+commands:
+  default:
+    unix: echo hello
+env_specs:
+  # Replace this key with the name of an environment that
+  # already exists, and set ANACONDA_PROJECT_ENVS_PATH to
+  # the parent directory of that environment. This should
+  # allow anaconda-project prepare to exit immediately.
+  nbck:
+    channels: []
+    packages: []
+platforms:
+- linux-64
+- osx-64
+- win-64

--- a/examples/existing/anaconda-project.yml
+++ b/examples/existing/anaconda-project.yml
@@ -2,16 +2,12 @@ name: Simple Project
 description: A simple example project
 commands:
   default:
-    unix: echo hello
+    unix: python -c 'import sys; print(sys.prefix)'
 env_specs:
   # Replace this key with the name of an environment that
   # already exists, and set ANACONDA_PROJECT_ENVS_PATH to
   # the parent directory of that environment. This should
   # allow anaconda-project prepare to exit immediately.
   nbck:
-    channels: []
-    packages: []
-platforms:
-- linux-64
-- osx-64
-- win-64
+    packages:
+    - python


### PR DESCRIPTION
This PR modifies the interpretation of ANACONDA_PROJECT_ENVS_PATH so that multiple environment directories can be considered. Rules:
- The variable is assumed to be a list of paths, separated by `os.pathsep`
- If an entry is empty, it is replaced with `envs`
- Relative paths are considered relative to the project directory (which is why `envs` is the appropriate default)
- If an environment with the given name does not exist anywhere on the path list, it is _created_ in the first directory.
- If the directory is outside of the project directory, it is not removed by cleanup commands.
So for example, suppose you want the default directory to still be the `envs` subdirectory, but you want to allow the child environments in your local Miniconda installation `~/miniconda3` to be considered. Then the value
```
export ANACONDA_PROJECT_ENVS_PATH=:~/miniconda3/envs
```
will produce the desired results.