### PR TITLE
Add replace option for readonly handling, with docs

### DIFF
--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -9,6 +9,7 @@
 from __future__ import absolute_import
 
 import codecs
+import shutil
 import glob
 import os
 

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -9,7 +9,6 @@
 from __future__ import absolute_import
 
 import codecs
-import shutil
 import glob
 import os
 

--- a/anaconda_project/requirements_registry/providers/conda_env.py
+++ b/anaconda_project/requirements_registry/providers/conda_env.py
@@ -208,7 +208,6 @@ class CondaEnvProvider(EnvVarProvider):
 
             if deviations.unfixable and readonly_policy in ('clone', 'replace'):
                 # scan for writable path
-                env_paths = os.environ.get('ANACONDA_PROJECT_ENVS_PATH', '').split(os.pathsep)
                 destination = env_spec.path(project_dir, reset=True, force_writable=True)
                 if destination != prefix:
                     if readonly_policy == 'replace':

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -2,8 +2,11 @@
 Configuration
 =============
 
-Anaconda Project has two modifiable configuration settings. Currently
-these setting are controlled exclusively by environment variables.
+Environment variables
+---------------------
+
+Anaconda Project has two modifiable configuration settings, both of which
+are currently controlled exclusively by environment variables.
 
 ``ANACONDA_PROJECT_ENVS_PATH``
   This variable provides a list of directories to search for environments
@@ -44,24 +47,57 @@ these setting are controlled exclusively by environment variables.
   instead of the default location of ``$PROJECT_DIR/envs/default``.
 
 ``ANACONDA_PROJECT_READONLY_ENVS_POLICY``
-  When using ``ANACONDA_PROJECT_ENVS_PATH`` one or more of the envs directories
-  may contain read-only environments. These environments can be created on shared
-  systems to speed-up project preparation steps by providing a pre-built environment
-  matching an ``env_spec`` defined in a user's ``anaconda-project.yml`` file.
-
-  For the scenario where a user specifies an ``env_spec`` that is found in a read-only
-  directory and when the package list differs from the environment on disk the
-  ``ANACONDA_PROJECT_READONLY_ENVS_POLICY`` variable controls what action is taken.
-
-  The ``ANACONDA_PROJECT_READONLY_ENVS_POLICY`` variable accepts two values ``fail``
-  and ``clone``. The default behavior is ``fail`` if this variable is not set.
+  When an ``anaconda-project.yml`` specifies the use of an existing environment,
+  but that environment is missing one or more of the requested packages,
+  Anaconda Project attempts to remedy the deficiency by installing the missing
+  packages. If the specified environment is *read-only*, however, such an
+  installation would fail. The value of the environment variable
+  ``ANACONDA_PROJECT_READONLY_ENVS_POLICY`` governs what action should be
+  taken in such a case.
 
   ``fail``
-    If a user requests changes to be made to a read-only environment the action will
-    fail with a message that the requested changes cannot be made. 
+    The attempt will fail, and a message returned indicating that the requested
+    changes could not be made.
 
   ``clone``
-    If a user requests changes to be make to a read-only environment anaconda-project
-    will first clone the read-only environment to the first writable path in the
-    ``ANACONDA_PROJECT_ENVS_PATH`` list before making modifications. If no modifications
-    to a read-only environment are requested then the environment will not be cloned.
+    A clone of the read-only environment will be made, and additional packages
+    will be installed into this cloned environment. Note that a clone will occur
+    *only* if additional packages are required.
+
+  ``replace``
+    An entirely new environment will be created.
+
+  If this environment variable is empty or contains any other value than these,
+  the ``fail`` behavior will be assumed. Note that for ``clone`` or ``replace``
+  to succeed, a writable environment location must exist somewhere in the
+  ``ANACONDA_PROJECT_ENVS_PATH`` path.
+
+
+Read-only environments
+----------------------
+
+On some systems, it is desirable to provide Anaconda Project access to one
+or more *read-only* environments. These environments can be centrally
+managed by administrators, and will speed up environment preparation
+for users that elect to use them.
+
+On Unix, a read-only environment is quite easy to enforce with standard
+POSIX permissions settings. Unfortunately, our experience on Windows
+systems suggests it is more challenging to enforce. For this reason,
+we have adopted a simple approach that allows environments to be
+explicitly marked as read-only with a flag file:
+
+- If a file called ``.readonly`` is found in the root of an environment,
+  that environment will be considered read-only.
+- If a file called ``.readonly`` is found in the *parent* of an environment
+  directory, the environment will be considered read-only.
+- An attempt is made to write a file ``var/cache/anaconda-project/status``
+  within the environment, creating the subdirectories as needed. If
+  successful, the environment is considered read-write; otherwise, it
+  is considered read-only.
+
+This second test is particularly useful when centrally managing and entire
+directory of environments. With a single ``.readonly`` flag file, all new
+environments created within that directory will be treated as read-only.
+Of course, for the best protection, POSIX or Windows read-only permissions
+should be applied nevertheless.


### PR DESCRIPTION
While expanding the docs around read-only environments it occurred to me we have one more logical outcome for read-only environments: _full replacement_. This implements that, including a test