### PR TITLE
Move the refresh logic deeper into prepare

### DIFF
--- a/anaconda_project/internal/cli/prepare.py
+++ b/anaconda_project/internal/cli/prepare.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import, print_function
 import anaconda_project.internal.cli.console_utils as console_utils
 from anaconda_project.internal.cli.prepare_with_mode import prepare_with_ui_mode_printing_errors
 from anaconda_project.internal.cli.project_load import load_project
-from anaconda_project.requirements_registry.providers.conda_env import _remove_env_path
 
 
 def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=False, refresh=False):
@@ -21,26 +20,18 @@ def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=F
         Prepare result (can be treated as True on success).
     """
     project = load_project(project_dir)
+    project_dir = project.directory_path
     if console_utils.print_project_problems(project):
         return False
     if all:
-        result = []
-        for k, v in project.env_specs.items():
-            if refresh:
-                _remove_env_path(v.path(project.directory_path))
-            result = prepare_with_ui_mode_printing_errors(project,
-                                                          env_spec_name=k,
-                                                          ui_mode=ui_mode,
-                                                          command_name=command_name)
+        specs = project.env_specs
     else:
-        if refresh:
-            conda_environment = 'default' if conda_environment is None else conda_environment
-            _remove_env_path(project.env_specs[conda_environment].path(project.directory_path))
-        result = prepare_with_ui_mode_printing_errors(project,
-                                                      env_spec_name=conda_environment,
-                                                      ui_mode=ui_mode,
-                                                      command_name=command_name)
-
+        specs = {conda_environment: project.env_specs.get(conda_environment)}
+    result = True
+    for k, v in specs.items():
+        if not prepare_with_ui_mode_printing_errors(
+                project, env_spec_name=k, ui_mode=ui_mode, command_name=command_name, refresh=refresh):
+            result = False
     return result
 
 

--- a/anaconda_project/internal/cli/prepare_with_mode.py
+++ b/anaconda_project/internal/cli/prepare_with_mode.py
@@ -80,7 +80,8 @@ def prepare_with_ui_mode_printing_errors(project,
                                          env_spec_name=None,
                                          command_name=None,
                                          command=None,
-                                         extra_command_args=None):
+                                         extra_command_args=None,
+                                         refresh=False):
     """Perform all steps needed to get a project ready to execute.
 
     This may need to ask the user questions, may start services,
@@ -140,7 +141,8 @@ def prepare_with_ui_mode_printing_errors(project,
                                                      env_spec_name=env_spec_name,
                                                      command_name=command_name,
                                                      command=command,
-                                                     extra_command_args=extra_command_args)
+                                                     extra_command_args=extra_command_args,
+                                                     refresh=refresh)
 
         if result.failed:
             if ask and _interactively_fix_missing_variables(project, result):

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -537,7 +537,7 @@ def remove_env_spec(project, name):
     # that was prepared. So instead we share some code with the
     # CondaEnvProvider but don't try to go through the unprepare
     # machinery.
-    status = _remove_env_path(env_path)
+    status = _remove_env_path(env_path, project.directory_path)
     if status:
         with _updating_project_lock_file(project) as status_holder:
             project.project_file.unset_value(['env_specs', name])

--- a/anaconda_project/test/test_api.py
+++ b/anaconda_project/test/test_api.py
@@ -84,7 +84,7 @@ def _test_prepare_without_interaction(monkeypatch, api_method, provide_mode):
     from anaconda_project.prepare import prepare_without_interaction
     _verify_args_match(getattr(api.AnacondaProject, api_method),
                        prepare_without_interaction,
-                       ignored=['self', 'mode', 'provide_whitelist'])
+                       ignored=['self', 'mode', 'provide_whitelist', 'refresh'])
 
     params = _monkeypatch_prepare_without_interaction(monkeypatch)
     p = api.AnacondaProject()


### PR DESCRIPTION
I moved the `--refresh` logic—which removes the conda environment for re-creation—into the prepare step. This consolidated and simplified some of the logic. But the truth is that really the refresh logic should somehow work its way into the _requirements_ and _provider_ code. Specifically, when a refresh is requested, the requirements analysis should state that the environment needs to be re-created, and the provider should do it. But for now this is a lot closer.