### PR TITLE
Allow .readonly flag in parent

### DIFF
--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -264,6 +264,11 @@ def clone(prefix, source, stdout_callback=None, stderr_callback=None):
 
     cmd_list = ['create', '-p', prefix, '--clone', source]
     _call_conda(cmd_list, stdout_callback=stdout_callback, stderr_callback=stderr_callback)
+    # If someone is using the .readonly flag-file approach, the clone command is going to copy
+    # that. So we need to remove it if we find it in the new, copied environment.
+    readonly_file = os.path.join(prefix, '.readonly')
+    if os.path.exists(readonly_file):
+        os.unlink(readonly_file)
 
 
 def install(prefix, pkgs=None, channels=(), stdout_callback=None, stderr_callback=None):

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -121,7 +121,9 @@ class DefaultCondaManager(CondaManager):
     def _test_writable_file(self, prefix):
         return os.path.join(self._cache_directory(prefix), "status")
 
-    def _force_readonly_file(self, prefix):
+    def _force_readonly_file(self, prefix, parent=False):
+        if parent:
+            prefix = os.path.dirname(prefix)
         return os.path.join(prefix, '.readonly')
 
     def _timestamp_file(self, prefix, spec):
@@ -196,8 +198,8 @@ class DefaultCondaManager(CondaManager):
             return False
 
     def _is_environment_writable(self, prefix):
-        filename = self._force_readonly_file(prefix)
-        if os.path.exists(filename):
+        if (os.path.exists(self._force_readonly_file(prefix))
+                or os.path.exists(self._force_readonly_file(prefix, parent=True))):
             return False
         filename = self._test_writable_file(prefix)
         return self._write_a_file(filename)


### PR DESCRIPTION
We currently offer the use of a `.readonly` file in the root directory of a conda environment to force anaconda-project to treat it as if it were readonly (regardless of the actual permissions). In a use case where there is an entire directory of environments where we might wish to do this, it would be nice to declare that entire directory as readonly with a single such flag file.