### PR TITLE
Add support for .readonly file

### DIFF
--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -121,6 +121,9 @@ class DefaultCondaManager(CondaManager):
     def _test_writable_file(self, prefix):
         return os.path.join(self._cache_directory(prefix), "status")
 
+    def _force_readonly_file(self, prefix):
+        return os.path.join(prefix, '.readonly')
+
     def _timestamp_file(self, prefix, spec):
         return os.path.join(self._cache_directory(prefix), "env-specs", spec.locked_hash)
 
@@ -193,6 +196,9 @@ class DefaultCondaManager(CondaManager):
             return False
 
     def _is_environment_writable(self, prefix):
+        filename = self._force_readonly_file(prefix)
+        if os.path.exists(filename):
+            return False
         filename = self._test_writable_file(prefix)
         return self._write_a_file(filename)
 


### PR DESCRIPTION
If a prefix has a `.readonly` file in it, then anaconda-project will assume it is read-only, even if it is not. At bare minimum this is useful for testing