### PR TITLE
Do not create projectignore if gitignore is present

### DIFF
--- a/anaconda_project/archiver.py
+++ b/anaconda_project/archiver.py
@@ -148,6 +148,8 @@ def _load_ignore_file(project_directory, frontend):
 
 def _git_ignored_files(project_directory, frontend):
     if not os.path.exists(os.path.join(project_directory, ".git")):
+        if os.path.exists(os.path.join(project_directory, ".gitignore")):
+            frontend.error("Warning: the .gitignore file is being ignored because this directory is not a Git repository.")
         return []
 
     # It is pretty involved to parse .gitignore correctly. Lots of

--- a/anaconda_project/archiver.py
+++ b/anaconda_project/archiver.py
@@ -218,9 +218,9 @@ def _enumerate_archive_files(project_directory, frontend, requirements):
     if git_filter is None or ignore_file_filter is None:
         return None
 
-    plugin_patterns = set()
+    plugin_patterns = {'/anaconda-project-local.yml'}
     for req in requirements:
-        plugin_patterns = plugin_patterns.union(req.ignore_patterns)
+        plugin_patterns.update(req.ignore_patterns)
     plugin_patterns = [_FilePattern(s) for s in plugin_patterns]
 
     def is_plugin_generated(info):

--- a/anaconda_project/archiver.py
+++ b/anaconda_project/archiver.py
@@ -149,7 +149,8 @@ def _load_ignore_file(project_directory, frontend):
 def _git_ignored_files(project_directory, frontend):
     if not os.path.exists(os.path.join(project_directory, ".git")):
         if os.path.exists(os.path.join(project_directory, ".gitignore")):
-            frontend.error("Warning: the .gitignore file is being ignored because this directory is not a Git repository.")
+            frontend.error(
+                "Warning: the .gitignore file is being ignored because this directory is not a Git repository.")
         return []
 
     # It is pretty involved to parse .gitignore correctly. Lots of

--- a/anaconda_project/projectignore.py
+++ b/anaconda_project/projectignore.py
@@ -11,27 +11,40 @@ import os
 import codecs
 
 _default_projectignore = """
-# project-local contains your personal configuration choices and state
+# This file contains a list of matching patterns to instruct
+# anaconda-project to ignore files/directories when building a
+# project archive, such as downloaded data sets. A subset of 
+# the .gitignore file format is supported; see the documentation
+# for details. In fact, if your project already has a .gitignore
+# file, these patterns can be merged into it and this file removed.
+
 /anaconda-project-local.yml
 
-# Files autocreated by Python
-__pycache__/
+# Python caching
 *.pyc
-*.pyo
 *.pyd
+*.pyo
+__pycache__/
 
-# Notebook stuff
+# nodejs caching
+.cache/
+
+# Jupyter & Spyder stuff
 .ipynb_checkpoints/
-
-# Spyder stuff
+.Trash-*/
 /.spyderproject
+
+# Anaconda-project work directories
+/tmp/
+/envs/
 """.lstrip()
 
 
 def add_projectignore_if_none(project_directory):
     """Add .projectignore if not found in project directory."""
     filename = os.path.join(project_directory, ".projectignore")
-    if not os.path.exists(filename):
+    gfile = os.path.join(project_directory, ".gitignore")
+    if not os.path.exists(filename) and not os.path.exists(gfilename):
         try:
             with codecs.open(filename, 'w', 'utf-8') as f:
                 f.write(_default_projectignore)

--- a/anaconda_project/projectignore.py
+++ b/anaconda_project/projectignore.py
@@ -11,12 +11,13 @@ import os
 import codecs
 
 _default_projectignore = """
-# This file contains a list of matching patterns to instruct
-# anaconda-project to ignore files/directories when building a
-# project archive, such as downloaded data sets. A subset of
-# the .gitignore file format is supported; see the documentation
-# for details. In fact, if your project already has a .gitignore
-# file, these patterns can be merged into it and this file removed.
+# This file contains a list of match patterns that instructs
+# anaconda-project to exclude certain files or directories when
+# building a project archive. The file format is a simplfied
+# version of Git's .gitignore file format. In fact, if the
+# project is hosted in a Git repository, these patterns can be
+# merged into the .gitignore file and this file removed.
+# See the anaconda-project documentation for more details.
 
 /anaconda-project-local.yml
 
@@ -26,17 +27,10 @@ _default_projectignore = """
 *.pyo
 __pycache__/
 
-# nodejs caching
-.cache/
-
 # Jupyter & Spyder stuff
 .ipynb_checkpoints/
 .Trash-*/
 /.spyderproject
-
-# Anaconda-project work directories
-/tmp/
-/envs/
 """.lstrip()
 
 

--- a/anaconda_project/projectignore.py
+++ b/anaconda_project/projectignore.py
@@ -13,7 +13,7 @@ import codecs
 _default_projectignore = """
 # This file contains a list of matching patterns to instruct
 # anaconda-project to ignore files/directories when building a
-# project archive, such as downloaded data sets. A subset of 
+# project archive, such as downloaded data sets. A subset of
 # the .gitignore file format is supported; see the documentation
 # for details. In fact, if your project already has a .gitignore
 # file, these patterns can be merged into it and this file removed.
@@ -43,7 +43,7 @@ __pycache__/
 def add_projectignore_if_none(project_directory):
     """Add .projectignore if not found in project directory."""
     filename = os.path.join(project_directory, ".projectignore")
-    gfile = os.path.join(project_directory, ".gitignore")
+    gfilename = os.path.join(project_directory, ".gitignore")
     if not os.path.exists(filename) and not os.path.exists(gfilename):
         try:
             with codecs.open(filename, 'w', 'utf-8') as f:

--- a/anaconda_project/projectignore.py
+++ b/anaconda_project/projectignore.py
@@ -19,8 +19,6 @@ _default_projectignore = """
 # merged into the .gitignore file and this file removed.
 # See the anaconda-project documentation for more details.
 
-/anaconda-project-local.yml
-
 # Python caching
 *.pyc
 *.pyd

--- a/anaconda_project/test/test_bundler.py
+++ b/anaconda_project/test/test_bundler.py
@@ -23,7 +23,7 @@ def test_parse_ignore_file():
 
         pattern_strings = [pattern.pattern for pattern in patterns]
 
-        assert pattern_strings == [
+        assert set(pattern_strings) == [
             'bar', '/baz', 'whitespace_surrounding', 'foo # this comment will be part of the pattern',
             '#patternwithhash', 'hello'
         ]
@@ -99,8 +99,8 @@ def test_parse_default_ignore_file():
         pattern_strings = [pattern.pattern for pattern in patterns]
 
         assert pattern_strings == [
-            '/anaconda-project-local.yml', '__pycache__/', '*.pyc', '*.pyo', '*.pyd', '.ipynb_checkpoints/',
-            '/.spyderproject'
+            '/anaconda-project-local.yml', '*.pyc', '*.pyd', '*.pyo', '__pycache__/', '.ipynb_checkpoints/',
+            '.Trash-*/', '/.spyderproject'
         ]
 
     with_directory_contents(dict(), check)

--- a/anaconda_project/test/test_bundler.py
+++ b/anaconda_project/test/test_bundler.py
@@ -23,10 +23,10 @@ def test_parse_ignore_file():
 
         pattern_strings = [pattern.pattern for pattern in patterns]
 
-        assert set(pattern_strings) == [
+        assert set(pattern_strings) == {
             'bar', '/baz', 'whitespace_surrounding', 'foo # this comment will be part of the pattern',
             '#patternwithhash', 'hello'
-        ]
+        }
 
     with_directory_contents(
         {
@@ -99,8 +99,7 @@ def test_parse_default_ignore_file():
         pattern_strings = [pattern.pattern for pattern in patterns]
 
         assert pattern_strings == [
-            '/anaconda-project-local.yml', '*.pyc', '*.pyd', '*.pyo', '__pycache__/', '.ipynb_checkpoints/',
-            '.Trash-*/', '/.spyderproject'
+            '*.pyc', '*.pyd', '*.pyo', '__pycache__/', '.ipynb_checkpoints/', '.Trash-*/', '/.spyderproject'
         ]
 
     with_directory_contents(dict(), check)

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -3785,14 +3785,7 @@ def test_archive_tar():
             assert os.path.exists(archivefile)
             _assert_tar_contains(
                 archivefile,
-                [
-                    '.projectignore',
-                    'a/b/c/d.py',
-                    'a/b/c/e.py',
-                    'emptydir',
-                    'foo.py',
-                    'anaconda-project.yml'  # , 'anaconda-project-local.yml'
-                ])
+                ['.projectignore', 'a/b/c/d.py', 'a/b/c/e.py', 'emptydir', 'foo.py', 'anaconda-project.yml'])
 
             # overwriting should work
             status = project_ops.archive(project, archivefile)
@@ -3801,14 +3794,7 @@ def test_archive_tar():
             assert os.path.exists(archivefile)
             _assert_tar_contains(
                 archivefile,
-                [
-                    '.projectignore',
-                    'a/b/c/d.py',
-                    'a/b/c/e.py',
-                    'emptydir',
-                    'foo.py',
-                    'anaconda-project.yml'  # , 'anaconda-project-local.yml'
-                ])
+                ['.projectignore', 'a/b/c/d.py', 'a/b/c/e.py', 'emptydir', 'foo.py', 'anaconda-project.yml'])
 
         with_directory_contents_completing_project_file(
             {
@@ -3985,7 +3971,7 @@ def test_archive_zip_with_gitignore():
 
             assert status
             assert os.path.exists(archivefile)
-            _assert_zip_contains(archivefile, ['foo.py', '.gitignore', 'anaconda-project.yml', '.projectignore'])
+            _assert_zip_contains(archivefile, ['foo.py', '.gitignore', 'anaconda-project.yml'])
 
         with_directory_contents_completing_project_file(
             _add_empty_git({

--- a/docs/source/user-guide/tasks/create-project-archive.rst
+++ b/docs/source/user-guide/tasks/create-project-archive.rst
@@ -18,7 +18,9 @@ files, you might not want to include those either.
 
 The ``anaconda-project archive`` command automatically omits the
 files that Project can reproduce automatically, which includes
-the ``envs/default`` directory and any downloaded data.
+the ``envs/default`` directory and any downloaded data. It also
+excludes ``anaconda-project-local.yml``, which is intended to
+hold local configuration state only.
 
 To manually exclude any other files that you do not want to be
 in the archive, create a ``.projectignore`` file or a

--- a/docs/source/user-guide/tasks/create-project-archive.rst
+++ b/docs/source/user-guide/tasks/create-project-archive.rst
@@ -21,8 +21,15 @@ files that Project can reproduce automatically, which includes
 the ``envs/default`` directory and any downloaded data.
 
 To manually exclude any other files that you do not want to be
-in the archive, create a ``.projectignore`` file.
+in the archive, create a ``.projectignore`` file or a
+``.gitignore`` file.
 
+.. note::
+
+  If you anticipate that this project will be managed as a Git
+  repository, use of ``.gitignore`` is preferred over
+  ``.projectignore``. However, use of ``.gitignore`` outside
+  of a Git repository is not supported.
 
 Creating the archive file
 =========================


### PR DESCRIPTION
Because anaconda-project respects `.gitignore` inside Git repositories there is no need to automatically create `.projectignore` if `.gitignore` is present. It is proving mildly disruptive in AE5 to create this file unnecessarily.