### PR TITLE
Support for read-only environments

### DIFF
--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -12,7 +12,6 @@ import codecs
 import difflib
 import os
 import re
-import shutil
 
 import anaconda_project.internal.conda_api as conda_api
 import anaconda_project.internal.pip_api as pip_api

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -12,6 +12,7 @@ import codecs
 import difflib
 import os
 import re
+import shutil
 
 import anaconda_project.internal.conda_api as conda_api
 import anaconda_project.internal.pip_api as pip_api

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -287,6 +287,7 @@ class EnvSpec(object):
             self._path = None
 
         if self._path is None:
+
             def _prefix(base_path):
                 base_path = os.path.expanduser(base_path) if base_path else 'envs'
                 path = os.path.abspath(os.path.join(project_dir, base_path, self.name))

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -37,6 +37,12 @@ class CondaEnvExistsError(CondaError):
     pass
 
 
+class CondaEnvMissingError(CondaError):
+    """Conda environment missing."""
+
+    pass
+
+
 # this function exists so we can monkeypatch it in tests
 def _get_conda_command(extra_args):
     # just use whatever conda is on the path
@@ -251,10 +257,10 @@ def create(prefix, pkgs=None, channels=(), stdout_callback=None, stderr_callback
     _call_conda(cmd_list, stdout_callback=stdout_callback, stderr_callback=stderr_callback)
 
 
-def clone(prefix, source=None, stdout_callback=None, stderr_callback=None):
+def clone(prefix, source, stdout_callback=None, stderr_callback=None):
     """Clone a pre-existing env."""
-    if not source:
-        raise TypeError('You must specify the full path to the pre-existing source env.')
+    if not os.path.exists(source):
+        raise CondaEnvMissingError('Conda environment [%s] does not exist to clone.' % source)
 
     cmd_list = ['create', '-p', prefix, '--clone', source]
     _call_conda(cmd_list, stdout_callback=stdout_callback, stderr_callback=stderr_callback)

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -251,6 +251,15 @@ def create(prefix, pkgs=None, channels=(), stdout_callback=None, stderr_callback
     _call_conda(cmd_list, stdout_callback=stdout_callback, stderr_callback=stderr_callback)
 
 
+def clone(prefix, source=None, stdout_callback=None, stderr_callback=None):
+    """Clone a pre-existing env."""
+    if not source:
+        raise TypeError('You must specify the full path to the pre-existing source env.')
+
+    cmd_list = ['create', '-p', prefix, '--clone', source]
+    _call_conda(cmd_list, stdout_callback=stdout_callback, stderr_callback=stderr_callback)
+
+
 def install(prefix, pkgs=None, channels=(), stdout_callback=None, stderr_callback=None):
     """Install packages into an environment either by name or path with a specified set of packages."""
     if not pkgs or not isinstance(pkgs, (list, tuple)):

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -1200,7 +1200,7 @@ def test_conda_clone_readonly():
         assert os.path.isdir(os.path.join(cloned, "conda-meta"))
         assert os.path.exists(os.path.join(cloned, PYTHON_BINARY))
 
-        write_mode = stat.S_IWUSR ^ readonly_mode
+        write_mode = (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH) ^ readonly_mode
         os.chmod(readonly, write_mode)
         os.chmod(os.path.join(readonly, 'conda-meta'), write_mode)
 

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -12,6 +12,7 @@ import os
 import platform
 import pytest
 import random
+import stat
 
 from pprint import pprint
 
@@ -1188,8 +1189,9 @@ def test_conda_clone_readonly():
         assert os.path.isdir(os.path.join(readonly, "conda-meta"))
         assert os.path.exists(os.path.join(readonly, PYTHON_BINARY))
 
-        os.chmod(readonly, 0o555)
-        os.chmod(os.path.join(readonly, 'conda-meta'), 0o555)
+        readonly_mode = stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
+        os.chmod(readonly, readonly_mode)
+        os.chmod(os.path.join(readonly, 'conda-meta'), readonly_mode)
 
         cloned = os.path.join(dirname, 'cloned')
         conda_api.clone(cloned, readonly)
@@ -1198,8 +1200,9 @@ def test_conda_clone_readonly():
         assert os.path.isdir(os.path.join(cloned, "conda-meta"))
         assert os.path.exists(os.path.join(cloned, PYTHON_BINARY))
 
-        os.chmod(readonly, 0o755)
-        os.chmod(os.path.join(readonly, 'conda-meta'), 0o755)
+        write_mode = stat.S_IWUSR ^ readonly_mode
+        os.chmod(readonly, write_mode)
+        os.chmod(os.path.join(readonly, 'conda-meta'), write_mode)
 
     with_directory_contents(dict(), do_test)
 

--- a/anaconda_project/requirements_registry/providers/test/test_conda_env.py
+++ b/anaconda_project/requirements_registry/providers/test/test_conda_env.py
@@ -371,7 +371,7 @@ def _readonly_env(env_name, packages):
 @pytest.mark.slow
 def test_clone_readonly_environment_with_deviations(monkeypatch):
     def clone_readonly_and_prepare(dirname):
-        with _readonly_env(env_name='default', packages=('python=3.7',)) as ro_prefix:
+        with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:
             readonly = conda_api.installed(ro_prefix)
             assert 'python' in readonly
             assert 'requests' not in readonly
@@ -405,14 +405,13 @@ env_specs:
 @pytest.mark.slow
 def test_fail_readonly_environment_with_deviations_unset(monkeypatch):
     def clone_readonly_and_prepare(dirname):
-        with _readonly_env(env_name='default', packages=('python=3.7',)) as ro_prefix:
+        with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:
             readonly = conda_api.installed(ro_prefix)
             assert 'python' in readonly
             assert 'requests' not in readonly
 
             ro_envs = os.path.dirname(ro_prefix)
-            environ = minimal_environ(PROJECT_DIR=dirname,
-                                      ANACONDA_PROJECT_ENVS_PATH=':{}'.format(ro_envs))
+            environ = minimal_environ(PROJECT_DIR=dirname, ANACONDA_PROJECT_ENVS_PATH=':{}'.format(ro_envs))
             monkeypatch.setattr('os.environ', environ)
 
             project = Project(dirname)
@@ -433,7 +432,7 @@ env_specs:
 @pytest.mark.slow
 def test_fail_readonly_environment_with_deviations_set(monkeypatch):
     def clone_readonly_and_prepare(dirname):
-        with _readonly_env(env_name='default', packages=('python=3.7',)) as ro_prefix:
+        with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:
             readonly = conda_api.installed(ro_prefix)
             assert 'python' in readonly
             assert 'requests' not in readonly

--- a/anaconda_project/requirements_registry/providers/test/test_conda_env.py
+++ b/anaconda_project/requirements_registry/providers/test/test_conda_env.py
@@ -12,7 +12,10 @@ import platform
 import pytest
 import stat
 from contextlib import contextmanager
-from tempfile import TemporaryDirectory
+try:
+    from backports.tempfile import TemporaryDirectory
+except ImportError:
+    from tempfile import TemporaryDirectory
 
 import anaconda_project.internal.conda_api as conda_api
 import anaconda_project.internal.pip_api as pip_api

--- a/anaconda_project/requirements_registry/providers/test/test_conda_env.py
+++ b/anaconda_project/requirements_registry/providers/test/test_conda_env.py
@@ -371,7 +371,7 @@ def _readonly_env(env_name, packages):
 
         yield ro_prefix
 
-        write_mode = stat.S_IWUSR ^ readonly_mode
+        write_mode = (stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH) ^ readonly_mode
         os.chmod(ro_prefix, write_mode)
         os.chmod(conda_meta, write_mode)
 

--- a/anaconda_project/requirements_registry/providers/test/test_conda_env.py
+++ b/anaconda_project/requirements_registry/providers/test/test_conda_env.py
@@ -377,8 +377,7 @@ def _readonly_env(env_name, packages):
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(platform.system() == 'Windows',
-                    reason='Windows has a hard time with read-only directories')
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
 def test_clone_readonly_environment_with_deviations(monkeypatch):
     def clone_readonly_and_prepare(dirname):
         with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:
@@ -413,8 +412,7 @@ env_specs:
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(platform.system() == 'Windows',
-                    reason='Windows has a hard time with read-only directories')
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
 def test_fail_readonly_environment_with_deviations_unset_policy(monkeypatch):
     def clone_readonly_and_prepare(dirname):
         with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:
@@ -442,8 +440,7 @@ env_specs:
 
 
 @pytest.mark.slow
-@pytest.mark.skipif(platform.system() == 'Windows',
-                    reason='Windows has a hard time with read-only directories')
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
 def test_fail_readonly_environment_with_deviations_set_policy(monkeypatch):
     def clone_readonly_and_prepare(dirname):
         with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:

--- a/anaconda_project/requirements_registry/providers/test/test_conda_env.py
+++ b/anaconda_project/requirements_registry/providers/test/test_conda_env.py
@@ -377,6 +377,8 @@ def _readonly_env(env_name, packages):
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(platform.system() == 'Windows',
+                    reason='Windows has a hard time with read-only directories')
 def test_clone_readonly_environment_with_deviations(monkeypatch):
     def clone_readonly_and_prepare(dirname):
         with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:
@@ -411,6 +413,8 @@ env_specs:
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(platform.system() == 'Windows',
+                    reason='Windows has a hard time with read-only directories')
 def test_fail_readonly_environment_with_deviations_unset_policy(monkeypatch):
     def clone_readonly_and_prepare(dirname):
         with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:
@@ -438,6 +442,8 @@ env_specs:
 
 
 @pytest.mark.slow
+@pytest.mark.skipif(platform.system() == 'Windows',
+                    reason='Windows has a hard time with read-only directories')
 def test_fail_readonly_environment_with_deviations_set_policy(monkeypatch):
     def clone_readonly_and_prepare(dirname):
         with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -2,8 +2,8 @@
 Configuration
 =============
 
-Anaconda Project has only one modifiable configuration setting. Currently
-this setting is controlled exclusively by an environment variable.
+Anaconda Project has two modifiable configuration settings. Currently
+these setting are controlled exclusively by environment variables.
 
 ``ANACONDA_PROJECT_ENVS_PATH``
   This variable provides a list of directories to search for environments
@@ -23,7 +23,7 @@ this setting is controlled exclusively by an environment variable.
 
   * When searching for an environment, the directories are searched in
     left-to-right order.
-  * If an environment with the requeted name is found nowhere in the path, 
+  * If an environment with the requested name is found nowhere in the path, 
     one will be created as a subdirectory of the first entry in the path.
 
   For example, given a Unix machine with
@@ -42,3 +42,26 @@ this setting is controlled exclusively by an environment variable.
 
   If no such environment exists, one will be created as ``/opt/envs/default``,
   instead of the default location of ``$PROJECT_DIR/envs/default``.
+
+``ANACONDA_PROJECT_READONLY_ENVS_POLICY``
+  When using ``ANACONDA_PROJECT_ENVS_PATH`` one or more of the envs directories
+  may contain read-only environments. These environments can be created on shared
+  systems to speed-up project preparation steps by providing a pre-built environment
+  matching an ``env_spec`` defined in a user's ``anaconda-project.yml`` file.
+
+  For the scenario where a user specifies an ``env_spec`` that is found in a read-only
+  directory and when the package list differs from the environment on disk the
+  ``ANACONDA_PROJECT_READONLY_ENVS_POLICY`` variable controls what action is taken.
+
+  The ``ANACONDA_PROJECT_READONLY_ENVS_POLICY`` variable accepts two values ``fail``
+  and ``clone``. The default behavior is ``fail`` if this variable is not set.
+
+  ``fail``
+    If a user requests changes to be made to a read-only environment the action will
+    fail with a message that the requested changes cannot be made. 
+
+  ``clone``
+    If a user requests changes to be make to a read-only environment anaconda-project
+    will first clone the read-only environment to the first writable path in the
+    ``ANACONDA_PROJECT_ENVS_PATH`` list before making modifications. If no modifications
+    to a read-only environment are requested then the environment will not be cloned.


### PR DESCRIPTION
to utilize read-only environments place the local envs directory (aliased as `:`) first and the read-only envs directory second.

```
export ANACONDA_PROJECT_ENVS_PATH=:/path/to/readonly/envs
anaconda-project ...
```

For all project actions the `ANACONDA_PROJECT_ENVS_PATH` paths are searched *backwards*
1. If a matching `env_spec` name is found the env is scanned for deviations
1. if there are deviations and the env is unfixable (read-only) the next `ANACONDA_PROJECT_ENVS_PATH` is checked
1. if no `env_spec` is found the env will be created in the local `envs` directory

TODO:
- [x] tests