### PR TITLE
support default command alias with prepare

### DIFF
--- a/anaconda_project/prepare.py
+++ b/anaconda_project/prepare.py
@@ -709,7 +709,7 @@ def _internal_prepare_in_stages(project, environ_copy, overrides, keep_going_unt
         raise ValueError("invalid provide mode " + mode)
 
     assert not (command_name is not None and command is not None)
-    assert command_name is None or command_name in project.commands
+    assert command_name is None or (command_name in project.commands) or (command_name == 'default')
     assert overrides.env_spec_name is None or overrides.env_spec_name in project.env_specs
 
     if command is None:
@@ -817,7 +817,9 @@ def _project_problems_to_prepare_failure(project, environ, overrides, would_have
 
 
 def _prepare_failure_on_bad_command_name(project, command_name, environ, overrides, would_have_used_env_spec):
-    if command_name is not None and command_name not in project.commands:
+    if command_name == 'default':
+        command_name = project.default_command.name
+    elif command_name is not None and command_name not in project.commands:
         error = ("Command name '%s' is not in %s, these names were found: %s" %
                  (command_name, project.project_file.filename, ", ".join(sorted(project.commands.keys()))))
         project.frontend.error(error)

--- a/anaconda_project/test/test_prepare.py
+++ b/anaconda_project/test/test_prepare.py
@@ -285,6 +285,37 @@ packages:
         }, check)
 
 
+def test_prepare_default_command():
+    def check(dirname):
+        project = project_no_dedicated_env(dirname)
+        environ = minimal_environ()
+        result = prepare_without_interaction(project, environ=environ, command_name='default')
+        assert result.errors == []
+        assert result
+        assert os.path.join(project.directory_path, 'foo.py') in result.command_exec_info.args
+
+        # environ = minimal_environ()
+        # result = prepare_without_interaction(project, environ=environ, command_name='bar')
+        # assert result.errors == []
+        # assert result
+        # assert os.path.join(project.directory_path, 'bar.py') in result.command_exec_info.args
+
+    with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME: """
+commands:
+    foo:
+       bokeh_app: foo.py
+    bar:
+       bokeh_app: bar.py
+packages:
+  - bokeh
+""",
+            "foo.py": "# foo",
+            "bar.py": "# bar"
+        }, check)
+
+
 def test_prepare_command_not_in_project():
     def check(dirname):
         # create a command that isn't in the Project


### PR DESCRIPTION
this enables `anaconda-project prepare --command default` when 'default' is an alias for the first command in the anaconda-project.yml file (see #264 )