### PR TITLE
Add tdqm dependency for progress bars.  Resolves #355.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,6 +13,7 @@ dependencies:
   - requests
   - psutil
   - tornado>=4.2
+  - tqdm
   - pip
   - keyring
   - pytest

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,17 @@ setuptools.setup(
     description='Tool for encapsulating, running, and reproducing data science projects',
     long_description=io.open("README.md", 'r', encoding='utf-8').read(),
     zip_safe=False,
-    install_requires=['anaconda-client', 'conda-pack', 'requests', 'ruamel_yaml', 'tornado>=4.2', 'jinja2'],
-    entry_points={'console_scripts': [
-        'anaconda-project = anaconda_project.cli:main',
+    install_requires=[
+        "anaconda-client",
+        "conda-pack",
+        "requests",
+        "ruamel_yaml",
+        "tornado>=4.2",
+        "jinja2",
+        "tqdm",
+    ],
+    entry_points={"console_scripts": [
+        "anaconda-project = anaconda_project.cli:main",
     ]},
     packages=setuptools.find_packages(exclude=['contrib', 'docs', 'tests*']),
     include_package_data=True,


### PR DESCRIPTION
This is a minimal fix for issue #355.  Note: after running the tests, many pieces of code were reformatted.  I did not include these changes to keep the noise at a minimum.  Should I first commit a `lint` revision with the reformatted code, then rebase my changes on top?  (If so, this could be spelled out explicitly in `CONTRIBUTING.md`.  Let me know and I can include in a future documentation PR.)

I am not comfortable enough with the project's CI to figure out why this error was not caught during CI.  Does the CI provision from an environment that uses `conda/meta.yml`?  If so, we might like to add some CI provisioning from `environment.yml` directly (for developers) and from `setup.py` (for people who install from `pip`).