### PR TITLE
Fix extract for zipfiles from Github/Gitlab

### DIFF
--- a/anaconda_project/archiver.py
+++ b/anaconda_project/archiver.py
@@ -440,7 +440,8 @@ def _extractall_chmod(zf, destination):
     for zinfo in zf.infolist():
         out_path = zf.extract(zinfo.filename, path=destination)
         mode = zinfo.external_attr >> 16
-        os.chmod(out_path, mode)
+        if not (mode == 0):
+            os.chmod(out_path, mode)
 
 
 def _extract_files_zip(zip_path, src_and_dest, frontend):

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -4963,7 +4963,8 @@ def test_unarchive_zip_mode_zero():
             'a/q/b.txt': _CONTENTS_FILE,
             'a/c': _CONTENTS_DIR,
             'a': _CONTENTS_DIR
-        }, mode_zero=True)
+        },
+                                mode_zero=True)
 
         # with zipfile.ZipFile(archivefile, 'r') as zf:
         #    print(repr(zf.namelist()))


### PR DESCRIPTION
Zip files from Github and Gitlab have `external_attr` set to 16 for all files, which would lead `chmod` to attempt to set permission 0, which may not have a meaning.

This skips the chmod if external_attr is 16

TODO:

- [x] tests