### PR TITLE
Allow unpacking into empty directory

### DIFF
--- a/anaconda_project/archiver.py
+++ b/anaconda_project/archiver.py
@@ -473,10 +473,11 @@ def _get_source_and_dest_files(archive_path, list_files, project_dir, parent_dir
     assert canonical_project_dir.startswith(canonical_parent_dir)
 
     if os.path.exists(canonical_project_dir):
-        # This is an error to ensure we always do a "fresh" unpack
-        # without worrying about overwriting stuff.
-        frontend.error("Directory '%s' already exists." % canonical_project_dir)
-        return None
+        if os.listdir(canonical_project_dir):
+            # This is an error to ensure we always do a "fresh" unpack
+            # without worrying about overwriting stuff.
+            frontend.error("Directory '%s' already exists and is not empty." % canonical_project_dir)
+            return None
 
     src_and_dest = []
     for (name, prefix, remainder) in items:
@@ -561,8 +562,8 @@ def _unarchive_project(archive_filename, project_dir, frontend, parent_dir=None)
                                 description=("Could not unpack archive %s" % archive_filename),
                                 errors=frontend.pop_errors())
 
-        assert not os.path.exists(canonical_project_dir)
-        os.makedirs(canonical_project_dir)
+        if not os.path.exists(canonical_project_dir):
+            os.makedirs(canonical_project_dir)
 
         try:
             extract_files(archive_filename, src_and_dest, frontend)

--- a/anaconda_project/archiver.py
+++ b/anaconda_project/archiver.py
@@ -473,10 +473,10 @@ def _get_source_and_dest_files(archive_path, list_files, project_dir, parent_dir
     assert canonical_project_dir.startswith(canonical_parent_dir)
 
     if os.path.exists(canonical_project_dir):
-        if os.listdir(canonical_project_dir):
+        if not os.path.isdir(canonical_project_dir) or os.listdir(canonical_project_dir):
             # This is an error to ensure we always do a "fresh" unpack
             # without worrying about overwriting stuff.
-            frontend.error("Directory '%s' already exists and is not empty." % canonical_project_dir)
+            frontend.error("Destination '%s' already exists and is not an empty directory." % canonical_project_dir)
             return None
 
     src_and_dest = []

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -4533,8 +4533,9 @@ def test_unarchive_error_on_dest_dir_exists():
             unpacked = os.path.join(dirname, "foo")
             os.mkdir(unpacked)
             status = project_ops.unarchive(archivefile, unpacked)
+            status = project_ops.unarchive(archivefile, unpacked)
 
-            message = "Directory '%s' already exists." % unpacked
+            message = "Destination '%s' already exists and is not an empty directory." % unpacked
             assert status.errors == [message]
             assert not status
 


### PR DESCRIPTION
Currently it is not possible to supply an existing directory to `anaconda-project unarchive`, even if that directory is empty. AE5 works around this for now (when unpacking for a deployment), but with persistent storage for the session project we can't do that.
 