### PR TITLE
Enable pip package locking

### DIFF
--- a/anaconda_project/api.py
+++ b/anaconda_project/api.py
@@ -442,7 +442,7 @@ class AnacondaProject(object):
         """
         return project_ops.export_env_spec(project=project, name=name, filename=filename)
 
-    def add_packages(self, project, env_spec_name, packages, channels):
+    def add_packages(self, project, env_spec_name, packages, channels, pip=False):
         """Attempt to install packages then add them to anaconda-project.yml.
 
         If the environment spec name is None rather than an env
@@ -460,6 +460,7 @@ class AnacondaProject(object):
             env_spec_name (str): environment spec name or None for all environment specs
             packages (list of str): packages (with optional version info, as for conda install)
             channels (list of str): channels (as they should be passed to conda --channel)
+            pip (bool): Flag to request packages to be installed with pip if True else use Conda.
 
         Returns:
             ``Status`` instance
@@ -468,7 +469,8 @@ class AnacondaProject(object):
         return project_ops.add_packages(project=project,
                                         env_spec_name=env_spec_name,
                                         packages=packages,
-                                        channels=channels)
+                                        channels=channels,
+                                        pip=pip)
 
     def remove_packages(self, project, env_spec_name, packages):
         """Attempt to remove packages from an environment spec in anaconda-project.yml.

--- a/anaconda_project/api.py
+++ b/anaconda_project/api.py
@@ -472,7 +472,7 @@ class AnacondaProject(object):
                                         channels=channels,
                                         pip=pip)
 
-    def remove_packages(self, project, env_spec_name, packages):
+    def remove_packages(self, project, env_spec_name, packages, pip):
         """Attempt to remove packages from an environment spec in anaconda-project.yml.
 
         If the environment spec name is None rather than an env
@@ -489,12 +489,13 @@ class AnacondaProject(object):
             project (Project): the project
             env_spec_name (str): environment name or None for all environments
             packages (list of str): packages
+            pip (bool): Flag to request packages to be removed with pip if True else use Conda.
 
         Returns:
             ``Status`` instance
 
         """
-        return project_ops.remove_packages(project=project, env_spec_name=env_spec_name, packages=packages)
+        return project_ops.remove_packages(project=project, env_spec_name=env_spec_name, packages=packages, pip=pip)
 
     def lock(self, project, env_spec_name):
         """Attempt to freeze dependency versions in anaconda-project-lock.yml.

--- a/anaconda_project/archiver.py
+++ b/anaconda_project/archiver.py
@@ -358,9 +358,11 @@ def _archive_project(project, filename, pack_envs=False):
         for env in os.listdir(envs_path):
             ext = 'zip' if filename.lower().endswith(".zip") else 'tar'
             pack = os.path.join(conda_pack_dir, '{}_envs_{}.{}'.format(current_platform(), env, ext))
+            zip_symlinks = True if ext == 'zip' else False
             fn = conda_pack.pack(prefix=os.path.join(envs_path, env),
                                  arcroot=os.path.join(project.name, 'envs', env),
                                  output=pack,
+                                 zip_symlinks=zip_symlinks,
                                  verbose=True,
                                  force=True)
             packed_envs.append(fn)

--- a/anaconda_project/conda_manager.py
+++ b/anaconda_project/conda_manager.py
@@ -159,7 +159,7 @@ class CondaManager(with_metaclass(ABCMeta)):
         pass  # pragma: no cover
 
     @abstractmethod
-    def remove_packages(self, prefix, packages):
+    def remove_packages(self, prefix, packages, pip):
         """Remove the given package name from the environment in prefix.
 
         This method ideally would not exist. The ideal approach is
@@ -174,6 +174,7 @@ class CondaManager(with_metaclass(ABCMeta)):
         Args:
            prefix (str): environment path
            package (list of str): package names
+           pip (bool): remove packages using pip
 
         Returns:
            None

--- a/anaconda_project/conda_manager.py
+++ b/anaconda_project/conda_manager.py
@@ -426,6 +426,10 @@ class CondaLockSet(object):
         return _combine_conda_package_lists(shared, per_platform)
 
     @property
+    def pip_package_specs(self):
+        return self._package_specs_by_platform.get('pip', [])
+
+    @property
     def package_specs_for_current_platform(self):
         """Sequence of package spec strings for the current platform."""
         assert self.supports_current_platform

--- a/anaconda_project/conda_manager.py
+++ b/anaconda_project/conda_manager.py
@@ -427,6 +427,7 @@ class CondaLockSet(object):
 
     @property
     def pip_package_specs(self):
+        """Sequence of pip packages."""
         return self._package_specs_by_platform.get('pip', [])
 
     @property

--- a/anaconda_project/docker.py
+++ b/anaconda_project/docker.py
@@ -15,7 +15,7 @@ DEFAULT_BUILDER_IMAGE = 'conda/s2i-anaconda-project-ubi8'
 
 try:
     FileNotFoundError  # noqa
-except NameError:
+except NameError:      # pragma: no cover
     # python 2
     FileNotFoundError = OSError
 

--- a/anaconda_project/docker.py
+++ b/anaconda_project/docker.py
@@ -15,7 +15,7 @@ DEFAULT_BUILDER_IMAGE = 'conda/s2i-anaconda-project-ubi8'
 
 try:
     FileNotFoundError  # noqa
-except NameError:      # pragma: no cover
+except NameError:  # pragma: no cover
     # python 2
     FileNotFoundError = OSError
 

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -268,7 +268,13 @@ class EnvSpec(object):
     def pip_packages_for_create(self):
         """Get pip packages (preferring the lock set list if present)."""
         if self._lock_set is not None and self._lock_set.enabled and self._lock_set.supports_current_platform:
-            return self._lock_set.pip_package_specs
+            # This happens during the lock procedure because pip packages
+            # cannot be determined until they are installed. Conda is the
+            # reverse.
+            if not self._lock_set.pip_package_specs and self.pip_packages:
+                return self.pip_packages
+            else:
+                return self._lock_set.pip_package_specs
         else:
             return self.pip_packages
 

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -250,7 +250,6 @@ class EnvSpec(object):
     def pip_package_names_for_create_set(self):
         """Pip package names that we require, as a Python set."""
         return set(self._pip_specs_for_create_by_name.keys())
-        
 
     @property
     def lock_set(self):

--- a/anaconda_project/internal/cli/environment_commands.py
+++ b/anaconda_project/internal/cli/environment_commands.py
@@ -63,10 +63,10 @@ def add_packages(project, environment, packages, channels, pip=False):
     return _handle_status(status, success_message)
 
 
-def remove_packages(project, environment, packages):
+def remove_packages(project, environment, packages, pip):
     """Remove packages from the project."""
     project = load_project(project)
-    status = project_ops.remove_packages(project, env_spec_name=environment, packages=packages)
+    status = project_ops.remove_packages(project, env_spec_name=environment, packages=packages, pip=pip)
     package_list = ", ".join(packages)
     if environment is None:
         success_message = "Removed packages from project file: %s." % (package_list)
@@ -195,7 +195,7 @@ def main_add_packages(args):
 
 def main_remove_packages(args):
     """Start the remove-packages command and return exit status code."""
-    return remove_packages(args.directory, args.env_spec, args.packages)
+    return remove_packages(args.directory, args.env_spec, args.packages, args.pip)
 
 
 def main_add_platforms(args):

--- a/anaconda_project/internal/cli/environment_commands.py
+++ b/anaconda_project/internal/cli/environment_commands.py
@@ -51,10 +51,10 @@ def export_env_spec(project_dir, name, filename):
     return _handle_status(status)
 
 
-def add_packages(project, environment, packages, channels):
+def add_packages(project, environment, packages, channels, pip=False):
     """Add packages to the project."""
     project = load_project(project)
-    status = project_ops.add_packages(project, env_spec_name=environment, packages=packages, channels=channels)
+    status = project_ops.add_packages(project, env_spec_name=environment, packages=packages, channels=channels, pip=pip)
     package_list = ", ".join(packages)
     if environment is None:
         success_message = "Added packages to project file: %s." % (package_list)
@@ -185,7 +185,7 @@ def main_export(args):
 
 def main_add_packages(args):
     """Start the add-packages command and return exit status code."""
-    return add_packages(args.directory, args.env_spec, args.packages, args.channel)
+    return add_packages(args.directory, args.env_spec, args.packages, args.channel, args.pip)
 
 
 def main_remove_packages(args):

--- a/anaconda_project/internal/cli/environment_commands.py
+++ b/anaconda_project/internal/cli/environment_commands.py
@@ -120,8 +120,13 @@ def list_packages(project_dir, environment):
     if env is None:
         print("Project doesn't have an environment called '{}'".format(environment), file=sys.stderr)
         return 1
-    print("Packages for environment '{}':\n".format(env.name))
+    print("Conda packages for environment '{}':\n".format(env.name))
     print("\n".join(sorted(env.conda_packages)), end='\n\n')
+
+    if env.pip_packages:
+        print("Pip packages for environment '{}':\n".format(env.name))
+        print("\n".join(sorted(env.pip_packages)), end='\n\n')
+
     return 0
 
 

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -334,6 +334,7 @@ def _parse_args_and_run_subcommand(argv):
     preset = subparsers.add_parser('remove-packages', help="Remove packages from one or all project environments")
     add_directory_arg(preset)
     add_env_spec_arg(preset)
+    preset.add_argument('--pip', action='store_true', help='Uninstall the requested packages using pip.')
     preset.add_argument('packages', metavar='PACKAGE_NAME', default=None, nargs='+')
     preset.set_defaults(main=environment_commands.main_remove_packages)
 

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -281,6 +281,7 @@ def _parse_args_and_run_subcommand(argv):
     preset.set_defaults(main=service_commands.main_list)
 
     def add_package_args(preset):
+        preset.add_argument('--pip', action='store_true', help='Install the requested packages using pip.')
         preset.add_argument('-c',
                             '--channel',
                             metavar='CHANNEL',

--- a/anaconda_project/internal/cli/test/test_environment_commands.py
+++ b/anaconda_project/internal/cli/test/test_environment_commands.py
@@ -447,7 +447,7 @@ def test_remove_packages_from_all_environments(capsys, monkeypatch):
         assert '' == err
 
         assert 1 == len(params['args'])
-        assert dict(env_spec_name=None, packages=['bar']) == params['kwargs']
+        assert dict(env_spec_name=None, packages=['bar'], pip=False) == params['kwargs']
 
     with_directory_contents_completing_project_file(dict(), check)
 
@@ -465,7 +465,7 @@ def test_remove_packages_from_specific_environment(capsys, monkeypatch):
         assert '' == err
 
         assert 1 == len(params['args'])
-        assert dict(env_spec_name='foo', packages=['bar']) == params['kwargs']
+        assert dict(env_spec_name='foo', packages=['bar'], pip=False) == params['kwargs']
 
     with_directory_contents_completing_project_file(dict(), check)
 

--- a/anaconda_project/internal/cli/test/test_environment_commands.py
+++ b/anaconda_project/internal/cli/test/test_environment_commands.py
@@ -371,8 +371,7 @@ def test_add_pip_packages_to_all_environments(capsys, monkeypatch):
         _monkeypatch_pwd(monkeypatch, dirname)
         params = _monkeypatch_add_packages(monkeypatch, SimpleStatus(success=True, description='Installed ok.'))
 
-        code = _parse_args_and_run_subcommand(
-            ['anaconda-project', 'add-packages', '--pip', 'a', 'b'])
+        code = _parse_args_and_run_subcommand(['anaconda-project', 'add-packages', '--pip', 'a', 'b'])
         assert code == 0
 
         out, err = capsys.readouterr()
@@ -643,8 +642,10 @@ def _test_list_packages(capsys, env, expected_conda_deps, expected_pip_deps):
 
         project = Project(dirname)
         assert project.default_env_spec_name == 'foo'
-        expected_out = "Conda packages for environment '{}':\n{}".format(env or project.default_env_spec_name, expected_conda_deps)
-        expected_out += "Pip packages for environment '{}':\n{}".format(env or project.default_env_spec_name, expected_pip_deps)
+        expected_out = "Conda packages for environment '{}':\n{}".format(env or project.default_env_spec_name,
+                                                                         expected_conda_deps)
+        expected_out += "Pip packages for environment '{}':\n{}".format(env or project.default_env_spec_name,
+                                                                        expected_pip_deps)
         assert out == expected_out
 
     project_contents = ('env_specs:\n'

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -16,6 +16,7 @@ import re
 import shutil
 import sys
 import tempfile
+import yaml
 
 from anaconda_project.internal import streaming_popen
 from anaconda_project.internal.directory_contains import subdirectory_relative_to_directory
@@ -328,8 +329,9 @@ def installed(prefix):
 
 
 def installed_pip(prefix):
-    cmd_list = ['env', 'export', '--json', '-p', prefix]
-    parsed = _call_and_parse_json(cmd_list)
+    cmd_list = ['env', 'export', '-p', prefix]
+    stdout = _call_conda(cmd_list)
+    parsed = yaml.safe_load(stdout)
     dependencies = parsed.get('dependencies', [])
     for dep in dependencies:
         if is_dict(dep):

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -19,7 +19,7 @@ import tempfile
 
 from anaconda_project.internal import streaming_popen
 from anaconda_project.internal.directory_contains import subdirectory_relative_to_directory
-from anaconda_project.internal.py2_compat import is_string
+from anaconda_project.internal.py2_compat import is_string, is_dict
 
 CONDA_EXE = os.environ.get("CONDA_EXE", "conda")
 
@@ -325,6 +325,15 @@ def installed(prefix):
         if pieces is not None:
             result[pieces[0]] = pieces
     return result
+
+
+def installed_pip(prefix):
+    cmd_list = ['env', 'export', '--json', '-p', prefix]
+    parsed = _call_and_parse_json(cmd_list)
+    dependencies = parsed.get('dependencies', [])
+    for dep in dependencies:
+        if is_dict(dep):
+            return dep.get('pip', [])
 
 
 def resolve_dependencies(pkgs, channels=(), platform=None):

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -465,8 +465,14 @@ class DefaultCondaManager(CondaManager):
         # write a file to tell us we can short-circuit next time
         self._write_timestamp_file(prefix, spec)
 
-    def remove_packages(self, prefix, packages):
-        try:
-            conda_api.remove(prefix, packages, stdout_callback=self._on_stdout, stderr_callback=self._on_stderr)
-        except conda_api.CondaError as e:
-            raise CondaManagerError("Failed to remove packages from %s: %s" % (prefix, str(e)))
+    def remove_packages(self, prefix, packages, pip=False):
+        if pip:
+            try:
+                pip_api.remove(prefix, packages, stdout_callback=self._on_stdout, stderr_callback=self._on_stderr)
+            except pip_api.PipError as e:
+                raise CondaManagerError('Failed to remove pip packages from {}: {}'.format(prefix, str(e)))
+        else:
+            try:
+                conda_api.remove(prefix, packages, stdout_callback=self._on_stdout, stderr_callback=self._on_stderr)
+            except conda_api.CondaError as e:
+                raise CondaManagerError("Failed to remove packages from %s: %s" % (prefix, str(e)))

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -454,7 +454,7 @@ class DefaultCondaManager(CondaManager):
             specs = spec.specs_for_pip_package_names(missing)
             assert len(specs) == len(missing)
             try:
-                pip_api.install(prefix=prefix, pkgs=specs)
+                pip_api.install(prefix=prefix, pkgs=specs, stdout_callback=self._on_stdout, stderr_callback=self._on_stderr)
             except pip_api.PipError as e:
                 raise CondaManagerError("Failed to install missing pip packages: {}: {}".format(
                     ", ".join(missing), str(e)))

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -385,6 +385,7 @@ class DefaultCondaManager(CondaManager):
 
         conda_meta = os.path.join(prefix, 'conda-meta')
         packed = os.path.join(conda_meta, '.packed')
+        install_pip = True
 
         if os.path.isdir(conda_meta) and os.path.exists(packed):
             with open(packed) as f:
@@ -401,6 +402,7 @@ class DefaultCondaManager(CondaManager):
                 try:
                     subprocess.check_call(unpack_script)
                     os.remove(packed)
+                    install_pip = False
                 except (subprocess.CalledProcessError, OSError) as e:
                     self._log_info('Warning: conda-unpack could not be run: \n{}\n'
                                    'The environment will be recreated.'.format(str(e)))
@@ -450,7 +452,7 @@ class DefaultCondaManager(CondaManager):
 
         # now add pip if needed
         missing = list(deviations.missing_pip_packages)
-        if len(missing) > 0:
+        if (len(missing) > 0) and install_pip:
             specs = spec.specs_for_pip_package_names(missing)
             assert len(specs) == len(missing)
             try:

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -454,7 +454,10 @@ class DefaultCondaManager(CondaManager):
             specs = spec.specs_for_pip_package_names(missing)
             assert len(specs) == len(missing)
             try:
-                pip_api.install(prefix=prefix, pkgs=specs, stdout_callback=self._on_stdout, stderr_callback=self._on_stderr)
+                pip_api.install(prefix=prefix,
+                                pkgs=specs,
+                                stdout_callback=self._on_stdout,
+                                stderr_callback=self._on_stderr)
             except pip_api.PipError as e:
                 raise CondaManagerError("Failed to install missing pip packages: {}: {}".format(
                     ", ".join(missing), str(e)))

--- a/anaconda_project/internal/default_conda_manager.py
+++ b/anaconda_project/internal/default_conda_manager.py
@@ -335,7 +335,7 @@ class DefaultCondaManager(CondaManager):
                                               (prefix),
                                               missing_packages=tuple(spec.conda_package_names_for_create_set),
                                               wrong_version_packages=(),
-                                              missing_pip_packages=tuple(spec.pip_package_names_set),
+                                              missing_pip_packages=tuple(spec.pip_package_names_for_create_set),
                                               wrong_version_pip_packages=(),
                                               broken=True)
 

--- a/anaconda_project/internal/pip_api.py
+++ b/anaconda_project/internal/pip_api.py
@@ -8,7 +8,6 @@
 from __future__ import absolute_import, print_function
 
 import collections
-import subprocess
 import os
 import re
 import sys

--- a/anaconda_project/internal/pip_api.py
+++ b/anaconda_project/internal/pip_api.py
@@ -89,7 +89,7 @@ def installed(prefix):
     try:
         # Use freeze instead of list so we get a consistent format across
         # different versions of pip
-        out = _call_pip(prefix, extra_args=['freeze']).decode('utf-8')
+        out = _call_pip(prefix, extra_args=['freeze'])
         # on Windows, $ in a regex doesn't match \r\n, we need to get rid of \r
         out = out.replace("\r\n", "\n")
     except PipNotInstalledError:

--- a/anaconda_project/internal/pip_api.py
+++ b/anaconda_project/internal/pip_api.py
@@ -13,7 +13,7 @@ import os
 import re
 import sys
 
-from anaconda_project.internal import logged_subprocess
+from anaconda_project.internal import streaming_popen
 
 
 class PipError(Exception):
@@ -41,43 +41,44 @@ def _get_pip_command(prefix, extra_args):
     return cmd_list
 
 
-def _call_pip(prefix, extra_args):
+def _call_pip(prefix, extra_args, stdout_callback=None, stderr_callback=None):
     cmd_list = _get_pip_command(prefix, extra_args)
 
     try:
-        p = logged_subprocess.Popen(cmd_list, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        (p, stdout_lines, stderr_lines) = streaming_popen.popen(cmd_list,
+                                                                stdout_callback=stdout_callback,
+                                                                stderr_callback=stderr_callback)
     except OSError as e:
         raise PipError("failed to run: %r: %r" % (" ".join(cmd_list), repr(e)))
-    (out, err) = p.communicate()
-    errstr = err.decode().strip()
+    errstr = "".join(stderr_lines)
     if p.returncode != 0:
         raise PipError('%s: %s' % (" ".join(cmd_list), errstr))
     elif errstr != '':
         for line in errstr.split("\n"):
             print("%s %s: %s" % (cmd_list[0], cmd_list[1], line), file=sys.stderr)
-    return out
+    return "".join(stdout_lines)
 
 
-def install(prefix, pkgs=None):
+def install(prefix, pkgs=None, stdout_callback=None, stderr_callback=None):
     """Install packages into an environment."""
     if not pkgs or not isinstance(pkgs, (list, tuple)):
         raise TypeError('must specify a list of one or more packages to install into existing environment, not %r' %
                         pkgs)
 
-    args = ['install', '--quiet']
+    args = ['install']
     args.extend(pkgs)
 
-    return _call_pip(prefix, extra_args=args)
+    return _call_pip(prefix, extra_args=args, stdout_callback=stdout_callback, stderr_callback=stderr_callback)
 
 
-def remove(prefix, pkgs=None):
+def remove(prefix, pkgs=None, stdout_callback=None, stderr_callback=None):
     """Remove packages from an environment."""
     if not pkgs or not isinstance(pkgs, (list, tuple)):
         raise TypeError('must specify a list of one or more packages to remove from existing environment')
 
-    args = ['uninstall', '--quiet', '--yes']
+    args = ['uninstall', '--yes']
     args.extend(pkgs)
-    return _call_pip(prefix, extra_args=args)
+    return _call_pip(prefix, extra_args=args, stdout_callback=stdout_callback, stderr_callback=stderr_callback)
 
 
 def installed(prefix):

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -17,6 +17,7 @@ import stat
 from pprint import pprint
 
 import anaconda_project.internal.conda_api as conda_api
+import anaconda_project.internal.pip_api as pip_api
 
 from anaconda_project.internal.test.tmpfile_utils import (with_directory_contents, tmp_script_commandline)
 
@@ -147,6 +148,20 @@ def test_conda_install_no_packages(monkeypatch):
         with pytest.raises(TypeError) as excinfo:
             conda_api.install(prefix=envdir, pkgs=[])
         assert 'must specify a list' in repr(excinfo.value)
+
+    with_directory_contents(dict(), do_test)
+
+
+@pytest.mark.slow
+def test_pip_installed():
+    def do_test(dirname):
+        envdir = os.path.join(dirname, 'myenv')
+
+        conda_api.create(prefix=envdir, pkgs=['python'])
+        pip_api.install(prefix=envdir, pkgs=['chardet==3'])
+
+        pip_packages = conda_api.installed_pip(envdir)
+        assert pip_packages == ['chardet==3.0.0']
 
     with_directory_contents(dict(), do_test)
 

--- a/anaconda_project/project_lock_file.py
+++ b/anaconda_project/project_lock_file.py
@@ -139,6 +139,9 @@ env_specs: {}
         as_json = lock_set.to_json()
         self.set_value(['env_specs', env_spec_name], as_json)
 
+    def _add_pip_packages(self, env_spec_name, pip_packages):
+        self.set_value(['env_specs', env_spec_name, 'packages', 'pip'], pip_packages)
+
     def _disable_locking(self, env_spec_name):
         """Library-internal method."""
         if env_spec_name is None:

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -722,7 +722,6 @@ def remove_packages(project, env_spec_name, packages, pip=False):
         assert len(env_dicts) > 0
 
         def _get_deps(env_dict, pip=False):
-            # _pkgs = project.project_file.root.get('packages', [])
             _pkgs = env_dict.get('packages', [])
             if pip:
                 pip_dicts = [dep for dep in _pkgs if is_dict(dep) and 'pip' in dep]

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -392,7 +392,7 @@ def _updating_project_lock_file(project):
         status_holder.status = failed  # pragma: no cover # should not happen
 
 
-def _update_env_spec(project, name, packages, channels, create):
+def _update_env_spec(project, name, packages, channels, create, pip=False):
     failed = _check_problems(project)
     if failed is not None:
         return failed
@@ -424,7 +424,9 @@ def _update_env_spec(project, name, packages, channels, create):
         # packages may be a "CommentedSeq" and we don't want to lose the comments,
         # so don't convert this thing to a regular list.
         old_packages = env_dict.get('packages', [])
-        old_packages_set = set(parse_spec(dep).name for dep in old_packages if is_string(dep))
+        # old_packages_set = set(parse_spec(dep).name for dep in old_packages if is_string(dep))
+        conda_packages_set = project.env_specs[name].conda_package_names_set
+        pip_packages_set = project.env_specs[name].pip_package_names_set
         bad_specs = []
         updated_specs = []
         new_specs = []
@@ -594,7 +596,7 @@ def export_env_spec(project, name, filename):
     return SimpleStatus(success=True, description="Exported environment spec {} to {}.".format(name, filename))
 
 
-def add_packages(project, env_spec_name, packages, channels):
+def add_packages(project, env_spec_name, packages, channels, pip=False):
     """Attempt to install packages then add them to anaconda-project.yml.
 
     If the env_spec_name is None rather than an env name,
@@ -616,7 +618,7 @@ def add_packages(project, env_spec_name, packages, channels):
     Returns:
         ``Status`` instance
     """
-    return _update_env_spec(project, env_spec_name, packages, channels, create=False)
+    return _update_env_spec(project, env_spec_name, packages, channels, create=False, pip=pip)
 
 
 def remove_packages(project, env_spec_name, packages):

--- a/anaconda_project/test/test_api.py
+++ b/anaconda_project/test/test_api.py
@@ -372,7 +372,7 @@ def test_remove_packages(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.remove_packages', mock_remove_packages)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, env_spec_name='foo', packages=['a'])
+    kwargs = dict(project=43, env_spec_name='foo', packages=['a'], pip=None)
     result = p.remove_packages(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']

--- a/anaconda_project/test/test_api.py
+++ b/anaconda_project/test/test_api.py
@@ -352,7 +352,7 @@ def test_add_packages(monkeypatch):
     monkeypatch.setattr('anaconda_project.project_ops.add_packages', mock_add_packages)
 
     p = api.AnacondaProject()
-    kwargs = dict(project=43, env_spec_name='foo', packages=['a'], channels=['b'])
+    kwargs = dict(project=43, env_spec_name='foo', packages=['a'], channels=['b'], pip=False)
     result = p.add_packages(**kwargs)
     assert 42 == result
     assert kwargs == params['kwargs']

--- a/anaconda_project/test/test_docker.py
+++ b/anaconda_project/test/test_docker.py
@@ -28,6 +28,16 @@ def test_build_image_pass(monkeypatch):
     assert status
 
 
+def test_build_image_extra_args(monkeypatch):
+    def mock_check_call(*args, **kwargs):
+        return
+
+    monkeypatch.setattr('subprocess.check_call', mock_check_call)
+
+    status = build_image('.', 'tag', 'default', build_args={'-f': 'Dockerfile'})
+    assert status
+
+
 def test_build_image_failed(monkeypatch):
     def mock_check_call(*args, **kwargs):
         raise subprocess.CalledProcessError(1, 's2i', 'failed to build')

--- a/anaconda_project/test/test_project_lock_file.py
+++ b/anaconda_project/test/test_project_lock_file.py
@@ -176,6 +176,7 @@ def test_get_lock_set():
         foo_lock_set = _get_lock_set(lock_file, 'foo')
         assert foo_lock_set.enabled
         assert ('foo=1.0=1', ) == foo_lock_set.package_specs_for_current_platform
+        assert ['qbert==1.0.0'] == foo_lock_set.pip_package_specs
         bar_lock_set = _get_lock_set(lock_file, 'bar')
         assert bar_lock_set.disabled
 
@@ -191,12 +192,16 @@ env_specs:
     packages:
       all:
         - foo=1.0=1
+      pip:
+        - qbert==1.0.0
   bar:
     locked: false
     platforms: [linux-32,linux-64,osx-64,win-32,win-64]
     packages:
       all:
         - bar=2.0=2
+      pip:
+        - pbert==1.1.0
 """
         }, check_file)
 

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -4712,15 +4712,13 @@ def test_archive_unarchive_conda_pack_with_pip(suffix):
             assert status
 
         with_directory_contents_completing_project_file(
-            {
-                DEFAULT_PROJECT_FILENAME: """
+            {DEFAULT_PROJECT_FILENAME: """
 name: archivedproj
 packages:
   - python=3.8
   - pip:
     - pep8
-"""
-            }, check)
+"""}, check)
 
     with_directory_contents(dict(), archivetest)
 

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -2279,7 +2279,7 @@ def test_remove_pip_packages_from_one_environment_with_pkgs():
         # note that hello will still inherit the deps from the global packages,
         # and that's fine
         assert ['qbert', OrderedDict([('pip', ['pbert'])])] == list(project2.project_file.get_value('packages'))
-        assert [OrderedDict([('pip', [])])
+        assert ['qbert', OrderedDict([('pip', [])])
                 ] == list(project2.project_file.get_value(['env_specs', 'hello', 'packages'], []))
 
         # be sure we didn't delete comments from global packages section

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -4685,7 +4685,7 @@ name: archivedproj
 
 
 @pytest.mark.slow
-@pytset.mark.skipif((sys.version_info.major == 2) and (platform.system() == 'Linux'),
+@pytest.mark.skipif((sys.version_info.major == 2) and (platform.system() == 'Linux'),
                     reason='Something wrong with pip freeze on linux for py2')
 @pytest.mark.parametrize('suffix', ['zip', 'tar.bz2', 'tar.gz'])
 def test_archive_unarchive_conda_pack_with_pip(suffix):

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -16,6 +16,7 @@ import stat
 import tarfile
 import zipfile
 import glob
+import sys
 from collections import OrderedDict
 
 from anaconda_project import project_ops
@@ -4684,6 +4685,8 @@ name: archivedproj
 
 
 @pytest.mark.slow
+@pytset.mark.skipif((sys.version_info.major == 2) and (platform.system() == 'Linux'),
+                    reason='Something wrong with pip freeze on linux for py2')
 @pytest.mark.parametrize('suffix', ['zip', 'tar.bz2', 'tar.gz'])
 def test_archive_unarchive_conda_pack_with_pip(suffix):
     def archivetest(archive_dest_dir):

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1968,7 +1968,9 @@ def test_add_pip_packages_to_all_environments():
 
         # be sure we really made the config changes
         project2 = Project(dirname)
-        assert [dict(pip=['foo', 'bar']), ] == list(project2.project_file.get_value('packages'))
+        assert [
+            dict(pip=['foo', 'bar']),
+        ] == list(project2.project_file.get_value('packages'))
         # assert ['hello', 'world'] == list(project2.project_file.get_value('channels'))
 
         for env_spec in project2.env_specs.values():

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -4715,7 +4715,7 @@ def test_archive_unarchive_conda_pack_with_pip(suffix):
             {DEFAULT_PROJECT_FILENAME: """
 name: archivedproj
 packages:
-  - python=3.8
+  - python=3.7
   - pip:
     - pep8
 """}, check)

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -1,3 +1,5 @@
+.. _Configuration:
+
 =============
 Configuration
 =============

--- a/docs/source/user-guide/reference.rst
+++ b/docs/source/user-guide/reference.rst
@@ -477,6 +477,84 @@ you'll also get the dependencies those versions were tested with.
 And you'll be able to see changes in your dependencies over time
 in your revision control history.
 
+Additionally, all pip packages added to the ``anaconda-project.yml`` file
+or installed as dependencies will be added to the ``anaconda-project-lock.yml``
+file similar to the output of ``pip freeze``. For example, see the following
+``anaconda-project-lock.yml`` file that matches the following package specification.
+
+.. code-block:: yaml
+
+  packages:
+    - python=3.8
+    - pip:
+      - requests
+
+.. code-block:: yaml
+
+  locking_enabled: true
+  
+  env_specs:
+    default:
+      locked: true
+      env_spec_hash: 292a009a194f1ca1d3432c824df6ff51a7aef388
+      platforms:
+      - linux-64
+      - osx-64
+      - win-64
+      packages:
+        all:
+        - wheel=0.36.2=pyhd3eb1b0_0
+        linux-64:
+        - _libgcc_mutex=0.1=main
+        - ca-certificates=2021.4.13=h06a4308_1
+        - certifi=2020.12.5=py38h06a4308_0
+        - ld_impl_linux-64=2.33.1=h53a641e_7
+        - libffi=3.3=he6710b0_2
+        - libgcc-ng=9.1.0=hdf63c60_0
+        - libstdcxx-ng=9.1.0=hdf63c60_0
+        - ncurses=6.2=he6710b0_1
+        - openssl=1.1.1k=h27cfd23_0
+        - pip=21.0.1=py38h06a4308_0
+        - python=3.8.8=hdb3f193_5
+        - readline=8.1=h27cfd23_0
+        - setuptools=52.0.0=py38h06a4308_0
+        - sqlite=3.35.4=hdfb4753_0
+        - tk=8.6.10=hbc83047_0
+        - xz=5.2.5=h7b6447c_0
+        - zlib=1.2.11=h7b6447c_3
+        osx-64:
+        - ca-certificates=2021.4.13=hecd8cb5_1
+        - certifi=2020.12.5=py38hecd8cb5_0
+        - libcxx=10.0.0=1
+        - libffi=3.3=hb1e8313_2
+        - ncurses=6.2=h0a44026_1
+        - openssl=1.1.1k=h9ed2024_0
+        - pip=21.0.1=py38hecd8cb5_0
+        - python=3.8.8=h88f2d9e_5
+        - readline=8.1=h9ed2024_0
+        - setuptools=52.0.0=py38hecd8cb5_0
+        - sqlite=3.35.4=hce871da_0
+        - tk=8.6.10=hb0a8c7a_0
+        - xz=5.2.5=h1de35cc_0
+        - zlib=1.2.11=h1de35cc_3
+        win-64:
+        - ca-certificates=2021.4.13=haa95532_1
+        - certifi=2020.12.5=py38haa95532_0
+        - openssl=1.1.1k=h2bbff1b_0
+        - pip=21.0.1=py38haa95532_0
+        - python=3.8.8=hdbf39b2_5
+        - setuptools=52.0.0=py38haa95532_0
+        - sqlite=3.35.4=h2bbff1b_0
+        - vc=14.2=h21ff451_1
+        - vs2015_runtime=14.27.29016=h5e58377_2
+        - wincertstore=0.2=py38_0
+        pip:
+        - chardet==4.0.0
+        - idna==2.10
+        - requests==2.25.1
+        - urllib3==1.26.4
+
+
 Specifying supported platforms
 ==============================
 

--- a/docs/source/user-guide/tasks/create-project.rst
+++ b/docs/source/user-guide/tasks/create-project.rst
@@ -24,3 +24,45 @@ Creating a project
    see what the file looks like for an empty project. As you work
    with your project, the ``anaconda-project`` commands you use
    will modify this file.
+
+By default the ``init`` command will add the ``anaconda`` metapackage
+to the default environment. This metapackage will install over 200 of the
+most commonly used data science and scientific computing packages.
+
+The ``anaconda-project.yml`` file will include the following sections
+
+.. code-block:: yaml
+
+  name: iris
+
+  packages:
+    - anaconda
+  channels: []
+
+  env_specs:
+    default:
+      description: Default environment spec for running commands
+      packages: []
+      channels: []
+      platforms: []
+
+To create an ``anaconda-project.yml`` file with no default packages run::
+
+  anaconda-project init --empty-environment --directory iris
+
+*******************
+Prepare environment
+*******************
+
+Once the project directory and ``anaconda-project.yml`` file have been created
+``cd`` into the new directory and install the packages::
+
+  anaconda-project prepare
+
+This will create a new Conda environment in a subdirectory of your project
+directory called ``envs/default``.
+
+For more information about adding and removing packages and environments (``env_specs``)
+see :ref:`Packages`.
+
+See :ref:`Configuration` to change the default location of the Conda environments.

--- a/docs/source/user-guide/tasks/work-with-commands.rst
+++ b/docs/source/user-guide/tasks/work-with-commands.rst
@@ -68,6 +68,22 @@ to add code files to your project:
 #. OPTIONAL: In a text editor, open ``anaconda-project.yml`` to
    see the new command listed in the commands section.
 
+Specifying multi-line commands
+==============================
+
+Commands added to the ``anaconda-project.yml`` file can can
+multiple lines of execution by using the YAML ``|`` string specifier.
+For example a single command can be defined in the ``anaconda-project.yml``
+file to run multiple linting tools.
+
+.. code-block:: yaml
+
+  commands:
+    unix: |
+      yapf --in-place
+      flake8
+      pep256
+
 
 Using commands that need different environments
 ===============================================

--- a/docs/source/user-guide/tasks/work-with-commands.rst
+++ b/docs/source/user-guide/tasks/work-with-commands.rst
@@ -71,7 +71,7 @@ to add code files to your project:
 Specifying multi-line commands
 ==============================
 
-Commands added to the ``anaconda-project.yml`` file can can
+Commands added to the ``anaconda-project.yml`` file can span
 multiple lines of execution by using the YAML ``|`` string specifier.
 For example a single command can be defined in the ``anaconda-project.yml``
 file to run multiple linting tools.

--- a/docs/source/user-guide/tasks/work-with-packages.rst
+++ b/docs/source/user-guide/tasks/work-with-packages.rst
@@ -34,7 +34,7 @@ Adding packages
 ***************
 
 To add packages to your project that are not yet in your
-``packages:`` list:
+``packages:`` list there are two appraoches.
 
 #. From within your project directory, run::
 
@@ -54,37 +54,15 @@ To add packages to your project that are not yet in your
      Using Conda environment /Users/adefusco/Desktop/iris/envs/default.
      Added packages to project file: hvplot=0.7, dask.
 
-#. OPTIONAL: In a text editor, open ``anaconda-project.yml`` to
-   see the new packages listed in the packages section. To install the packages
-   run ``anaconda-project prepare``.
+#. Instead of using the ``add-packages`` command you can edit the ``anaconda-project.yml``
+   file directly using any text editor and add package names to the ``packages:`` list.
+   To complete the installation of these new packages into your activate environment run
+   ``anaconda-project prepare`` on the command line after saving the file.
 
-*****************
-Removing packages
-*****************
-
-To remove packages from the ``packages:`` list run::
-
-  anaconda-project remove-packages package1 package2
-
-NOTE: Replace ``package1`` and ``package2`` with the names of
-the packages that you want to include. You can specify as many
-packages as you want.
-
-EXAMPLE: To remove the package hvplot::
-
-  $ anaconda-project remove-packages hvplot
-  Using Conda environment /Users/adefusco/Desktop/testproj/envs/default.
-  Removed packages from project file: hvplot.
-
-******************
-Using pip packages
-******************
-
-In addition to adding and removing Conda packages as shown above Pip packages
+In addition to adding Conda packages as shown above Pip packages
 can be specified using the ``--pip`` flag::
 
   anaconda-project add-packages --pip package1 package2
-  anaconda-project remove-packages --pip package1 package2
 
 NOTE: Replace ``package1`` and ``package2`` with the names of
 the packages that you want to include. You can specify as many
@@ -126,7 +104,25 @@ the ``pip:`` key within the ``packages:`` list. For example,
 
 Then run ``anaconda-project prepare`` to install the new packages into the environment.
 
-EXAMPLE: To remove the ``requests`` package from the default environment::
+*****************
+Removing packages
+*****************
+
+To remove packages from the ``packages:`` list run::
+
+  anaconda-project remove-packages package1 package2
+
+NOTE: Replace ``package1`` and ``package2`` with the names of
+the packages that you want to include. You can specify as many
+packages as you want.
+
+EXAMPLE: To remove the package hvplot::
+
+  $ anaconda-project remove-packages hvplot
+  Using Conda environment /Users/adefusco/Desktop/testproj/envs/default.
+  Removed packages from project file: hvplot.
+
+EXAMPLE: To remove the ``requests`` pip package from the default environment::
 
   $ anaconda-project remove-packages --pip requests
   Found existing installation: requests 2.25.1
@@ -144,7 +140,6 @@ Pip packages can specified in a number of ways.
 * From PyPI (or other indexes)
 * Direct URL to the package archive
 * Revision Control services (for example git and svn)
-* Package directories inside the Anaconda Project itself
 
 To install a package from a revision control service::
 
@@ -159,7 +154,8 @@ Where
 * ``<package>`` is the name of the package as declared in ``setup.py``
 
 NOTE: It is required that you use ``#egg=<package>`` to install a revision control hosted
-package.
+package. This is considered `best practice by pip <https://pip.pypa.io/en/latest/cli/pip_install/#vcs-support>`_ and allows the pip dependency solver to 
+correctly identify the package if it is a dependency of another package in your project.
 
 EXAMPLE: Add the tranquilizer package to your project directly from Github::
 

--- a/docs/source/user-guide/tasks/work-with-packages.rst
+++ b/docs/source/user-guide/tasks/work-with-packages.rst
@@ -1,9 +1,40 @@
+.. _Packages:
+
 =====================
 Working with packages
 =====================
 
-To include packages in your project that are not yet in your
-environment:
+The ``anaconda-project.yml`` file enables specification
+of required packages and multiple Conda environments, referred
+to as ``env_specs``.
+
+For example the following ``anaconda-project.yml`` file will
+install ``python`` version 3.8, and latest version ``pandas``
+and ``notebook`` into the default environment when you execute
+``anaconda-project prepare`` on the command line.
+
+.. code-block:: yaml
+
+  name: ExampleProject
+
+  packages:
+    - python=3.8
+    - notebook
+    - pandas
+  
+  env_specs:
+    default: {}
+
+When ``anaconda-project prepare`` is run a new environment is created
+called ``default`` in the ``envs`` subdirectory of your project.
+See :ref:`Configuration` to change the default location of the Conda environments.
+
+***************
+Adding packages
+***************
+
+To add packages to your project that are not yet in your
+``packages:`` list:
 
 #. From within your project directory, run::
 
@@ -13,19 +44,136 @@ environment:
    the packages that you want to include. You can specify as many
    packages as you want.
 
-   The packages are installed in your project's environment, so
-   you now see package files in your project folder, such as::
+   EXAMPLE: To add the packages hvplot=0.7 and dask::
 
-     envs/PATH/package1
-
-   NOTE: Replace PATH with the actual path to your package.
-
-   EXAMPLE: To add the packages Bokeh and pandas::
-
-     $ anaconda-project add-packages bokeh=0.12 pandas
-     conda install: Using Anaconda Cloud api site https://api.anaconda.org
-     Using Conda environment /home/alice/mystuff/iris/envs/default.
-     Added packages to project file: bokeh=0.12, pandas.
+     $ anaconda-project add-packages hvplot=0.7 dask
+     Collecting package metadata (current_repodata.json): ...working... done
+     Solving environment: ...working... done
+     ...
+     Executing transaction: ...working... done
+     Using Conda environment /Users/adefusco/Desktop/iris/envs/default.
+     Added packages to project file: hvplot=0.7, dask.
 
 #. OPTIONAL: In a text editor, open ``anaconda-project.yml`` to
-   see the new packages listed in the packages section.
+   see the new packages listed in the packages section. To install the packages
+   run ``anaconda-project prepare``.
+
+*****************
+Removing packages
+*****************
+
+To remove packages from the ``packages:`` list run::
+
+  anaconda-project remove-packages package1 package2
+
+NOTE: Replace ``package1`` and ``package2`` with the names of
+the packages that you want to include. You can specify as many
+packages as you want.
+
+EXAMPLE: To remove the package hvplot::
+
+  $ anaconda-project remove-packages hvplot
+  Using Conda environment /Users/adefusco/Desktop/testproj/envs/default.
+  Removed packages from project file: hvplot.
+
+******************
+Using pip packages
+******************
+
+In addition to adding and removing Conda packages as shown above Pip packages
+can be specified using the ``--pip`` flag::
+
+  anaconda-project add-packages --pip package1 package2
+  anaconda-project remove-packages --pip package1 package2
+
+NOTE: Replace ``package1`` and ``package2`` with the names of
+the packages that you want to include. You can specify as many
+packages as you want.
+
+EXAMPLE: To add the ``requests`` package to the default environment::
+
+  $ anaconda-project add-packages --pip requests
+  Collecting requests
+    Using cached requests-2.25.1-py2.py3-none-any.whl (61 kB)
+  Requirement already satisfied: certifi>=2017.4.17 in ./envs/default/lib/python3.8/site-packages (from requests) (2020.12.5)
+  Collecting idna<3,>=2.5
+    Using cached idna-2.10-py2.py3-none-any.whl (58 kB)
+  Collecting chardet<5,>=3.0.2
+    Using cached chardet-4.0.0-py2.py3-none-any.whl (178 kB)
+  Collecting urllib3<1.27,>=1.21.1
+    Using cached urllib3-1.26.4-py2.py3-none-any.whl (153 kB)
+  Installing collected packages: urllib3, idna, chardet, requests
+  Successfully installed chardet-4.0.0 idna-2.10 requests-2.25.1 urllib3-1.26.4
+  Using Conda environment /Users/adefusco/Desktop/testproj/envs/default.
+  Added packages to project file: requests.
+
+Optionally, you can edit the ``anaconda-project.yml`` file to add packages using
+the ``pip:`` key within the ``packages:`` list. For example,
+
+.. code-block:: yaml
+
+  name: ExampleProject
+
+  packages:
+    - python=3.8
+    - notebook
+    - pandas
+    - pip:
+      - requests
+  
+  env_specs:
+    default: {}
+
+Then run ``anaconda-project prepare`` to install the new packages into the environment.
+
+EXAMPLE: To remove the ``requests`` package from the default environment::
+
+  $ anaconda-project remove-packages --pip requests
+  Found existing installation: requests 2.25.1
+  Uninstalling requests-2.25.1:
+    Successfully uninstalled requests-2.25.1
+  Using Conda environment /Users/adefusco/Desktop/testproj/envs/default.
+  Removed packages from project file: requests.
+
+
+Pip package specifications
+==========================
+
+Pip packages can specified in a number of ways.
+
+* From PyPI (or other indexes)
+* Direct URL to the package archive
+* Revision Control services (for example git and svn)
+* Package directories inside the Anaconda Project itself
+
+To install a package from a revision control service::
+
+  anaconda-project add-packages --pip git+<protocol>://<revision-control-domain>/<repository.git>[version-branch]#egg=<package-name>
+
+Where
+
+* ``<protocol>`` is the web protocol of the domain: i.e, ``http`` or ``https``
+* ``<revision-control-domain>`` is the URL of the service: i.e. ``github.com``
+* ``<repository.git>`` is the name of the revision control repository, you can include the branch name or release tag here.
+* ``[version-branch]`` optionally install a specific version or branch of the repository
+* ``<package>`` is the name of the package as declared in ``setup.py``
+
+NOTE: It is required that you use ``#egg=<package>`` to install a revision control hosted
+package.
+
+EXAMPLE: Add the tranquilizer package to your project directly from Github::
+
+  $ anaconda-project add-packages --pip git+https://github.com/continuumio/tranquilizer.git@0.5.0#egg=tranquilizer
+  Collecting tranquilizer
+  Cloning https://github.com/continuumio/tranquilizer.git (to revision 0.5.0) to /private/var/folders/lk/s__7f9fx15x_zrw6q5xkmm500000gp/T/pip-install-5ncd7pbt/tranquilizer_d037aa7b85d048c1acd4e2f0044c4cea
+  Using Conda environment /Users/adefusco/Desktop/testproj/envs/default.
+  Added packages to project file: git+https://github.com/continuumio/tranquilizer.git@0.5.0#egg=tranquilizer.
+
+Alternatively for github you can use the URL of the repository archive. For example, to install
+from the master branch of tranquilizer::
+
+  $ anaconda-project add-packages --pip https://github.com/continuumio/tranquilizer/archive/master.zip#egg=tranquilizer
+  Collecting tranquilizer
+  Downloading https://github.com/continuumio/tranquilizer/archive/master.zip
+  Using Conda environment /Users/adefusco/Desktop/testproj/envs/default.
+  Added packages to project file: https://github.com/continuumio/tranquilizer/archive/master.zip#egg=tranquilizer.


### PR DESCRIPTION
This PR adds several pip improvements (see #181)

- displays pip install output on `anaconda-project prepare`
- displays pip packages on `anaconda-project list-packages`
- adds `anaconda-project add-packages --pip ...` to install packages and add pip packages to the yaml file
- enables full pip package locking with `anaconda-project lock`

TODO:

- [x] Add pip locking tests
- [x] implement `anaconda-project remove-packages --pip ...`

## pip install output

```yaml
# anaconda-project.yml file
name: pip-pkgs

packages:
- python=3.7
- pip:
  - chardet
channels: []

env_specs:
  default: {}
  test:
    packages:
    - pip:
      - requests
    channels: []
platforms:
- linux-64
- osx-64
- win-64
```

```
> anaconda-project prepare
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/adefusco/Development/AnacondaPlatform/anaconda-project/examples/pip/envs/default

  added / updated specs:
    - python=3.7


The following NEW packages will be INSTALLED:

  ca-certificates    pkgs/main/osx-64::ca-certificates-2021.4.13-hecd8cb5_1
  certifi            pkgs/main/osx-64::certifi-2020.12.5-py37hecd8cb5_0
  libcxx             pkgs/main/osx-64::libcxx-10.0.0-1
  libffi             pkgs/main/osx-64::libffi-3.3-hb1e8313_2
  ncurses            pkgs/main/osx-64::ncurses-6.2-h0a44026_1
  openssl            pkgs/main/osx-64::openssl-1.1.1k-h9ed2024_0
  pip                pkgs/main/osx-64::pip-21.0.1-py37hecd8cb5_0
  python             pkgs/main/osx-64::python-3.7.10-h88f2d9e_0
  readline           pkgs/main/osx-64::readline-8.1-h9ed2024_0
  setuptools         pkgs/main/osx-64::setuptools-52.0.0-py37hecd8cb5_0
  sqlite             pkgs/main/osx-64::sqlite-3.35.4-hce871da_0
  tk                 pkgs/main/osx-64::tk-8.6.10-hb0a8c7a_0
  wheel              pkgs/main/noarch::wheel-0.36.2-pyhd3eb1b0_0
  xz                 pkgs/main/osx-64::xz-5.2.5-h1de35cc_0
  zlib               pkgs/main/osx-64::zlib-1.2.11-h1de35cc_3


Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
#
# To activate this environment, use
#
#     $ conda activate /Users/adefusco/Development/AnacondaPlatform/anaconda-project/examples/pip/envs/default
#
# To deactivate an active environment, use
#
#     $ conda deactivate

Collecting chardet
  Using cached chardet-4.0.0-py2.py3-none-any.whl (178 kB)
Installing collected packages: chardet
Successfully installed chardet-4.0.0
The project is ready to run commands.
Use `anaconda-project list-commands` to see what's available.
```

## list pip packages

```
>anaconda-project list-packages
Conda packages for environment 'default':

python=3.7

Pip packages for environment 'default':

chardet
```

## locking with pip packages

```
> anaconda-project lock
Updating locked dependencies for env spec default...
Resolving conda packages for osx-64
Resolving conda packages for linux-64
Resolving conda packages for win-64
...

> tail -n 10 anaconda-project-lock.yml 
      - openssl=1.1.1k=h2bbff1b_0
      - pip=21.0.1=py37haa95532_0
      - python=3.7.10=h6244533_0
      - setuptools=52.0.0=py37haa95532_0
      - sqlite=3.35.4=h2bbff1b_0
      - vc=14.2=h21ff451_1
      - vs2015_runtime=14.27.29016=h5e58377_2
      - wincertstore=0.2=py37_0
      pip:
      - chardet==4.0.0
```

## add pip packages

packages added to default env-spec

```
> anaconda-project add-packages --pip requests
Collecting requests
  Using cached requests-2.25.1-py2.py3-none-any.whl (61 kB)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.4-py2.py3-none-any.whl (153 kB)
Requirement already satisfied: certifi>=2017.4.17 in ./envs/default/lib/python3.7/site-packages (from requests) (2020.12.5)
Collecting idna<3,>=2.5
  Using cached idna-2.10-py2.py3-none-any.whl (58 kB)
Requirement already satisfied: chardet<5,>=3.0.2 in ./envs/default/lib/python3.7/site-packages (from requests) (4.0.0)
Installing collected packages: urllib3, idna, requests
Successfully installed idna-2.10 requests-2.25.1 urllib3-1.26.4
Using Conda environment /Users/adefusco/Development/AnacondaPlatform/anaconda-project/examples/pip/envs/default.
Added packages to project file: requests.
```

## add pip packages to env-spec

```
> anaconda-project prepare --env-spec test
...
Executing transaction: ...working... done
#
# To activate this environment, use
#
#     $ conda activate /Users/adefusco/Development/AnacondaPlatform/anaconda-project/examples/pip/envs/test
#
# To deactivate an active environment, use
#
#     $ conda deactivate

Collecting chardet
  Using cached chardet-4.0.0-py2.py3-none-any.whl (178 kB)
Collecting requests
  Using cached requests-2.25.1-py2.py3-none-any.whl (61 kB)
Requirement already satisfied: certifi>=2017.4.17 in ./envs/test/lib/python3.7/site-packages (from requests) (2020.12.5)
Collecting idna<3,>=2.5
  Using cached idna-2.10-py2.py3-none-any.whl (58 kB)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.4-py2.py3-none-any.whl (153 kB)
Installing collected packages: urllib3, idna, chardet, requests
Successfully installed chardet-4.0.0 idna-2.10 requests-2.25.1 urllib3-1.26.4
The project is ready to run commands.
Use `anaconda-project list-commands` to see what's available.

```

```
> anaconda-project add-packages --pip --env-spec test pytest
Collecting pytest
  Using cached pytest-6.2.3-py3-none-any.whl (280 kB)
Collecting py>=1.8.2
  Using cached py-1.10.0-py2.py3-none-any.whl (97 kB)
Collecting toml
  Using cached toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting packaging
  Using cached packaging-20.9-py2.py3-none-any.whl (40 kB)
Collecting attrs>=19.2.0
  Using cached attrs-20.3.0-py2.py3-none-any.whl (49 kB)
Collecting importlib-metadata>=0.12
  Using cached importlib_metadata-4.0.1-py3-none-any.whl (16 kB)
Collecting iniconfig
  Using cached iniconfig-1.1.1-py2.py3-none-any.whl (5.0 kB)
Collecting pluggy<1.0.0a1,>=0.12
  Using cached pluggy-0.13.1-py2.py3-none-any.whl (18 kB)
Collecting typing-extensions>=3.6.4
  Using cached typing_extensions-3.7.4.3-py3-none-any.whl (22 kB)
Collecting zipp>=0.5
  Using cached zipp-3.4.1-py3-none-any.whl (5.2 kB)
Collecting pyparsing>=2.0.2
  Using cached pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
Installing collected packages: zipp, typing-extensions, pyparsing, importlib-metadata, toml, py, pluggy, packaging, iniconfig, attrs, pytest
Successfully installed attrs-20.3.0 importlib-metadata-4.0.1 iniconfig-1.1.1 packaging-20.9 pluggy-0.13.1 py-1.10.0 pyparsing-2.4.7 pytest-6.2.3 toml-0.10.2 typing-extensions-3.7.4.3 zipp-3.4.1
Using Conda environment /Users/adefusco/Development/AnacondaPlatform/anaconda-project/examples/pip/envs/test.
Added packages to environment test in project file: pytest.
```






