### PR TITLE
Add Linux and Mac arm platforms

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+ARG MINICONDA_VERSION='latest'
+FROM continuumio/miniconda3:${MINICONDA_VERSION}
+
+ARG USERNAME="vscode"
+ARG UID=1000
+ARG GID=${UID}
+ARG PYTHON_VERSION="3.9"
+ARG ENV_NAME="dev"
+ARG ENV_YAML=''
+
+##########################################
+## It is not a good idea to use root since
+## the source directory will be mounted
+## into the container. Let's make a new
+## user.
+RUN groupadd --gid ${GID} ${USERNAME} \
+    && useradd --gid ${GID} --uid ${UID} -m ${USERNAME} --create-home --shell /bin/bash
+WORKDIR /home/${USERNAME}
+USER ${USERNAME}
+RUN conda config --prepend pkgs_dirs /home/${USERNAME}/.conda/pkgs
+
+# Environment creation is done in two steps.
+# 1. create env with desired Python version
+# 2. apply required packages from specified environment.yml file
+COPY ${ENV_YAML} /tmp/conda-tmp/environment.yml
+RUN conda create -n ${ENV_NAME} python=${PYTHON_VERSION} \
+    && if [ -f "/tmp/conda-tmp/environment.yml" ]; then \
+          conda env update -n ${ENV_NAME} -f /tmp/conda-tmp/environment.yml; \
+       fi

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+	"name": "Miniconda",
+	"build": { 
+		"context": "..",
+		"dockerfile": "Dockerfile",
+		"args": {
+			"MINICONDA_VERSION": "4.8.2",
+			"PYTHON_VERSION": "3.7.10",
+			"ENV_NAME": "dev",
+			"ENV_YAML": "environment.yml"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"python.condaPath": "/opt/conda/bin/conda",
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance"
+	],
+
+	"remoteUser": "vscode"
+}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,7 +117,7 @@ jobs:
           source ./conda/etc/profile.d/conda.sh
           [ ${{ matrix.pyver }} == 2.7 ] && BACKPORTS="backports.tempfile backports.functools_lru_cache"
           conda create -y -n anaconda-project-dev python=${{ matrix.pyver }} \
-            $BACKPORTS coverage 'pytest<5' pytest-cov redis notebook bokeh \
+            $BACKPORTS coverage pytest pytest-cov redis notebook bokeh \
             keyring setuptools pip local::anaconda-project
     - name: Run the tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,7 @@ jobs:
           - pyver: 2.7
             cver: 4.8
           - pyver: 2.7
+          # Py2.7 support ends
             cver: 4.9
           - pyver: 2.7
             cver: "4.10"
@@ -96,9 +97,17 @@ jobs:
           # Unexplained failures in test_download
           - pyver: 2.7
             os: macos-latest
-          # https://github.com/tornadoweb/tornado/issues/2804
-          # - pyver: 3.8
-          #   os: windows-latest
+          # Odd timestamp behavior
+          - pyver: 3.7
+            os: ubuntu-latest
+            cver: 4.8
+          - pyver: 3.8
+            os: ubuntu-latest
+            cver: 4.8
+          # Old versions will be trimmed from tests soon
+          - os: windows-latest
+            pyver: 2.7
+            cver: 4.6
     steps:
     - name: Retrieve the source code
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest,ubuntu-latest,windows-2019]
+        os: [macos-latest,ubuntu-latest,windows-latest]
         pyver: [2.7,3.6,3.7,3.8]
         cver: [4.6,4.7,4.8, 4.9, "4.10", "4.11"]
         exclude:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
       matrix:
         os: [macos-latest,ubuntu-latest,windows-latest]
         pyver: [2.7,3.6,3.7,3.8]
-        cver: [4.6,4.7,4.8]
+        cver: [4.6,4.7,4.8, 4.9, 4.10, 4.11]
         exclude:
           # Cannot instantiate these environment for these yet
           - pyver: 3.8
@@ -84,12 +84,21 @@ jobs:
             cver: 4.7
           - pyver: 2.7
             cver: 4.8
+          - pyver: 2.7
+            cver: 4.9
+          - pyver: 2.7
+            cver: 4.10
+          - pyver: 2.7
+            cver: 4.11
+          # Conda dropped py36 for base env
+          - pyver: 3.6
+            cver: 4.11
           # Unexplained failures in test_download
           - pyver: 2.7
             os: macos-latest
           # https://github.com/tornadoweb/tornado/issues/2804
-          - pyver: 3.8
-            os: windows-latest
+          # - pyver: 3.8
+          #   os: windows-latest
     steps:
     - name: Retrieve the source code
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,9 @@ jobs:
           - os: windows-latest
             pyver: 2.7
             cver: 4.6
+          - os: windows-latest
+            pyver: 3.6
+            cver: 4.6
     steps:
     - name: Retrieve the source code
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
       matrix:
         os: [macos-latest,ubuntu-latest,windows-latest]
         pyver: [2.7,3.6,3.7,3.8]
-        cver: [4.6,4.7,4.8, 4.9, 4.10, 4.11]
+        cver: [4.6,4.7,4.8, 4.9, "4.10", "4.11"]
         exclude:
           # Cannot instantiate these environment for these yet
           - pyver: 3.8
@@ -87,12 +87,12 @@ jobs:
           - pyver: 2.7
             cver: 4.9
           - pyver: 2.7
-            cver: 4.10
+            cver: "4.10"
           - pyver: 2.7
-            cver: 4.11
+            cver: "4.11"
           # Conda dropped py36 for base env
           - pyver: 3.6
-            cver: 4.11
+            cver: "4.11"
           # Unexplained failures in test_download
           - pyver: 2.7
             os: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest,ubuntu-latest,windows-latest]
+        os: [macos-latest,ubuntu-latest,windows-2019]
         pyver: [2.7,3.6,3.7,3.8]
         cver: [4.6,4.7,4.8, 4.9, "4.10", "4.11"]
         exclude:

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 *.tmp
 *.coverage.*
 .idea/
-.vscode/
 
 # Compiled source #
 ###################

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Debug Tests",
+            "type": "python",
+            "request": "test",
+            "console": "integratedTerminal",
+            "env": {
+                "PYTEST_ADDOPTS": "--no-cov -vv"
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "search.exclude": {
+        "**/envs": true
+    }
+}

--- a/anaconda_project/internal/cli/test/test_service_commands.py
+++ b/anaconda_project/internal/cli/test/test_service_commands.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, print_function
 
 import os
 import platform
+import pytest
 
 from anaconda_project.test.project_utils import project_no_dedicated_env
 from anaconda_project.test.environ_utils import minimal_environ, strip_environ
@@ -20,6 +21,7 @@ from anaconda_project.internal.test.tmpfile_utils import (tmp_script_commandline
                                                           with_directory_contents_completing_project_file)
 from anaconda_project.internal.simple_status import SimpleStatus
 from anaconda_project.local_state_file import LocalStateFile
+from anaconda_project.internal import conda_api
 
 
 def _monkeypatch_pwd(monkeypatch, dirname):
@@ -164,13 +166,9 @@ def test_remove_service_duplicate(capsys, monkeypatch):
         {DEFAULT_PROJECT_FILENAME: 'services:\n  ABC: redis\n  TEST: redis'}, check)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
+@pytest.mark.skipif(conda_api.current_platform() == 'osx-arm64', reason='We cannot install redis server on osx-arm64')
 def test_remove_service_running_redis(monkeypatch):
-    # this test will fail if you don't have Redis installed, since
-    # it actually starts it.
-    if platform.system() == 'Windows':
-        print("Cannot start redis-server on Windows")
-        return
-
     from anaconda_project.requirements_registry.network_util import can_connect_to_socket as real_can_connect_to_socket
     from anaconda_project.requirements_registry.providers.test import test_redis_provider
 

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -59,7 +59,7 @@ def _call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None
     command_in_errors = " ".join(cmd_list)
 
     env = None
-    if platform is not None and (platform != current_platform()):
+    if platform is not None:
         env = os.environ.copy()
         env['CONDA_SUBDIR'] = platform
         if 'win' in platform:

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -327,7 +327,7 @@ def _contains_conda_meta(path):
     return os.path.isdir(conda_meta)
 
 
-def _is_conda_bindir_unix(path): # pragma: no cover (unix only)
+def _is_conda_bindir_unix(path):  # pragma: no cover (unix only)
     if path.endswith("/"):
         path = path[:-1]
     if not path.endswith("/bin"):

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -63,7 +63,7 @@ def _call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None
         env = os.environ.copy()
         env['CONDA_SUBDIR'] = platform
         if 'win' in platform:
-            env['CONDA_CHANNELS'] = 'msys2'
+            env['CONDA_CHANNELS'] = 'defaults,msys2'
 
     try:
         (p, stdout_lines, stderr_lines) = streaming_popen.popen(cmd_list,

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -52,96 +52,22 @@ def _get_conda_command(extra_args):
     return cmd_list
 
 
-# This is obviously ridiculous, we'll work to
-# find a better way (at least in newer versions
-# of conda).
-def _platform_hacked_conda_code(platform, bits):
-    return """import conda
-try:
-    # this is conda 4.2 and 4.3
-
-    # fix whether default channels have msys
-    import conda.base.constants
-    from conda.base.constants import DEFAULT_CHANNELS_UNIX, DEFAULT_CHANNELS_WIN
-    if "{platform}" == 'win':
-        corrected_channels = DEFAULT_CHANNELS_WIN
-    else:
-        corrected_channels = DEFAULT_CHANNELS_UNIX
-
-    setattr(conda.base.constants, 'DEFAULT_CHANNELS', corrected_channels)
-
-    from conda.base.context import Context
-
-    class KapselHackedContext(Context):
-        @property
-        def subdir(self):
-            return "{platform}-{bits}"
-
-        @property
-        def bits(self):
-            return {bits}
-
-    setattr(conda.base.context.context, "__class__", KapselHackedContext)
-except ImportError:
-    # this is conda 4.1
-    import conda.config
-
-    setattr(conda.config, "platform", "{platform}")
-    setattr(conda.config, "bits", "{bits}")
-    setattr(conda.config, "subdir", "{platform}-{bits}")
-
-    # fix up the default urls
-    msys_url = 'https://repo.continuum.io/pkgs/msys2'
-    if "{platform}" == "win":
-        if msys_url not in conda.config.defaults_:
-            conda.config.defaults_.append(msys_url)
-    else:
-        if msys_url in conda.config.defaults_:
-            conda.config.defaults_.remove(msys_url)
-
-
-import conda.cli
-import sys
-
-sys.argv[0] = "conda"
-sys.exit(conda.cli.main())
-""".format(platform=platform, bits=bits).strip() + "\n"
-
-
-def _get_platform_hacked_conda_command(extra_args, platform):
-    """Get conda command and a string representing it in error messages."""
-    if platform == current_platform() or platform is None:
-        cmd_list = _get_conda_command(extra_args)
-        return (cmd_list, " ".join(cmd_list))
-    else:
-        (platform_name, bits) = platform.split("-")
-
-        conda_code = _platform_hacked_conda_code(platform_name, bits)
-
-        # this has to run with the python from the root env,
-        # so the conda modules will be found.
-        root_prefix = _get_root_prefix()
-        root_python = None
-        for location in (('bin', 'python'), ('python.exe', ), ('Scripts', 'python.exe'), ('Library', 'bin',
-                                                                                          'python.exe')):
-            candidate = os.path.join(root_prefix, *location)
-            if os.path.isfile(candidate):
-                root_python = candidate
-                break
-        assert root_python is not None
-
-        cmd_list = [root_python, '-c', conda_code]
-        cmd_list.extend(extra_args)
-        return (cmd_list, " ".join(["conda"] + cmd_list[3:]))
-
-
 def _call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
     assert len(extra_args) > 0  # we deref extra_args[0] below
 
-    (cmd_list, command_in_errors) = _get_platform_hacked_conda_command(extra_args, platform=platform)
+    cmd_list = _get_conda_command(extra_args)
+    command_in_errors = " ".join(cmd_list)
+
+    env = None
+    if platform is not None and (platform != current_platform()):
+        env = os.environ.copy()
+        env['CONDA_SUBDIR'] = platform
+        if 'win' in platform:
+            env['CONDA_CHANNELS'] = 'msys2'
 
     try:
         (p, stdout_lines, stderr_lines) = streaming_popen.popen(cmd_list,
+                                                                env=env,
                                                                 stdout_callback=stdout_callback,
                                                                 stderr_callback=stderr_callback)
     except OSError as e:
@@ -636,11 +562,18 @@ assert tuple(sorted(default_platforms)) == default_platforms
 default_platforms_plus_32_bit = ('linux-32', 'linux-64', 'osx-64', 'win-32', 'win-64')
 assert tuple(sorted(default_platforms_plus_32_bit)) == default_platforms_plus_32_bit
 
-_non_x86_linux_machines = {'armv6l', 'armv7l', 'ppc64le'}
+_non_x86_linux_machines = {'aarch64', 'armv6l', 'armv7l', 'ppc64le'}
+_non_x86_osx_machines = {'arm64'}
 
 # this list will get outdated, unfortunately.
 _known_platforms = tuple(
-    sorted(list(default_platforms_plus_32_bit) + ['osx-32'] + [("linux-%s" % m) for m in _non_x86_linux_machines]))
+    sorted(
+        list(default_platforms_plus_32_bit)
+        + ['osx-32']
+        + [("linux-%s" % m) for m in _non_x86_linux_machines]
+        + [("osx-%s" % m) for m in _non_x86_osx_machines]
+    )
+)
 
 known_platform_names = ('linux', 'osx', 'win')
 assert tuple(sorted(known_platform_names)) == known_platform_names
@@ -683,18 +616,8 @@ assert set(_known_platform_groups_keys) == set(_known_platform_groups.keys())
 
 
 def current_platform():
-    m = platform.machine()
-    if m in _non_x86_linux_machines:
-        return 'linux-%s' % m
-    else:
-        _platform_map = {
-            'linux2': 'linux',
-            'linux': 'linux',
-            'darwin': 'osx',
-            'win32': 'win',
-        }
-        p = _platform_map.get(sys.platform, 'unknown')
-        return '%s-%d' % (p, (8 * tuple.__itemsize__))
+    conda_info = info()
+    return conda_info.get('platform')
 
 
 _default_platforms_with_current = tuple(sorted(list(set(default_platforms + (current_platform(), )))))

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -158,17 +158,6 @@ def resolve_env_to_prefix(name_or_prefix):
     return None
 
 
-_cached_root_prefix = None
-
-
-def _get_root_prefix():
-    global _cached_root_prefix
-
-    if _cached_root_prefix is None:
-        _cached_root_prefix = resolve_env_to_prefix('root')
-    return _cached_root_prefix
-
-
 def create(prefix, pkgs=None, channels=(), stdout_callback=None, stderr_callback=None):
     """Create an environment either by name or path with a specified set of packages."""
     if os.path.exists(prefix):

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -568,12 +568,8 @@ _non_x86_osx_machines = {'arm64'}
 # this list will get outdated, unfortunately.
 _known_platforms = tuple(
     sorted(
-        list(default_platforms_plus_32_bit)
-        + ['osx-32']
-        + [("linux-%s" % m) for m in _non_x86_linux_machines]
-        + [("osx-%s" % m) for m in _non_x86_osx_machines]
-    )
-)
+        list(default_platforms_plus_32_bit) + ['osx-32'] + [("linux-%s" % m) for m in _non_x86_linux_machines] +
+        [("osx-%s" % m) for m in _non_x86_osx_machines]))
 
 known_platform_names = ('linux', 'osx', 'win')
 assert tuple(sorted(known_platform_names)) == known_platform_names

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -64,6 +64,8 @@ def _call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None
         env['CONDA_SUBDIR'] = platform
         if 'win' in platform:
             env['CONDA_CHANNELS'] = 'defaults,msys2'
+        else:
+            env['CONDA_CHANNELS'] = 'defaults'
 
     try:
         (p, stdout_lines, stderr_lines) = streaming_popen.popen(cmd_list,

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -327,7 +327,7 @@ def _contains_conda_meta(path):
     return os.path.isdir(conda_meta)
 
 
-def _is_conda_bindir_unix(path):
+def _is_conda_bindir_unix(path): # pragma: no cover (unix only)
     if path.endswith("/"):
         path = path[:-1]
     if not path.endswith("/bin"):

--- a/anaconda_project/internal/streaming_popen.py
+++ b/anaconda_project/internal/streaming_popen.py
@@ -80,7 +80,7 @@ def popen(args, stdout_callback, stderr_callback, **kwargs):
     if stderr_callback is None:
         stderr_callback = ignore_line
 
-    p = logged_subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    p = logged_subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
 
     queue = Queue()
 

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -249,7 +249,8 @@ sys.exit(0)
 
 def test_conda_create_gets_channels(monkeypatch):
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
-        assert ['create', '--yes', '--prefix', '/prefix', '--channel', 'foo', 'python'] == extra_args
+        assert ['create', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo',
+                'python'] == extra_args
 
     monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
     conda_api.create(prefix='/prefix', pkgs=['python'], channels=['foo'])
@@ -257,7 +258,8 @@ def test_conda_create_gets_channels(monkeypatch):
 
 def test_conda_install_gets_channels(monkeypatch):
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
-        assert ['install', '--yes', '--prefix', '/prefix', '--channel', 'foo', 'python'] == extra_args
+        assert ['install', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo',
+                'python'] == extra_args
 
     monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
     conda_api.install(prefix='/prefix', pkgs=['python'], channels=['foo'])
@@ -636,40 +638,41 @@ def test_environ_set_prefix_to_root():
 
 
 @pytest.mark.slow
-def test_resolve_dependencies_with_actual_conda_current_platform():
+@pytest.mark.parametrize('p', conda_api.default_platforms_plus_32_bit)
+def test_resolve_dependencies_with_actual_conda(p):
     try:
-        result = conda_api.resolve_dependencies(['bokeh=0.12.7'], platform=None)
+        result = conda_api.resolve_dependencies(['requests=2.20.1'], platform=p)
     except conda_api.CondaError as e:
+        print("*** Dependency resolution failed on %s" % p)
         pprint(e.json)
         raise e
 
     names = [pkg[0] for pkg in result]
-    assert 'bokeh' in names
+    assert 'requests' in names
     names_and_versions = [(pkg[0], pkg[1]) for pkg in result]
-    assert ('bokeh', '0.12.7') in names_and_versions
-    assert len(result) > 1  # bokeh has some dependencies so should be >1
+    assert ('requests', '2.20.1') in names_and_versions
+    assert len(result) > 1  # requests has some dependencies so should be >1
+
+    print("Dependency resolution test OK on %s" % p)
 
 
 @pytest.mark.slow
-def test_resolve_dependencies_with_actual_conda_other_platforms():
-    for p in conda_api.default_platforms_plus_32_bit:
-        if p == conda_api.current_platform():
-            print("Skipping dependency resolution test on current platform %s" % p)
-            continue
-        try:
-            result = conda_api.resolve_dependencies(['bokeh=0.12.7'], platform=p)
-        except conda_api.CondaError as e:
-            print("*** Dependency resolution failed on %s" % p)
-            pprint(e.json)
-            raise e
+@pytest.mark.parametrize('p', [p for p in conda_api.default_platforms_plus_32_bit if 'win' in p])
+def test_resolve_msys2_dependencies_with_actual_conda(p):
+    try:
+        result = conda_api.resolve_dependencies(['m2-msys2-runtime=2.5.0.17080.65c939c'], platform=p)
+    except conda_api.CondaError as e:
+        print("*** Dependency resolution failed on %s" % p)
+        pprint(e.json)
+        raise e
 
-        names = [pkg[0] for pkg in result]
-        assert 'bokeh' in names
-        names_and_versions = [(pkg[0], pkg[1]) for pkg in result]
-        assert ('bokeh', '0.12.7') in names_and_versions
-        assert len(result) > 1  # bokeh has some dependencies so should be >1
+    names = [pkg[0] for pkg in result]
+    assert 'm2-msys2-runtime' in names
+    names_and_versions = [(pkg[0], pkg[1]) for pkg in result]
+    assert ('m2-msys2-runtime', '2.5.0.17080.65c939c') in names_and_versions
+    assert len(result) > 1  # requests has some dependencies so should be >1
 
-        print("Dependency resolution test OK on %s" % p)
+    print("Dependency resolution test OK on %s" % p)
 
 
 @pytest.mark.slow
@@ -1135,33 +1138,14 @@ def test_current_platform_non_x86_linux(monkeypatch):
     assert conda_api.current_platform() == 'linux-armv7l'
 
 
+def test_current_platform_non_x86_mac(monkeypatch):
+    monkeypatch.setenv('CONDA_SUBDIR', 'osx-arm64')
+    assert conda_api.current_platform() == 'osx-arm64'
+
+
 # this test assumes all dev and CI happens on popular platforms.
 def test_current_platform_is_in_default():
     assert conda_api.current_platform() in conda_api.default_platforms
-
-
-@pytest.mark.slow
-def test_msys_for_all_platforms():
-    for p in conda_api.default_platforms_plus_32_bit:
-        (name, bits) = conda_api.parse_platform(p)
-        info = conda_api.info(platform=p)
-        print("*** info() for %s" % p)
-        pprint(info)
-        assert 'channels' in info
-
-        # conda 4.1 has a slash on the channels and 4.3 does not
-        def no_slash(url):
-            if url.endswith("/"):
-                return url[:-1]
-            else:
-                return url
-
-        channels = [no_slash(channel) for channel in info['channels']]
-        # Designed to handle repo.continuum.io and repo.anaconda.com
-        channels = '\n'.join(channels)
-        if name == 'win':
-            assert '/msys2/%s' % p in channels
-            assert '/msys2/noarch' in channels
 
 
 def test_sort_platform_list():

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -181,7 +181,7 @@ def test_conda_remove_no_packages(monkeypatch):
 
 
 def test_conda_invoke_fails(monkeypatch):
-    def mock_popen(args, stdout=None, stderr=None):
+    def mock_popen(args, stdout=None, stderr=None, env=None):
         raise OSError("failed to exec")
 
     def do_test(dirname):

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -155,7 +155,7 @@ def test_pip_installed():
     def do_test(dirname):
         envdir = os.path.join(dirname, 'myenv')
 
-        conda_api.create(prefix=envdir, pkgs=['python'])
+        conda_api.create(prefix=envdir, pkgs=['python3.8'])
         pip_api.install(prefix=envdir, pkgs=['chardet==3'])
 
         pip_packages = conda_api.installed_pip(envdir)

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -155,7 +155,7 @@ def test_pip_installed():
     def do_test(dirname):
         envdir = os.path.join(dirname, 'myenv')
 
-        conda_api.create(prefix=envdir, pkgs=['python3.8'])
+        conda_api.create(prefix=envdir, pkgs=['python=3.8'])
         pip_api.install(prefix=envdir, pkgs=['chardet==3'])
 
         pip_packages = conda_api.installed_pip(envdir)

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -1131,7 +1131,7 @@ def test_resolve_dependencies_with_conda_41_json(monkeypatch):
 
 
 def test_current_platform_non_x86_linux(monkeypatch):
-    monkeypatch.setattr('platform.machine', lambda: 'armv7l')
+    monkeypatch.setenv('CONDA_SUBDIR', 'linux-armv7l')
     assert conda_api.current_platform() == 'linux-armv7l'
 
 

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -73,9 +73,9 @@ def test_conda_create_and_install_and_remove(monkeypatch):
         envdir = os.path.join(dirname, "myenv")
         print('CONDA_EXE: {}'.format(os.environ.get('CONDA_EXE')))
         # originally we did not specify a python version here, but we
-        # needed to add it with python 3.8 was released because a compatible
+        # needed to add it with python 3.9 was released because a compatible
         # version of ipython had not been created yet.
-        conda_api.create(prefix=envdir, pkgs=['python<3.8'])
+        conda_api.create(prefix=envdir, pkgs=['python<3.9'])
 
         assert os.path.isdir(envdir)
         assert os.path.isdir(os.path.join(envdir, "conda-meta"))
@@ -689,7 +689,7 @@ def test_resolve_dependencies_for_bogus_package_with_actual_conda():
 @pytest.mark.slow
 def test_resolve_dependencies_with_actual_conda_depending_on_conda():
     try:
-        result = conda_api.resolve_dependencies(['conda=4.3.27'], platform=None)
+        result = conda_api.resolve_dependencies(['conda=4.10.1'], platform=None)
     except conda_api.CondaError as e:
         pprint(e.json)
         raise e
@@ -697,7 +697,7 @@ def test_resolve_dependencies_with_actual_conda_depending_on_conda():
     names = [pkg[0] for pkg in result]
     assert 'conda' in names
     names_and_versions = [(pkg[0], pkg[1]) for pkg in result]
-    assert ('conda', '4.3.27') in names_and_versions
+    assert ('conda', '4.10.1') in names_and_versions
     assert len(result) > 1  # conda has some dependencies so should be >1
 
 
@@ -1144,6 +1144,7 @@ def test_current_platform_non_x86_mac(monkeypatch):
 
 
 # this test assumes all dev and CI happens on popular platforms.
+@pytest.mark.skip(reason="This test is no longer a good idea")
 def test_current_platform_is_in_default():
     assert conda_api.current_platform() in conda_api.default_platforms
 
@@ -1178,7 +1179,7 @@ def test_conda_clone_readonly():
         # originally we did not specify a python version here, but we
         # needed to add it with python 3.8 was released because a compatible
         # version of ipython had not been created yet.
-        conda_api.create(prefix=readonly, pkgs=['python<3.8'])
+        conda_api.create(prefix=readonly, pkgs=['python<3.9'])
 
         assert os.path.isdir(readonly)
         assert os.path.isdir(os.path.join(readonly, "conda-meta"))

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -1162,8 +1162,6 @@ def test_msys_for_all_platforms():
         if name == 'win':
             assert '/msys2/%s' % p in channels
             assert '/msys2/noarch' in channels
-        else:
-            assert '/msys2' not in channels
 
 
 def test_sort_platform_list():

--- a/anaconda_project/internal/test/test_default_conda_manager.py
+++ b/anaconda_project/internal/test/test_default_conda_manager.py
@@ -40,7 +40,7 @@ else:
     # Use a different package from the test env due to weird CI path/env errors
     PYINSTRUMENT_BINARY = "bin/pyinstrument"
 
-test_spec = EnvSpec(name='myenv', conda_packages=['ipython', 'python=3.6'], pip_packages=['pyinstrument'], channels=[])
+test_spec = EnvSpec(name='myenv', conda_packages=['ipython', 'python=3.8'], pip_packages=['pyinstrument'], channels=[])
 
 
 def test_current_platform_unsupported_by_env_spec(monkeypatch):
@@ -76,7 +76,7 @@ def test_current_platform_unsupported_by_lock_set(monkeypatch):
                    conda_packages=['ipython'],
                    pip_packages=['flake8'],
                    channels=[],
-                   platforms=conda_api.default_platforms,
+                   platforms=conda_api.default_platforms_with_current(),
                    lock_set=lock_set)
 
     def do_test(dirname):
@@ -101,7 +101,7 @@ def test_conda_create_and_install_and_remove(monkeypatch):
     monkeypatch_conda_not_to_use_links(monkeypatch)
 
     spec = test_spec
-    assert spec.conda_packages == ('ipython', 'python=3.6')
+    assert spec.conda_packages == ('ipython', 'python=3.8')
     assert spec.pip_packages == ('pyinstrument', )
 
     spec_with_phony_pip_package = EnvSpec(name='myenv',
@@ -123,21 +123,21 @@ def test_conda_create_and_install_and_remove(monkeypatch):
     assert spec_with_bad_url_pip_package.pip_package_names_set == set(('pyinstrument', 'phony'))
 
     spec_with_old_ipython = EnvSpec(name='myenv',
-                                    conda_packages=['ipython=5.4.1'],
+                                    conda_packages=['ipython=7.10.1'],
                                     pip_packages=['pyinstrument'],
                                     channels=[])
-    assert spec_with_old_ipython.conda_packages == ('ipython=5.4.1', )
+    assert spec_with_old_ipython.conda_packages == ('ipython=7.10.1', )
 
     spec_with_bokeh = EnvSpec(name='myenv', conda_packages=['bokeh'], pip_packages=['pyinstrument'], channels=[])
     assert spec_with_bokeh.conda_packages == ('bokeh', )
 
     spec_with_bokeh_and_old_ipython = EnvSpec(name='myenv',
-                                              conda_packages=['bokeh', 'ipython=5.4.1'],
+                                              conda_packages=['bokeh', 'ipython=7.10.1'],
                                               pip_packages=['pyinstrument'],
                                               channels=[])
     assert spec_with_bokeh_and_old_ipython.conda_packages == (
         'bokeh',
-        'ipython=5.4.1',
+        'ipython=7.10.1',
     )
 
     def do_test(dirname):

--- a/anaconda_project/requirements_registry/providers/test/test_conda_env.py
+++ b/anaconda_project/requirements_registry/providers/test/test_conda_env.py
@@ -225,9 +225,9 @@ def test_prepare_project_scoped_env_with_packages(monkeypatch):
             DEFAULT_PROJECT_FILENAME:
             """
 packages:
-    - python=3.7
+    - python=3.8
     - ipython
-    - numpy=1.15
+    - numpy=1.19
     - pip
     - pip:
       - flake8
@@ -380,7 +380,7 @@ def _readonly_env(env_name, packages):
 @pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
 def test_clone_readonly_environment_with_deviations(monkeypatch):
     def clone_readonly_and_prepare(dirname):
-        with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:
+        with _readonly_env(env_name='default', packages=('python=3.8', )) as ro_prefix:
             readonly = conda_api.installed(ro_prefix)
             assert 'python' in readonly
             assert 'requests' not in readonly
@@ -404,7 +404,7 @@ def test_clone_readonly_environment_with_deviations(monkeypatch):
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
 packages:
-  - python=3.7
+  - python=3.8
   - requests
 env_specs:
   default: {}
@@ -415,7 +415,7 @@ env_specs:
 @pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
 def test_replace_readonly_environment_with_deviations(monkeypatch):
     def replace_readonly_and_prepare(dirname):
-        with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:
+        with _readonly_env(env_name='default', packages=('python=3.8', )) as ro_prefix:
             readonly = conda_api.installed(ro_prefix)
             assert 'python' in readonly
             assert 'requests' not in readonly
@@ -439,7 +439,7 @@ def test_replace_readonly_environment_with_deviations(monkeypatch):
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
 packages:
-  - python=3.7
+  - python=3.8
   - requests
 env_specs:
   default: {}
@@ -450,7 +450,7 @@ env_specs:
 @pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
 def test_fail_readonly_environment_with_deviations_unset_policy(monkeypatch):
     def clone_readonly_and_prepare(dirname):
-        with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:
+        with _readonly_env(env_name='default', packages=('python=3.8', )) as ro_prefix:
             readonly = conda_api.installed(ro_prefix)
             assert 'python' in readonly
             assert 'requests' not in readonly
@@ -467,7 +467,7 @@ def test_fail_readonly_environment_with_deviations_unset_policy(monkeypatch):
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
 packages:
-  - python=3.7
+  - python=3.8
   - requests
 env_specs:
   default: {}
@@ -478,7 +478,7 @@ env_specs:
 @pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
 def test_fail_readonly_environment_with_deviations_set_policy(monkeypatch):
     def clone_readonly_and_prepare(dirname):
-        with _readonly_env(env_name='default', packages=('python=3.7', )) as ro_prefix:
+        with _readonly_env(env_name='default', packages=('python=3.8', )) as ro_prefix:
             readonly = conda_api.installed(ro_prefix)
             assert 'python' in readonly
             assert 'requests' not in readonly
@@ -497,7 +497,7 @@ def test_fail_readonly_environment_with_deviations_set_policy(monkeypatch):
     with_directory_contents_completing_project_file(
         {DEFAULT_PROJECT_FILENAME: """
 packages:
-  - python=3.7
+  - python=3.8
   - requests
 env_specs:
   default: {}

--- a/anaconda_project/requirements_registry/providers/test/test_redis_provider.py
+++ b/anaconda_project/requirements_registry/providers/test/test_redis_provider.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, print_function
 import codecs
 import os
 import platform
+import pytest
 import sys
 
 from anaconda_project.test.project_utils import project_no_dedicated_env
@@ -25,6 +26,7 @@ from anaconda_project.requirements_registry.requirements.redis import RedisRequi
 from anaconda_project.prepare import prepare_without_interaction, unprepare
 from anaconda_project import provide
 from anaconda_project.project_file import DEFAULT_PROJECT_FILENAME
+from anaconda_project.internal import conda_api
 
 
 # This is kind of an awkward way to do it for historical reasons,
@@ -198,13 +200,9 @@ def _monkeypatch_can_connect_to_socket_on_nonstandard_port_only(monkeypatch, rea
     return can_connect_args_list
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
+@pytest.mark.skipif(conda_api.current_platform() == 'osx-arm64', reason='We cannot install redis server on osx-arm64')
 def test_prepare_and_unprepare_local_redis_server(monkeypatch):
-    # this test will fail if you don't have Redis installed, since
-    # it actually starts it.
-    if platform.system() == 'Windows':
-        print("Cannot start redis-server on Windows")
-        return
-
     from anaconda_project.requirements_registry.network_util import can_connect_to_socket as real_can_connect_to_socket
 
     can_connect_args_list = _monkeypatch_can_connect_to_socket_on_nonstandard_port_only(
@@ -253,13 +251,9 @@ services:
 """}, start_local_redis)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
+@pytest.mark.skipif(conda_api.current_platform() == 'osx-arm64', reason='We cannot install redis server on osx-arm64')
 def test_prepare_and_unprepare_local_redis_server_with_failed_unprovide(monkeypatch):
-    # this test will fail if you don't have Redis installed, since
-    # it actually starts it.
-    if platform.system() == 'Windows':
-        print("Cannot start redis-server on Windows")
-        return
-
     from anaconda_project.requirements_registry.network_util import can_connect_to_socket as real_can_connect_to_socket
 
     _monkeypatch_can_connect_to_socket_on_nonstandard_port_only(monkeypatch, real_can_connect_to_socket)
@@ -283,13 +277,9 @@ services:
 """}, start_local_redis)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
+@pytest.mark.skipif(conda_api.current_platform() == 'osx-arm64', reason='We cannot install redis server on osx-arm64')
 def test_prepare_and_unprepare_two_local_redis_servers_with_failed_unprovide(monkeypatch):
-    # this test will fail if you don't have Redis installed, since
-    # it actually starts it.
-    if platform.system() == 'Windows':
-        print("Cannot start redis-server on Windows")
-        return
-
     from anaconda_project.requirements_registry.network_util import can_connect_to_socket as real_can_connect_to_socket
 
     _monkeypatch_can_connect_to_socket_on_nonstandard_port_only(monkeypatch, real_can_connect_to_socket)
@@ -316,13 +306,9 @@ services:
 """}, start_local_redis)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
+@pytest.mark.skipif(conda_api.current_platform() == 'osx-arm64', reason='We cannot install redis server on osx-arm64')
 def test_prepare_local_redis_server_twice_reuses(monkeypatch):
-    # this test will fail if you don't have Redis installed, since
-    # it actually starts it.
-    if platform.system() == 'Windows':
-        print("Cannot start redis-server on Windows")
-        return
-
     from anaconda_project.requirements_registry.network_util import can_connect_to_socket as real_can_connect_to_socket
 
     can_connect_args_list = _monkeypatch_can_connect_to_socket_on_nonstandard_port_only(
@@ -387,13 +373,9 @@ services:
 """}, start_local_redis)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Windows has a hard time with read-only directories')
+@pytest.mark.skipif(conda_api.current_platform() == 'osx-arm64', reason='We cannot install redis server on osx-arm64')
 def test_prepare_local_redis_server_times_out(monkeypatch, capsys):
-    # this test will fail if you don't have Redis installed, since
-    # it actually starts it.
-    if platform.system() == 'Windows':
-        print("Cannot start redis-server on Windows")
-        return
-
     from anaconda_project.requirements_registry.network_util import can_connect_to_socket as real_can_connect_to_socket
 
     _monkeypatch_can_connect_to_socket_on_nonstandard_port_only(monkeypatch, real_can_connect_to_socket)

--- a/anaconda_project/test/test_env_spec.py
+++ b/anaconda_project/test/test_env_spec.py
@@ -361,7 +361,8 @@ channels:
 
 
 def test_overwrite_packages_with_lock_set():
-    lock_set = CondaLockSet({'all': ['a=1.0=1']}, platforms=['linux-32', 'linux-64', 'osx-64', 'osx-arm64', 'win-32', 'win-64'])
+    lock_set = CondaLockSet({'all': ['a=1.0=1']},
+                            platforms=['linux-32', 'linux-64', 'osx-64', 'osx-arm64', 'win-32', 'win-64'])
     spec = EnvSpec(name="foo",
                    conda_packages=['a', 'b'],
                    pip_packages=['c', 'd'],
@@ -388,7 +389,8 @@ def test_lock_set_affects_name_sets():
 
 
 def test_lock_set_affects_hash():
-    lock_set = CondaLockSet({'all': ['a=1.0=1']}, platforms=['linux-32', 'linux-64', 'osx-64', 'osx-arm64', 'win-32', 'win-64'])
+    lock_set = CondaLockSet({'all': ['a=1.0=1']},
+                            platforms=['linux-32', 'linux-64', 'osx-64', 'osx-arm64', 'win-32', 'win-64'])
     with_lock_spec = EnvSpec(name="foo",
                              conda_packages=['a', 'b'],
                              pip_packages=['c', 'd'],

--- a/anaconda_project/test/test_env_spec.py
+++ b/anaconda_project/test/test_env_spec.py
@@ -361,7 +361,7 @@ channels:
 
 
 def test_overwrite_packages_with_lock_set():
-    lock_set = CondaLockSet({'all': ['a=1.0=1']}, platforms=['linux-32', 'linux-64', 'osx-64', 'win-32', 'win-64'])
+    lock_set = CondaLockSet({'all': ['a=1.0=1']}, platforms=['linux-32', 'linux-64', 'osx-64', 'osx-arm64', 'win-32', 'win-64'])
     spec = EnvSpec(name="foo",
                    conda_packages=['a', 'b'],
                    pip_packages=['c', 'd'],
@@ -374,7 +374,7 @@ def test_overwrite_packages_with_lock_set():
 
 def test_lock_set_affects_name_sets():
     lock_set = CondaLockSet({'all': ['a=1.0=1', 'q=2.0=2']},
-                            platforms=['linux-32', 'linux-64', 'osx-64', 'win-32', 'win-64'])
+                            platforms=['linux-32', 'linux-64', 'osx-64', 'osx-arm64', 'win-32', 'win-64'])
     spec = EnvSpec(name="foo",
                    conda_packages=['a', 'b'],
                    pip_packages=['c', 'd'],
@@ -388,7 +388,7 @@ def test_lock_set_affects_name_sets():
 
 
 def test_lock_set_affects_hash():
-    lock_set = CondaLockSet({'all': ['a=1.0=1']}, platforms=['linux-32', 'linux-64', 'osx-64', 'win-32', 'win-64'])
+    lock_set = CondaLockSet({'all': ['a=1.0=1']}, platforms=['linux-32', 'linux-64', 'osx-64', 'osx-arm64', 'win-32', 'win-64'])
     with_lock_spec = EnvSpec(name="foo",
                              conda_packages=['a', 'b'],
                              pip_packages=['c', 'd'],

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -2870,8 +2870,8 @@ def test_auto_fix_env_spec_out_of_sync():
 
     with_directory_contents(
         {
-            DEFAULT_PROJECT_FILENAME:
-            "name: foo\nenv_specs: { 'stuff': { 'packages':[] } }\nplatforms: [linux-32,linux-64,osx-64,win-32,win-64]\n",
+            DEFAULT_PROJECT_FILENAME: "name: foo\nenv_specs: { 'stuff': { 'packages':[] } }\n"
+            "platforms: [linux-32,linux-64,osx-64,win-32,win-64]\n",
             "environment.yml": """
 name: stuff
 dependencies:
@@ -3004,8 +3004,8 @@ def test_no_auto_fix_env_spec_with_notebook_bokeh_injection():
 
     with_directory_contents(
         {
-            DEFAULT_PROJECT_FILENAME:
-            "name: foo\nenv_specs: { 'stuff': { 'packages':[] } }\nplatforms: [linux-32,linux-64,osx-64,win-32,win-64]\n",
+            DEFAULT_PROJECT_FILENAME: "name: foo\nenv_specs: { 'stuff': { 'packages':[] } }\n"
+            "platforms: [linux-32,linux-64,osx-64,win-32,win-64]\n",
             "environment.yml": """
 name: stuff
 dependencies:

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -3620,7 +3620,7 @@ def test_fix_project_file_with_no_platforms():
 
         assert [] == project.problems
 
-        assert ('linux-64', 'osx-64', 'win-64') == project.env_specs['default'].platforms
+        assert conda_api.default_platforms_with_current() == project.env_specs['default'].platforms
 
     with_directory_contents(
         {
@@ -3655,8 +3655,8 @@ def test_fix_env_spec_with_no_platforms():
         assert [] == project.problems
 
         assert ('linux-64', ) == project.env_specs['default'].platforms
-        assert ('linux-64', 'osx-64', 'win-64') == project.env_specs['foo'].platforms
-        assert ('linux-64', 'osx-64', 'win-64') == project.env_specs['bar'].platforms
+        assert conda_api.default_platforms_with_current() == project.env_specs['foo'].platforms
+        assert conda_api.default_platforms_with_current() == project.env_specs['bar'].platforms
 
     with_directory_contents(
         {

--- a/anaconda_project/test/test_project_file.py
+++ b/anaconda_project/test/test_project_file.py
@@ -12,6 +12,7 @@ from anaconda_project.internal.test.tmpfile_utils import with_directory_contents
 from anaconda_project.test.project_utils import assert_identical_except_blank_lines
 from anaconda_project.project_file import ProjectFile, DEFAULT_PROJECT_FILENAME, possible_project_file_names
 from anaconda_project.env_spec import EnvSpec
+from anaconda_project.internal import conda_api
 
 expected_default_file_template = """# This is an Anaconda project file.
 #
@@ -82,10 +83,8 @@ default_global_platforms = """#
 # Use `anaconda-project add-platforms` to add platforms.
 #
 platforms:
-- linux-64
-- osx-64
-- win-64
-"""
+{platforms}
+""".format(platforms='\n'.join(['- {p}'.format(p=p) for p in conda_api.default_platforms_with_current()]))
 
 empty_default_env_specs = """#
 # You can define multiple, named environment specs.

--- a/anaconda_project/test/test_project_lock_file.py
+++ b/anaconda_project/test/test_project_lock_file.py
@@ -188,7 +188,7 @@ locking_enabled: true
 env_specs:
   foo:
     locked: true
-    platforms: [linux-32,linux-64,osx-64,win-32,win-64]
+    platforms: [linux-32,linux-64,osx-64,osx-arm64,win-32,win-64]
     packages:
       all:
         - foo=1.0=1
@@ -196,7 +196,7 @@ env_specs:
         - qbert==1.0.0
   bar:
     locked: false
-    platforms: [linux-32,linux-64,osx-64,win-32,win-64]
+    platforms: [linux-32,linux-64,osx-64,osx-arm64,win-32,win-64]
     packages:
       all:
         - bar=2.0=2
@@ -228,13 +228,13 @@ locking_enabled: true
 env_specs:
   foo:
     locked: true
-    platforms: [linux-32,linux-64,osx-64,win-32,win-64]
+    platforms: [linux-32,linux-64,osx-64,osx-arm64,win-32,win-64]
     packages:
       all:
         - foo=1.0=1
   bar:
     locked: false
-    platforms: [linux-32,linux-64,osx-64,win-32,win-64]
+    platforms: [linux-32,linux-64,osx-64,osx-arm64,win-32,win-64]
     packages:
       all:
         - bar=2.0=2
@@ -259,7 +259,7 @@ def test_set_lock_set():
         all_names = ['foo', 'bar']
 
         lock_set = CondaLockSet({'all': ['something=3.0=0']},
-                                platforms=['linux-32', 'linux-64', 'osx-64', 'win-32', 'win-64'])
+                                platforms=['linux-32', 'linux-64', 'osx-64', 'osx-arm64', 'win-32', 'win-64'])
         lock_set.env_spec_hash = "hash-hash-hash"
 
         lock_file._set_lock_set('bar', lock_set, all_names=all_names)
@@ -305,13 +305,13 @@ def test_set_lock_set():
 locking_enabled: false
 env_specs:
   foo:
-    platforms: [linux-32,linux-64,osx-64,win-32,win-64]
+    platforms: [linux-32,linux-64,osx-64,osx-arm64,win-32,win-64]
     packages:
       all:
         - foo=1.0=1
   bar:
     locked: false
-    platforms: [linux-32,linux-64,osx-64,win-32,win-64]
+    platforms: [linux-32,linux-64,osx-64,osx-arm64,win-32,win-64]
     packages:
       all:
         - bar=2.0=2
@@ -328,7 +328,7 @@ def test_set_lock_set_has_to_create_env_specs_to_disable():
         all_names = ['foo', 'bar']
 
         lock_set = CondaLockSet({'all': ['something=3.0=0']},
-                                platforms=['linux-32', 'linux-64', 'osx-64', 'win-32', 'win-64'])
+                                platforms=['linux-32', 'linux-64', 'osx-64', 'osx-arm64', 'win-32', 'win-64'])
 
         # so the point of this test is that we need to create env_specs
         # dict and the 'foo' entry as a side effect of setting 'bar',

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1535,7 +1535,7 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
     def check(dirname):
         project = Project(dirname)
         specs = ('numpy<1.19.2', 'pandas')
-        pip_spec = ['chardet']
+        pip_spec = ['requests']
         for spec in specs:
             if spec == specs[0]:
                 status = project_ops.add_env_spec(project, name='foo', packages=[spec], channels=[])

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1535,7 +1535,7 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
     def check(dirname):
         project = Project(dirname)
         specs = ('numpy<1.19.2', 'pandas')
-        pip_spec = ['requests']
+        pip_spec = ['chardet']
         for spec in specs:
             if spec == specs[0]:
                 status = project_ops.add_env_spec(project, name='foo', packages=[spec], channels=[])
@@ -1569,7 +1569,7 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
             assert tuple(map(int, version.split('.'))) < (1, 19, 2), files[0]
 
             status = project_ops.add_packages(project, 'foo', packages=pip_spec, pip=True, channels=[])
-            assert status
+            assert status, status.errors
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_LOCK_FILENAME: "locking_enabled: true\n"}, check)
 

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1590,7 +1590,6 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
         project2 = Project(dirname)
         env_spec = project2.env_specs['foo']
         assert 'chardet' in env_spec.pip_packages, {'conda': env_spec.conda_packages, 'pip': env_spec.pip_packages}
-        assert 'chardet' in os.listdir(os.path.join(dirname, 'envs', 'foo', 'lib', 'python3.8', 'site-packages'))
 
     with_directory_contents_completing_project_file(
         {

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1568,6 +1568,9 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
             version = os.path.basename(files[0]).split('-', 2)[1]
             assert tuple(map(int, version.split('.'))) < (1, 19, 2), files[0]
 
+            status = project_ops.add_packages(project, 'foo', packages=['pip'], channels=[])
+            assert status, status.errors
+
             status = project_ops.add_packages(project, 'foo', packages=pip_spec, pip=True, channels=[])
             assert status, status.errors
 

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1592,9 +1592,10 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
         assert 'chardet' in env_spec.pip_packages, {'conda': env_spec.conda_packages, 'pip': env_spec.pip_packages}
         assert 'chardet' in os.listdir(os.path.join(dirname, 'envs', 'foo', 'lib', 'python3.8', 'site-packages'))
 
-    with_directory_contents_completing_project_file({
-        DEFAULT_PROJECT_LOCK_FILENAME: "locking_enabled: true\n",
-        DEFAULT_PROJECT_FILENAME: "platforms: [linux-64,osx-64,osx-arm64,win-64]\n"
+    with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_LOCK_FILENAME: "locking_enabled: true\n",
+            DEFAULT_PROJECT_FILENAME: "platforms: [linux-64,osx-64,osx-arm64,win-64]\n"
         }, check)
 
 
@@ -1709,15 +1710,14 @@ def test_add_env_spec_no_global_platforms(mocked_hash):
 
         # be sure we really made the config changes
         project2 = Project(dirname)
-        assert dict(packages=[], channels=[],
-                    platforms=list(conda_api.default_platforms_with_current())
-                    ) == dict(project2.project_file.get_value(['env_specs', 'foo']))
+        assert dict(packages=[], channels=[], platforms=list(conda_api.default_platforms_with_current())) == dict(
+            project2.project_file.get_value(['env_specs', 'foo']))
 
         assert dict(locked=True,
                     env_spec_hash='da39a3ee5e6b4b0d3255bfef95601890afd80709',
                     packages=dict(all=[]),
-                    platforms=list(conda_api.default_platforms_with_current())
-                    ) == dict(project2.lock_file.get_value(['env_specs', 'foo']))
+                    platforms=list(conda_api.default_platforms_with_current())) == dict(
+                        project2.lock_file.get_value(['env_specs', 'foo']))
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_LOCK_FILENAME: "locking_enabled: true\n"}, check)
 
@@ -3135,8 +3135,8 @@ Added locked dependencies for env spec foo to anaconda-project-lock.yml.""".form
 
             # we should NOT have set the global platforms
             assert project.project_file.get_value('platforms', None) is None
-            assert conda_api.default_platforms_with_current() == project.project_file.get_value(['env_specs', 'foo', 'platforms'],
-                                                                                 None)
+            assert conda_api.default_platforms_with_current() == project.project_file.get_value(
+                ['env_specs', 'foo', 'platforms'], None)
             assert [
                 'osx-64',
             ] == project.project_file.get_value(['env_specs', 'bar', 'platforms'], None)

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1534,7 +1534,7 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
 
     def check(dirname):
         project = Project(dirname)
-        specs = ('numpy<1.11.3', 'pandas')
+        specs = ('python=3.8', 'numpy<1.19.2', 'pandas')
         pip_spec = ['chardet']
         for spec in specs:
             if spec == specs[0]:
@@ -1556,7 +1556,7 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
             env_commented_map = project2.project_file.get_value(['env_specs', 'foo'])
             assert spec in env_commented_map['packages'], env_commented_map['packages']
 
-            # ensure numpy <1.11.3 is present in both passes
+            # ensure numpy <1.19.2 is present in both passes
             meta_path = os.path.join(dirname, 'envs', 'foo', 'conda-meta')
             # pinned file no longer present between environment preparation steps
             assert os.path.isdir(meta_path)
@@ -1566,7 +1566,7 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
             files = glob.glob(os.path.join(meta_path, 'numpy-1.*-*'))
             assert len(files) == 1, files
             version = os.path.basename(files[0]).split('-', 2)[1]
-            assert tuple(map(int, version.split('.'))) < (1, 11, 3), files[0]
+            assert tuple(map(int, version.split('.'))) < (1, 19, 2), files[0]
 
             status = project_ops.add_packages(project, 'foo', packages=pip_spec, pip=True, channels=[])
             assert status

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1534,17 +1534,13 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
 
     def check(dirname):
         project = Project(dirname)
-        specs = ('numpy<1.19.2', 'pandas')
-        pip_spec = ['chardet']
-        for spec in specs:
-            if spec == specs[0]:
-                status = project_ops.add_env_spec(project, name='foo', packages=[spec], channels=[])
-            else:
-                status = project_ops.add_packages(project, 'foo', packages=[spec], channels=[])
-            if not status:
-                print(status.status_description)
-                print(repr(status.errors))
-            assert status
+
+        status = project_ops.add_env_spec(project, name='foo', packages=['python=3.8'], channels=[])
+        assert status, status.errors
+
+        for spec in ['numpy<1.19.2', 'bokeh', 'pip']:
+            status = project_ops.add_packages(project, 'foo', packages=[spec], channels=[])
+            assert status, status.errors
 
             assert 'foo' in project.env_specs
             env = project.env_specs['foo']
@@ -1568,11 +1564,11 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
             version = os.path.basename(files[0]).split('-', 2)[1]
             assert tuple(map(int, version.split('.'))) < (1, 19, 2), files[0]
 
-            status = project_ops.add_packages(project, 'foo', packages=['pip'], channels=[])
-            assert status, status.errors
-
-            status = project_ops.add_packages(project, 'foo', packages=pip_spec, pip=True, channels=[])
-            assert status, status.errors
+        status = project_ops.add_packages(project, 'foo', packages=['chardet'], pip=True, channels=[])
+        assert status, status.errors
+        project2 = Project(dirname)
+        env_spec = project2.env_specs['foo']
+        assert 'chardet' in env_spec.pip_packages, {'conda': env_spec.conda_packages, 'pip': env_spec.pip_packages}
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_LOCK_FILENAME: "locking_enabled: true\n"}, check)
 

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1839,7 +1839,7 @@ env_specs:
 locking_enabled: true
 env_specs:
   hello:
-    platforms: [linux-32,linux-64,osx-64,win-32,win-64]
+    platforms: [linux-32,linux-64,osx-64,osx-arm64,win-32,win-64]
     packages:
       all:
       - a=1.0=1
@@ -1924,7 +1924,7 @@ env_specs:
 locking_enabled: true
 env_specs:
   hello:
-    platforms: [linux-32,linux-64,osx-64,win-32,win-64]
+    platforms: [linux-32,linux-64,osx-64,osx-arm64,win-32,win-64]
     packages:
       all:
       - a=1.0=1
@@ -3192,7 +3192,7 @@ def test_locking_with_missing_lock_set_does_an_update():
 
             project = Project(dirname, frontend=FakeFrontend())
 
-            assert project.env_specs['foo'].platforms == ('linux-64', 'osx-64', 'win-64')
+            assert project.env_specs['foo'].platforms == ('linux-64', 'osx-64', 'osx-arm64', 'win-64')
             # lock set should be enabled yet missing and empty
             assert project.env_specs['foo'].lock_set.enabled
             assert project.env_specs['foo'].lock_set.missing
@@ -3208,6 +3208,7 @@ def test_locking_with_missing_lock_set_does_an_update():
                     '  platforms:',
                     '+   linux-64',
                     '+   osx-64',
+                    '+   osx-arm64',
                     '+   win-64',
                     '  packages:',
                     '+   all:',
@@ -3222,7 +3223,7 @@ def test_locking_with_missing_lock_set_does_an_update():
 
             foo_lock_set = project.env_specs['foo'].lock_set
             assert ('a=1.0=1', ) == foo_lock_set.package_specs_for_current_platform
-            assert foo_lock_set.env_spec_hash == 'b7f3266407fe0056da25fc23764bb7643c3560be'
+            assert foo_lock_set.env_spec_hash == '83ac707b75eaa131f7a26a0b09172a7f39ff7195'
             assert project.env_specs['foo'].lock_set.enabled
             assert not project.env_specs['foo'].lock_set.missing
 
@@ -3232,7 +3233,7 @@ def test_locking_with_missing_lock_set_does_an_update():
         {
             DEFAULT_PROJECT_FILENAME: """
 name: locktest
-platforms: [linux-64,osx-64,win-64]
+platforms: [linux-64,osx-64,osx-arm64,win-64]
 env_specs:
   foo:
     packages:
@@ -3262,14 +3263,14 @@ def test_update_changes_only_the_hash():
             assert status
             assert [
                 'Updating locked dependencies for env spec foo...',
-                'Updated hash for env spec foo to 9990ec43408f9593030a3a136c916022189f04b3 in '
+                'Updated hash for env spec foo to 072f81028686690f6e2c6602e484ba78d084eec9 in '
                 'anaconda-project-lock.yml.'
             ] == project.frontend.logs
             assert 'Update complete.' == status.status_description
 
             foo_lock_set = project.env_specs['foo'].lock_set
             assert ('a=1.0=1', ) == foo_lock_set.package_specs_for_current_platform
-            assert foo_lock_set.env_spec_hash == '9990ec43408f9593030a3a136c916022189f04b3'
+            assert foo_lock_set.env_spec_hash == '072f81028686690f6e2c6602e484ba78d084eec9'
 
         _with_conda_test(attempt, resolve_dependencies={'all': ['a=1.0=1']})
 
@@ -3278,7 +3279,7 @@ def test_update_changes_only_the_hash():
             DEFAULT_PROJECT_FILENAME:
             """
 name: locktest
-platforms: [linux-32,linux-64,osx-64,win-32,win-64]
+platforms: [linux-32,linux-64,osx-64,osx-arm64,win-32,win-64]
 env_specs:
   foo:
     packages:
@@ -3289,7 +3290,7 @@ env_specs:
 locking_enabled: true
 env_specs:
   foo:
-    platforms: [linux-32,linux-64,osx-64,win-32,win-64]
+    platforms: [linux-32,linux-64,osx-64,osx-arm64,win-32,win-64]
     env_spec_hash: old
     packages:
       all: ['a=1.0=1']
@@ -3501,6 +3502,7 @@ def test_update_empty_lock_sets():
                 '  platforms:',
                 '+   linux-64',
                 '+   osx-64',
+                '+   osx-arm64',
                 '+   win-64',
                 '  packages:',
                 '+   all:',
@@ -3511,6 +3513,7 @@ def test_update_empty_lock_sets():
                 '  platforms:',
                 '+   linux-64',
                 '+   osx-64',
+                '+   osx-arm64',
                 '+   win-64',
                 '  packages:',
                 '+   all:',
@@ -3521,7 +3524,7 @@ def test_update_empty_lock_sets():
             for env in project.env_specs.values():
                 assert env.lock_set.enabled
                 assert env.lock_set.supports_current_platform
-                assert env.lock_set.platforms == conda_api.default_platforms
+                assert env.lock_set.platforms == ('linux-64', 'osx-64', 'osx-arm64', 'win-64')
                 assert env.lock_set.package_specs_for_current_platform == ('a=1.0=1', )
 
         _with_conda_test(attempt, resolve_dependencies=resolve_results)
@@ -3530,7 +3533,7 @@ def test_update_empty_lock_sets():
         {
             DEFAULT_PROJECT_FILENAME: """
 name: locktest
-platforms: [linux-64,osx-64,win-64]
+platforms: [linux-64,osx-64,osx-arm64,win-64]
 env_specs:
   foo:
     packages:

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -4721,7 +4721,7 @@ def test_archive_unarchive_conda_pack_with_pip(suffix):
             {DEFAULT_PROJECT_FILENAME: """
 name: archivedproj
 packages:
-  - python=3.7
+  - python=3.8
   - pip:
     - pep8
 """}, check)

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1534,7 +1534,7 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
 
     def check(dirname):
         project = Project(dirname)
-        specs = ('python=3.8', 'numpy<1.19.2', 'pandas')
+        specs = ('numpy<1.19.2', 'pandas')
         pip_spec = ['chardet']
         for spec in specs:
             if spec == specs[0]:

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1559,7 +1559,7 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
         status = project_ops.add_env_spec(project, name='foo', packages=['python=3.8'], channels=[])
         assert status, status.errors
 
-        for spec in ['markupsafe<2.0.1', 'jinja2', 'pip']:
+        for spec in ['markupsafe<2.0.0', 'jinja2', 'pip']:
             status = project_ops.add_packages(project, 'foo', packages=[spec], channels=[])
             assert status, status.errors
 
@@ -1573,7 +1573,7 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
             env_commented_map = project2.project_file.get_value(['env_specs', 'foo'])
             assert spec in env_commented_map['packages'], env_commented_map['packages']
 
-            # ensure markupsafe <2.0.1 is present in both passes
+            # ensure markupsafe <2.0.0 is present in both passes
             meta_path = os.path.join(dirname, 'envs', 'foo', 'conda-meta')
             # pinned file no longer present between environment preparation steps
             assert os.path.isdir(meta_path)
@@ -1583,7 +1583,7 @@ def test_add_env_spec_with_real_conda_manager(monkeypatch):
             files = glob.glob(os.path.join(meta_path, 'markupsafe-1.*-*'))
             assert len(files) == 1, files
             version = os.path.basename(files[0]).split('-', 2)[1]
-            assert tuple(map(int, version.split('.'))) < (2, 0, 1), files[0]
+            assert tuple(map(int, version.split('.'))) < (2, 0, 0), files[0]
 
         status = project_ops.add_packages(project, 'foo', packages=['chardet'], pip=True, channels=[])
         assert status, status.errors

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - anaconda-client
   - conda-pack
   - requests
+  - tqdm
   - psutil
   - tornado>=4.2
   - pip


### PR DESCRIPTION
This adds `linux-aarch64` and `osx-arm64` as known platforms.

Further, this PR also solves #274 and allows `CONDA_SUBDIR` env var to be used to override the current platform.

For example, on an Apple M1 you can now force it to create envs for osx-64. First you'll see that Conda determines my platform is osx-arm64. I can force anaconda-project to create an osx-64 env_spec by setting `CONDA_SUBDIR=osx-64`. Otherwise the prepare would fail because Python 3.7 is not available for osx-arm64. Note that you must keep CONDA_SUBDIR set for all anaconda-project actions, not just the prepare step.

```
> conda info --json | jq .platform
"osx-arm64"

> cat anaconda-project.yml
name: arm
packages:
- python=3.7

> anaconda-project prepare
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... failed with repodata from current_repodata.json, will retry with next repodata source.
Collecting package metadata (repodata.json): ...working... done
Solving environment: ...working... failed

PackagesNotFoundError: The following packages are not available from current channels:

  - python=3.7

Current channels:

  - https://repo.anaconda.com/pkgs/main/osx-arm64
  - https://repo.anaconda.com/pkgs/main/noarch
  - https://repo.anaconda.com/pkgs/r/osx-arm64
  - https://repo.anaconda.com/pkgs/r/noarch

To search for alternate channels that may provide the conda package you're
looking for, navigate to

    https://anaconda.org

and use the search bar at the top of the page.


missing requirement to run this project: The project needs a Conda environment containing all required packages.
  '/Users/adefusco/Desktop/arm/envs/default' doesn't look like it contains a Conda environment yet.

> CONDA_SUBDIR=osx-64 anaconda-project prepare
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/adefusco/Desktop/arm/envs/default

  added / updated specs:
    - python=3.7


The following NEW packages will be INSTALLED:

  ca-certificates    pkgs/main/osx-64::ca-certificates-2021.10.26-hecd8cb5_2
  certifi            pkgs/main/osx-64::certifi-2021.10.8-py37hecd8cb5_0
  libcxx             pkgs/main/osx-64::libcxx-12.0.0-h2f01273_0
  libffi             pkgs/main/osx-64::libffi-3.3-hb1e8313_2
  ncurses            pkgs/main/osx-64::ncurses-6.3-hca72f7f_2
  openssl            pkgs/main/osx-64::openssl-1.1.1l-h9ed2024_0
  pip                pkgs/main/osx-64::pip-21.2.2-py37hecd8cb5_0
  python             pkgs/main/osx-64::python-3.7.11-h88f2d9e_0
  readline           pkgs/main/osx-64::readline-8.1.2-hca72f7f_0
  setuptools         pkgs/main/osx-64::setuptools-58.0.4-py37hecd8cb5_0
  sqlite             pkgs/main/osx-64::sqlite-3.37.0-h707629a_0
  tk                 pkgs/main/osx-64::tk-8.6.11-h7bc2e8c_0
  wheel              pkgs/main/noarch::wheel-0.37.1-pyhd3eb1b0_0
  xz                 pkgs/main/osx-64::xz-5.2.5-h1de35cc_0
  zlib               pkgs/main/osx-64::zlib-1.2.11-h4dc903c_4


Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
#
# To activate this environment, use
#
#     $ conda activate /Users/adefusco/Desktop/arm/envs/default
#
# To deactivate an active environment, use
#
#     $ conda deactivate

The project is ready to run commands.
Use `anaconda-project list-commands` to see what's available.
```