### PR TITLE
Conda project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Editor temporary/working/backup files #
 #########################################
+env/
 .#*
 [#]*#
 *~

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -18,7 +18,6 @@ import anaconda_project.internal.conda_api as conda_api
 import anaconda_project.internal.pip_api as pip_api
 from anaconda_project.internal.py2_compat import is_string
 from anaconda_project import conda_manager
-from anaconda_project.internal.conda_api import default_platforms_with_current
 
 from anaconda_project.yaml_file import _load_string, _save_file, _YAMLError, ryaml
 
@@ -63,9 +62,6 @@ class EnvSpec(object):
         self._inherit_from_names = inherit_from_names
         self._inherit_from = inherit_from
         self._lock_set = lock_set
-
-        if not platforms:
-            platforms = default_platforms_with_current()
         self._platforms = tuple(conda_api.sort_platform_list(platforms))
 
         # inherit_from must be a subset of inherit_from_names

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -18,6 +18,7 @@ import anaconda_project.internal.conda_api as conda_api
 import anaconda_project.internal.pip_api as pip_api
 from anaconda_project.internal.py2_compat import is_string
 from anaconda_project import conda_manager
+from anaconda_project.internal.conda_api import default_platforms_with_current
 
 from anaconda_project.yaml_file import _load_string, _save_file, _YAMLError, ryaml
 
@@ -62,6 +63,9 @@ class EnvSpec(object):
         self._inherit_from_names = inherit_from_names
         self._inherit_from = inherit_from
         self._lock_set = lock_set
+
+        if not platforms:
+            platforms = default_platforms_with_current()
         self._platforms = tuple(conda_api.sort_platform_list(platforms))
 
         # inherit_from must be a subset of inherit_from_names

--- a/anaconda_project/env_spec.py
+++ b/anaconda_project/env_spec.py
@@ -501,7 +501,7 @@ def _load_environment_yml(filename):
             name = os.path.basename(yaml['prefix'])
 
     if not name:
-        name = os.path.basename(filename)
+        name = 'default'
 
     # We don't do too much validation here because we end up doing it
     # later if we import this into the project, and then load it from

--- a/anaconda_project/internal/cli/activate.py
+++ b/anaconda_project/internal/cli/activate.py
@@ -27,11 +27,9 @@ def activate(dirname, ui_mode, conda_environment, command_name):
     Returns:
         None on failure or a list of lines to print.
     """
-    project = load_project(dirname)
-    result = prepare_with_ui_mode_printing_errors(project,
-                                                  ui_mode=ui_mode,
-                                                  env_spec_name=conda_environment,
-                                                  command_name=command_name)
+    project = load_project(dirname, save=False)
+    result = prepare_with_ui_mode_printing_errors(
+        project, ui_mode=ui_mode, env_spec_name=conda_environment, command_name=command_name)
     if result.failed:
         return None
 

--- a/anaconda_project/internal/cli/activate.py
+++ b/anaconda_project/internal/cli/activate.py
@@ -28,8 +28,10 @@ def activate(dirname, ui_mode, conda_environment, command_name):
         None on failure or a list of lines to print.
     """
     project = load_project(dirname, save=False)
-    result = prepare_with_ui_mode_printing_errors(
-        project, ui_mode=ui_mode, env_spec_name=conda_environment, command_name=command_name)
+    result = prepare_with_ui_mode_printing_errors(project,
+                                                  ui_mode=ui_mode,
+                                                  env_spec_name=conda_environment,
+                                                  command_name=command_name)
     if result.failed:
         return None
 

--- a/anaconda_project/internal/cli/archive.py
+++ b/anaconda_project/internal/cli/archive.py
@@ -29,7 +29,7 @@ def archive_command(project_dir, archive_filename, pack_envs):
         if not prepare_status:
             return 1
 
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
 
     status = project_ops.archive(project, archive_filename, pack_envs)
     if status:

--- a/anaconda_project/internal/cli/clean.py
+++ b/anaconda_project/internal/cli/clean.py
@@ -21,7 +21,7 @@ def clean_command(project_dir):
     Returns:
         exit code
     """
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     # we don't want to print errors during this prepare, clean
     # can proceed even though the prepare fails.
     with project.null_frontend():

--- a/anaconda_project/internal/cli/command_commands.py
+++ b/anaconda_project/internal/cli/command_commands.py
@@ -93,7 +93,7 @@ def list_commands(project_dir):
     Returns:
         int exit code
     """
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return 1
 
@@ -111,7 +111,7 @@ def list_default_command(project_dir):
     Returns:
         int exit code
     """
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return 1
 

--- a/anaconda_project/internal/cli/dockerize.py
+++ b/anaconda_project/internal/cli/dockerize.py
@@ -19,7 +19,7 @@ def dockerize_command(project_dir, tag, command, builder_image, build_args):
     Returns:
         exit code
     """
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     status = project_ops.dockerize(project,
                                    tag=tag,
                                    command=command,

--- a/anaconda_project/internal/cli/download_commands.py
+++ b/anaconda_project/internal/cli/download_commands.py
@@ -61,7 +61,7 @@ def remove_download(project_dir, env_spec_name, filename_variable):
 
 def list_downloads(project_dir, env_spec_name):
     """List the downloads present in project."""
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return 1
 

--- a/anaconda_project/internal/cli/environment_commands.py
+++ b/anaconda_project/internal/cli/environment_commands.py
@@ -157,7 +157,7 @@ def lock(project_dir, env_spec_name):
 
 def update(project_dir, env_spec_name):
     """Update dependency versions."""
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return 1
     status = project_ops.update(project, env_spec_name=env_spec_name)

--- a/anaconda_project/internal/cli/environment_commands.py
+++ b/anaconda_project/internal/cli/environment_commands.py
@@ -46,7 +46,7 @@ def remove_env_spec(project_dir, name):
 
 def export_env_spec(project_dir, name, filename):
     """Save an environment.yml file."""
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     status = project_ops.export_env_spec(project, name=name, filename=filename)
     return _handle_status(status)
 
@@ -101,7 +101,7 @@ def remove_platforms(project, environment, platforms):
 
 def list_env_specs(project_dir):
     """List environments in the project."""
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return 1
     print("Environments for project: {}\n".format(project_dir))
@@ -111,7 +111,7 @@ def list_env_specs(project_dir):
 
 def list_packages(project_dir, environment):
     """List the packages for an environment in the project."""
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return 1
     if environment is None:
@@ -132,7 +132,7 @@ def list_packages(project_dir, environment):
 
 def list_platforms(project_dir, environment):
     """List the platforms for an environment in the project."""
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return 1
     if environment is None:
@@ -166,7 +166,7 @@ def update(project_dir, env_spec_name):
 
 def unlock(project_dir, env_spec_name):
     """Unlock dependency versions."""
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return 1
     status = project_ops.unlock(project, env_spec_name=env_spec_name)

--- a/anaconda_project/internal/cli/environment_commands.py
+++ b/anaconda_project/internal/cli/environment_commands.py
@@ -148,7 +148,7 @@ def list_platforms(project_dir, environment):
 
 def lock(project_dir, env_spec_name):
     """Lock dependency versions."""
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return 1
     status = project_ops.lock(project, env_spec_name=env_spec_name)

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -41,7 +41,7 @@ import anaconda_project.internal.cli.command_commands as command_commands
 
 
 def _parse_args_and_run_subcommand(argv):
-    parser = ArgumentParser(prog="anaconda-project", description="Actions on projects (runnable projects).")
+    parser = ArgumentParser(prog="conda-project", description="Actions on projects (runnable projects).")
 
     subparsers = parser.add_subparsers(help="Sub-commands")
 
@@ -59,7 +59,7 @@ def _parse_args_and_run_subcommand(argv):
                             metavar='ENVIRONMENT_SPEC_NAME',
                             default=None,
                             action='store',
-                            help="An environment spec name from anaconda-project.yml")
+                            help="An environment spec name from conda-project.yml")
 
     def add_prepare_args(preset, include_command=True):
         add_directory_arg(preset)
@@ -79,7 +79,7 @@ def _parse_args_and_run_subcommand(argv):
                 metavar='COMMAND_NAME',
                 default=None,
                 action='store',
-                help="A command name from anaconda-project.yml (env spec for this command will be used)")
+                help="A command name from conda-project.yml (env spec for this command will be used)")
 
     def add_env_spec_name_arg(preset, required):
         preset.add_argument('-n',
@@ -87,7 +87,7 @@ def _parse_args_and_run_subcommand(argv):
                             metavar='ENVIRONMENT_SPEC_NAME',
                             required=required,
                             action='store',
-                            help="Name of the environment spec from anaconda-project.yml")
+                            help="Name of the environment spec from conda-project.yml")
 
     preset = subparsers.add_parser('init', help="Initialize a directory with default project configuration")
     add_directory_arg(preset)
@@ -108,7 +108,7 @@ def _parse_args_and_run_subcommand(argv):
                         metavar='COMMAND_NAME',
                         default=None,
                         nargs='?',
-                        help="A command name from anaconda-project.yml")
+                        help="A command name from conda-project.yml")
     preset.add_argument('extra_args_for_command', metavar='EXTRA_ARGS_FOR_COMMAND', default=None, nargs=REMAINDER)
     preset.set_defaults(main=run.main)
 
@@ -224,14 +224,14 @@ def _parse_args_and_run_subcommand(argv):
     preset.set_defaults(main=variable_commands.main_list)
 
     preset = subparsers.add_parser('set-variable',
-                                   help="Set an environment variable value in anaconda-project-local.yml")
+                                   help="Set an environment variable value in conda-project-local.yml")
     add_env_spec_arg(preset)
     preset.add_argument('vars_and_values', metavar='VARS_AND_VALUES', default=None, nargs=REMAINDER)
     add_directory_arg(preset)
     preset.set_defaults(main=variable_commands.main_set)
 
     preset = subparsers.add_parser('unset-variable',
-                                   help="Unset an environment variable value from anaconda-project-local.yml")
+                                   help="Unset an environment variable value from conda-project-local.yml")
     add_env_spec_arg(preset)
     add_directory_arg(preset)
     preset.add_argument('vars_to_unset', metavar='VARS_TO_UNSET', default=None, nargs=REMAINDER)
@@ -442,4 +442,4 @@ def main():
     Conda expects us to take no args and return an exit code.
     """
     details = {'version': version}
-    return handle_bugs(_main_without_bug_handler, program_name='anaconda-project', details_dict=details)
+    return handle_bugs(_main_without_bug_handler, program_name='conda-project', details_dict=details)

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -115,6 +115,7 @@ def _parse_args_and_run_subcommand(argv):
     preset = subparsers.add_parser('prepare', help="Set up the project requirements, but does not run the project")
     preset.add_argument('--all', action='store_true', help="Prepare all environments", default=None)
     preset.add_argument('--refresh', action='store_true', help='Remove and recreate the environment', default=None)
+    preset.add_argument('--python', type=str, help='Specify Python version if using requirements.txt', default=None)
     add_prepare_args(preset)
     preset.set_defaults(main=prepare.main)
 

--- a/anaconda_project/internal/cli/prepare.py
+++ b/anaconda_project/internal/cli/prepare.py
@@ -19,8 +19,7 @@ def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=F
     Returns:
         Prepare result (can be treated as True on success).
     """
-    project = load_project(project_dir)
-    project_dir = project.directory_path
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return False
     if all:

--- a/anaconda_project/internal/cli/prepare.py
+++ b/anaconda_project/internal/cli/prepare.py
@@ -22,7 +22,7 @@ def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=F
     """
     project = load_project(project_dir, save=False)
 
-    if path.isfile(path.join(project_dir, 'requirements.txt')):  #and not path.isfile(project.project_file.filename):
+    if path.isfile(path.join(project_dir, 'requirements.txt')):
         default = project.env_specs[project.default_env_spec_name]
         if not default.conda_packages and (python is not None):
             default._conda_packages = [f'python={python}']

--- a/anaconda_project/internal/cli/prepare.py
+++ b/anaconda_project/internal/cli/prepare.py
@@ -7,19 +7,26 @@
 # -----------------------------------------------------------------------------
 """The ``prepare`` command configures a project to run, asking the user questions if necessary."""
 from __future__ import absolute_import, print_function
+from os import path
 
 import anaconda_project.internal.cli.console_utils as console_utils
 from anaconda_project.internal.cli.prepare_with_mode import prepare_with_ui_mode_printing_errors
 from anaconda_project.internal.cli.project_load import load_project
 
 
-def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=False, refresh=False):
+def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=False, refresh=False, python=None):
     """Configure the project to run.
 
     Returns:
         Prepare result (can be treated as True on success).
     """
     project = load_project(project_dir, save=False)
+
+    if path.isfile(path.join(project_dir, 'requirements.txt')) and not path.isfile(project.project_file.filename):
+        default = project.env_specs[project.default_env_spec_name]
+        if not default.conda_packages and (python is not None):
+            default._conda_packages = [f'python={python}']
+
     if console_utils.print_project_problems(project):
         return False
     if all:
@@ -36,7 +43,7 @@ def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=F
 
 def main(args):
     """Start the prepare command and return exit status code."""
-    if prepare_command(args.directory, args.mode, args.env_spec, args.command, args.all, args.refresh):
+    if prepare_command(args.directory, args.mode, args.env_spec, args.command, args.all, args.refresh, args.python):
         print("The project is ready to run commands.")
         print("Use `anaconda-project list-commands` to see what's available.")
         return 0

--- a/anaconda_project/internal/cli/prepare.py
+++ b/anaconda_project/internal/cli/prepare.py
@@ -22,7 +22,7 @@ def prepare_command(project_dir, ui_mode, conda_environment, command_name, all=F
     """
     project = load_project(project_dir, save=False)
 
-    if path.isfile(path.join(project_dir, 'requirements.txt')) and not path.isfile(project.project_file.filename):
+    if path.isfile(path.join(project_dir, 'requirements.txt')):  #and not path.isfile(project.project_file.filename):
         default = project.env_specs[project.default_env_spec_name]
         if not default.conda_packages and (python is not None):
             default._conda_packages = [f'python={python}']

--- a/anaconda_project/internal/cli/project_load.py
+++ b/anaconda_project/internal/cli/project_load.py
@@ -35,7 +35,7 @@ class CliFrontend(Frontend):
         sys.stderr.flush()
 
 
-def load_project(dirname):
+def load_project(dirname, save=True):
     """Load a Project, fixing it if needed and possible."""
     project = Project(dirname, frontend=CliFrontend(), must_exist=True)
 
@@ -65,6 +65,7 @@ def load_project(dirname):
             # this happen 3 times before we give up.
             regressions += (len(problems) >= len(o_problems))
         if not problems:
-            project.save()
+            if save:
+                project.save()
 
     return project

--- a/anaconda_project/internal/cli/run.py
+++ b/anaconda_project/internal/cli/run.py
@@ -38,7 +38,7 @@ def run_command(project_dir, ui_mode, conda_environment, command_name, extra_com
     Returns:
         Does not return if successful.
     """
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
 
     if project.has_bootstrap_env_spec() and not project.is_running_in_bootstrap_env():
         print("Project should be ran by bootstrap env... fixing.")

--- a/anaconda_project/internal/cli/service_commands.py
+++ b/anaconda_project/internal/cli/service_commands.py
@@ -53,7 +53,7 @@ def remove_service(project_dir, env_spec_name, variable_name):
 
 def list_services(project_dir, env_spec_name):
     """List the services listed on the project."""
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return 1
 

--- a/anaconda_project/internal/cli/test/test_prepare.py
+++ b/anaconda_project/internal/cli/test/test_prepare.py
@@ -103,7 +103,7 @@ def test_main_fails_to_redis(monkeypatch, capsys):
 
     def main_redis_url(dirname):
         project_dir_disable_dedicated_env(dirname)
-        code = main(Args(directory=dirname, all=False, refresh=False))
+        code = main(Args(directory=dirname, all=False, refresh=False, python=None))
         assert 1 == code
 
     with_directory_contents_completing_project_file({DEFAULT_PROJECT_FILENAME: """

--- a/anaconda_project/internal/cli/upload.py
+++ b/anaconda_project/internal/cli/upload.py
@@ -19,7 +19,7 @@ def upload_command(project_dir, private, site, username, token, suffix):
     Returns:
         exit code
     """
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     status = project_ops.upload(project, private=private, site=site, username=username, token=token, suffix=suffix)
     if status:
         print(status.status_description)

--- a/anaconda_project/internal/cli/variable_commands.py
+++ b/anaconda_project/internal/cli/variable_commands.py
@@ -54,7 +54,7 @@ def remove_variables(project_dir, env_spec_name, vars_to_remove):
 
 def list_variables(project_dir, env_spec_name):
     """List variables present in project."""
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     if console_utils.print_project_problems(project):
         return 1
     print("Variables for project: {}\n".format(project_dir))

--- a/anaconda_project/internal/cli/variable_commands.py
+++ b/anaconda_project/internal/cli/variable_commands.py
@@ -75,7 +75,7 @@ def set_variables(project_dir, env_spec_name, vars_and_values):
             return 1
         # maxsplit=1 -- no maxsplit keywork in py27
         fixed_vars.append(tuple(var.split('=', 1)))
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     status = project_ops.set_variables(project, env_spec_name, fixed_vars)
     if status:
         print(status.status_description)
@@ -91,7 +91,7 @@ def unset_variables(project_dir, env_spec_name, vars_to_unset):
     Returns:
         Returns exit code
     """
-    project = load_project(project_dir)
+    project = load_project(project_dir, save=False)
     status = project_ops.unset_variables(project, env_spec_name, vars_to_unset)
     if status:
         print(status.status_description)

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -806,10 +806,10 @@ class _ConfigCache(object):
 
         (importable_spec, importable_filename) = _find_out_of_sync_importable_spec(self.env_specs.values(),
                                                                                    self.directory_path)
-        if importable_spec is not None:
-            skip_spec_import = project_file.get_value(['skip_imports', 'environment'])
-            if skip_spec_import == importable_spec.logical_hash:
-                importable_spec = None
+        # if importable_spec is not None:
+        #     skip_spec_import = project_file.get_value(['skip_imports', 'environment'])
+        #     if (skip_spec_import == importable_spec.logical_hash) or skip_spec_import:
+        #         importable_spec = None
 
         if importable_spec is not None:
             old = self.env_specs.get(importable_spec.name)
@@ -1639,6 +1639,9 @@ class Project(object):
         Does nothing for config files that are not dirty.
         """
         self.project_file.save()
+        self.lock_file.save()
+
+    def save_lock(self):
         self.lock_file.save()
 
     def use_changes_without_saving(self):

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -180,10 +180,14 @@ class _ConfigCache(object):
         if not project_exists:
             problems.append("Project directory '%s' does not exist." % self.directory_path)
         elif self.must_exist and not os.path.isfile(project_file.filename):
-            problems.append(
-                ProjectProblem(text="Project file '%s' does not exist." % os.path.basename(project_file.filename),
-                               fix_prompt="Create file '%s'?" % project_file.filename,
-                               fix_function=accept_project_creation))
+            filenames = ("environment.yml", "environment.yaml", 'requirements.txt')
+            filenames = map(lambda f: os.path.isfile(os.path.join(self.directory_path, f)), filenames)
+            if not any(filenames):
+                problems.append(
+                    ProjectProblem(
+                        text="Project file '%s' does not exist." % os.path.basename(project_file.filename),
+                        fix_prompt="Create file '%s'?" % project_file.filename,
+                        fix_function=accept_project_creation))
 
         if project_file.corrupted:
             problems.append(
@@ -220,7 +224,6 @@ class _ConfigCache(object):
             # options in the variables section, and after _update_env_specs
             # since we use those
             self._update_conda_env_requirements(requirements, problems, project_file)
-
             # this MUST be after we update env reqs so we have the valid env spec names
             self._update_commands(problems, project_file, requirements)
 

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -830,30 +830,34 @@ class _ConfigCache(object):
             importable_spec = None
 
         if importable_spec is not None:
-            if old is None:
-                text = "Environment spec '%s' from %s is not in %s." % (importable_spec.name, importable_filename,
-                                                                        os.path.basename(project_file.filename))
-                prompt = "Add env spec %s to %s?" % (importable_spec.name, os.path.basename(project_file.filename))
-            else:
-                text = "Environment spec '%s' from %s is out of sync with %s. Diff:\n%s" % (
-                    importable_spec.name, importable_filename, os.path.basename(
-                        project_file.filename), importable_spec.diff_from(old))
-                prompt = "Overwrite env spec %s with the changes from %s?" % (importable_spec.name, importable_filename)
+            project_file.set_value(['env_specs', importable_spec.name], importable_spec.to_json())
+            project_file.use_changes_without_saving()
+            # print(project_file._yaml)
+            # if old is None:
+            #     text = "Environment spec '%s' from %s is not in %s." % (importable_spec.name, importable_filename,
+            #                                                             os.path.basename(project_file.filename))
+            #     prompt = "Add env spec %s to %s?" % (importable_spec.name, os.path.basename(project_file.filename))
+            # else:
+            #     text = "Environment spec '%s' from %s is out of sync with %s. Diff:\n%s" % (
+            #         importable_spec.name, importable_filename, os.path.basename(project_file.filename),
+            #         importable_spec.diff_from(old))
+            #     prompt = "Overwrite env spec %s with the changes from %s?" % (importable_spec.name, importable_filename)
 
-            def overwrite_env_spec_from_importable(project):
-                project.project_file.set_value(['env_specs', importable_spec.name], importable_spec.to_json())
+            # def overwrite_env_spec_from_importable(project):
+            #     project.project_file.set_value(['env_specs', importable_spec.name], importable_spec.to_json())
 
-            def remember_no_import_importable(project):
-                project.project_file.set_value(['skip_imports', 'environment'], importable_spec.logical_hash)
+            # def remember_no_import_importable(project):
+            #     project.project_file.set_value(['skip_imports', 'environment'], importable_spec.logical_hash)
 
-            # we don't set the filename here because it isn't really an error in the
-            # file, it ends up reading strangely.
-            problems.append(
-                ProjectProblem(text=text,
-                               fix_prompt=prompt,
-                               fix_function=overwrite_env_spec_from_importable,
-                               no_fix_function=remember_no_import_importable))
-        elif env_specs_is_empty or env_specs_is_missing:
+            # # we don't set the filename here because it isn't really an error in the
+            # # file, it ends up reading strangely.
+            # problems.append(
+            #     ProjectProblem(
+            #         text=text,
+            #         fix_prompt=prompt,
+            #         fix_function=overwrite_env_spec_from_importable,
+            #         no_fix_function=remember_no_import_importable))
+        if env_specs_is_empty or env_specs_is_missing:
             # we do NOT want to add this problem if we merely
             # failed to parse individual env specs; it must be
             # safe to overwrite the env_specs key, so it has to

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -184,10 +184,9 @@ class _ConfigCache(object):
             filenames = map(lambda f: os.path.isfile(os.path.join(self.directory_path, f)), filenames)
             if not any(filenames):
                 problems.append(
-                    ProjectProblem(
-                        text="Project file '%s' does not exist." % os.path.basename(project_file.filename),
-                        fix_prompt="Create file '%s'?" % project_file.filename,
-                        fix_function=accept_project_creation))
+                    ProjectProblem(text="Project file '%s' does not exist." % os.path.basename(project_file.filename),
+                                   fix_prompt="Create file '%s'?" % project_file.filename,
+                                   fix_function=accept_project_creation))
 
         if project_file.corrupted:
             problems.append(

--- a/anaconda_project/project_file.py
+++ b/anaconda_project/project_file.py
@@ -15,7 +15,9 @@ from anaconda_project.env_spec import EnvSpec
 import anaconda_project.internal.conda_api as conda_api
 
 # these are in the order we'll use them if multiple are present
-possible_project_file_names = ("anaconda-project.yml", "anaconda-project.yaml", "kapsel.yml", "kapsel.yaml")
+possible_project_file_names = ("conda-project.yml", "conda-project.yaml",
+                               "anaconda-project.yml", "anaconda-project.yaml",
+                               "kapsel.yml", "kapsel.yaml")
 
 DEFAULT_PROJECT_FILENAME = possible_project_file_names[0]
 

--- a/anaconda_project/project_file.py
+++ b/anaconda_project/project_file.py
@@ -15,7 +15,8 @@ from anaconda_project.env_spec import EnvSpec
 import anaconda_project.internal.conda_api as conda_api
 
 # these are in the order we'll use them if multiple are present
-possible_project_file_names = ("conda-project.yml", "conda-project.yaml",
+possible_project_file_names = ('project.yml', 'project.yaml',
+                               "conda-project.yml", "conda-project.yaml",
                                "anaconda-project.yml", "anaconda-project.yaml",
                                "kapsel.yml", "kapsel.yaml")
 

--- a/anaconda_project/project_lock_file.py
+++ b/anaconda_project/project_lock_file.py
@@ -13,20 +13,21 @@ import os
 from anaconda_project.yaml_file import YamlFile, _CommentedMap, _block_style_all_nodes
 
 # these are in the order we'll use them if multiple are present
-possible_project_lock_file_names = ("conda-project-lock.yml", "conda-project-lock.yaml",
+possible_project_lock_file_names = ("project-lock.yml", 'project-lock.yaml',
+                                    "conda-project-lock.yml", "conda-project-lock.yaml",
                                     "anaconda-project-lock.yml", "anaconda-project-lock.yaml")
 
 DEFAULT_PROJECT_LOCK_FILENAME = possible_project_lock_file_names[0]
 
 
 class ProjectLockFile(YamlFile):
-    """Represents the ``anaconda-project-lock.yml`` file which describes locked package versions."""
+    """Represents the ``project-lock.yml`` file which describes locked package versions."""
 
     template = '''
-# This is an Anaconda project lock file.
+# This is a Conda project lock file.
 # The lock file locks down exact versions of all your dependencies.
 #
-# In most cases, this file is automatically maintained by the `anaconda-project` command or GUI tools.
+# In most cases, this file is automatically maintained by the `conda-project` command or GUI tools.
 # It's best to keep this file in revision control (such as git or svn).
 # The file is in YAML format, please see http://www.yaml.org/start.html for more.
 #

--- a/anaconda_project/project_lock_file.py
+++ b/anaconda_project/project_lock_file.py
@@ -13,7 +13,8 @@ import os
 from anaconda_project.yaml_file import YamlFile, _CommentedMap, _block_style_all_nodes
 
 # these are in the order we'll use them if multiple are present
-possible_project_lock_file_names = ("anaconda-project-lock.yml", "anaconda-project-lock.yaml")
+possible_project_lock_file_names = ("conda-project-lock.yml", "conda-project-lock.yaml",
+                                    "anaconda-project-lock.yml", "anaconda-project-lock.yaml")
 
 DEFAULT_PROJECT_LOCK_FILENAME = possible_project_lock_file_names[0]
 

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -923,7 +923,7 @@ def _update_and_lock(project, env_spec_name, update):
 
     # everything successful; save the project
     if need_save:
-        project.save()
+        project.save_lock()
 
     if update:
         description = "Update complete."

--- a/anaconda_project/test/test_env_spec.py
+++ b/anaconda_project/test/test_env_spec.py
@@ -77,7 +77,7 @@ def test_load_environment_yml_no_name():
         spec = _load_environment_yml(filename)
 
         assert spec is not None
-        assert spec.name == os.path.basename(filename)
+        assert spec.name == 'default'
         assert spec.conda_packages == ('bar=1.0', 'baz')
         assert spec.pip_packages == ('pippy', 'poppy==2.0')
         assert spec.channels == ('channel1', 'channel2')

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -2780,18 +2780,9 @@ def test_auto_fix_missing_name():
         check)
 
 
-def test_auto_fix_env_spec_import():
+def test_env_spec_in_environment_yml():
     def check(dirname):
         project = project_no_dedicated_env(dirname)
-        assert len(project.problems) == 1
-        assert len(project.problem_objects) == 1
-        assert len(project.fixable_problems) == 1
-        problem = project.problem_objects[0]
-        assert problem.text == "Environment spec 'stuff' from environment.yml is not in anaconda-project.yml."
-        assert problem.can_fix
-
-        problem.fix(project)
-        project.project_file.save()
 
         assert project.problems == []
         assert list(project.env_specs.keys()) == ['stuff']
@@ -2816,18 +2807,9 @@ channels:
         }, check)
 
 
-def test_auto_fix_requirements_txt_import():
+def test_requirements_txt():
     def check(dirname):
         project = project_no_dedicated_env(dirname)
-        assert len(project.problems) == 1
-        assert len(project.problem_objects) == 1
-        assert len(project.fixable_problems) == 1
-        problem = project.problem_objects[0]
-        assert problem.text == "Environment spec 'default' from requirements.txt is not in anaconda-project.yml."
-        assert problem.can_fix
-
-        problem.fix(project)
-        project.project_file.save()
 
         assert project.problems == []
         assert list(project.env_specs.keys()) == ['default']
@@ -3209,7 +3191,6 @@ def test_with_one_locked_env_spec_has_problems():
         project = project_no_dedicated_env(dirname)
         assert [
             "anaconda-project.yml: The 'name:' field is missing.",
-            "anaconda-project.yml: The 'platforms:' field should list platforms the project supports."
         ] == project.problems
 
     with_directory_contents(
@@ -3226,10 +3207,7 @@ env_specs:
 def test_with_locking_enabled_no_env_specs_has_problems():
     def check(dirname):
         project = project_no_dedicated_env(dirname)
-        assert [
-            "anaconda-project.yml: The 'name:' field is missing.",
-            "anaconda-project.yml: The 'platforms:' field should list platforms the project supports."
-        ] == project.problems
+        assert ["anaconda-project.yml: The 'name:' field is missing."] == project.problems
 
     with_directory_contents({
         DEFAULT_PROJECT_FILENAME: "",

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -210,7 +210,7 @@ def test_create_no_import_environment_yml_when_not_fix_problems():
                                      icon='something.png',
                                      description="Hello World",
                                      fix_problems=False)
-        assert ["Environment spec 'stuff' from environment.yml is not in anaconda-project.yml."] == project.problems
+        assert len(project.problems) == 0
 
     with_directory_contents(
         {

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -35,7 +35,7 @@ test:
   requires:
     - backports.tempfile # [py2k]
     - coverage
-    - pytest<5
+    - pytest
     - pytest-cov
     - redis
     - notebook

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set data = load_setup_py_data() %}
 
 package:
-  name: anaconda-project
+  name: conda-project
   version: {{ data.get('version') }}
 
 source:
@@ -12,7 +12,7 @@ build:
   noarch: python
   script: pip install . --no-deps --ignore-installed --no-cache-dir
   entry_points:
-    - anaconda-project = anaconda_project.cli:main
+    - conda-project = anaconda_project.cli:main
   script_env:
     - COVERAGE_DIR
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ parentdir_prefix = anaconda_project-
 [tool:pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
-norecursedirs= .* *.egg* build bin dist conda.recipe scripts examples
+norecursedirs= .* *.egg* build bin dist conda.recipe scripts examples env
 addopts =
     -vvrfe
     --durations=10

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import versioneer
 import io
 
 setuptools.setup(
-    name='anaconda-project',
+    name='conda-project',
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
     keywords=["conda anaconda project reproducible data science"],
@@ -34,7 +34,7 @@ setuptools.setup(
         "tqdm",
     ],
     entry_points={"console_scripts": [
-        "anaconda-project = anaconda_project.cli:main",
+        "conda-project = anaconda_project.cli:main",
     ]},
     packages=setuptools.find_packages(exclude=['contrib', 'docs', 'tests*']),
     include_package_data=True,


### PR DESCRIPTION
- [ ] README update for future of this tool (rip and replace as Conda API is available and conda-lock goes 1.0)
- [x] conda-* cli entry points (initialize, add/remove-*, dockerize, run)
- [x] Getting started and other docs converted to new CLI (update style to match conda-docs)
- [ ] submission for forking to conda-incubator
- [ ] [CEP](https://github.com/conda/ceps/blob/main/cep-1.md) for locking (implicit?) to provide a standard in the community as a dependency for project and other things (co-write with conda-lock authors)
- [x] merge and rebase against #359 
- [x] fix add/remove packages behavior (it will now create a separate project.yml file)
- [x] ensure backcompatibility using legacy anaconda-project cli or a conversion step
- [ ] motivating usecases: (alternative to pyenv+poetry)
- [ ] `commands: {<name>: {command: <str>}}` with unix-command/win-command when needed
- [ ] drop `supports_http_options` in favor of explicit jinja
- [ ] drop `notebook`, `bokeh` commands in favor docs with jinja docs

This PR combines #284 and #275 along with rebasing against latest commits to rename `anaconda-project` to `conda-project` with no other change in the commands (at this time).

```
conda install -c defusco/label/dev conda-project
```


The default project file is now `project.yml`, but may also be called `conda-project.yml` or `anaconda-project.yml`.

The largest change is that`environment.yml` or `requirements.txt` files can be used directly without the need to create a `project.yml` (nor will the file be created for you).

Enabled use cases
* `conda-project prepare`
* `conda-project run <executable> [<arg1>, <arg2>, ...]`

**Note** The run command can execute any executable in the environment and pass arguments to it. Commands need not be specified in an `project.yml` file to be able to run.

In the two use cases shown below there is no `project.yml` file and it will not be created with the commands shown. For both cases you can use `conda-project prepare` to create the file and import the required packages from either `environmnent.yml` or `requirements.txt`.

## environment.yml

Here's a typical environment specification file.

```yaml
name: envYaml

channels:
  - defaults
  - conda-forge

dependencies:
  - python=3.8
  - tranquilizer>=0.7
  - pip:
    - requests
```

Create the environment within the `envs` directory of the project. The name of the env_spec will match the `name:` key in the environment.yml.

```
> conda-project prepare
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/adefusco/Desktop/envYaml/envs/envYaml

  added / updated specs:
    - python=3.8
    - tranquilizer[version='>=0.7']


The following NEW packages will be INSTALLED:

  aniso8601          pkgs/main/noarch::aniso8601-9.0.1-pyhd3eb1b0_0
  attrs              pkgs/main/noarch::attrs-21.4.0-pyhd3eb1b0_0
  ca-certificates    pkgs/main/osx-arm64::ca-certificates-2021.10.26-hca03da5_2
  certifi            pkgs/main/osx-arm64::certifi-2021.10.8-py38hca03da5_2
  click              pkgs/main/noarch::click-8.0.3-pyhd3eb1b0_0
  flask              pkgs/main/noarch::flask-1.1.2-pyhd3eb1b0_0
  flask-cors         pkgs/main/noarch::flask-cors-3.0.10-pyhd3eb1b0_0
  flask-jwt-extended conda-forge/noarch::flask-jwt-extended-4.3.1-pyhd8ed1ab_0
  flask-restx        pkgs/main/noarch::flask-restx-0.5.1-pyhd3eb1b0_0
  importlib-metadata pkgs/main/osx-arm64::importlib-metadata-4.8.2-py38hca03da5_0
  importlib_metadata pkgs/main/noarch::importlib_metadata-4.8.2-hd3eb1b0_0
  itsdangerous       pkgs/main/noarch::itsdangerous-2.0.1-pyhd3eb1b0_0
  jinja2             pkgs/main/noarch::jinja2-3.0.2-pyhd3eb1b0_0
  jsonschema         pkgs/main/noarch::jsonschema-3.2.0-pyhd3eb1b0_2
  libcxx             pkgs/main/osx-arm64::libcxx-12.0.0-hf6beb65_1
  libffi             pkgs/main/osx-arm64::libffi-3.4.2-hc377ac9_2
  markupsafe         pkgs/main/osx-arm64::markupsafe-2.0.1-py38h1a28f6b_0
  ncurses            pkgs/main/osx-arm64::ncurses-6.3-h1a28f6b_2
  openssl            pkgs/main/osx-arm64::openssl-1.1.1m-h1a28f6b_0
  pip                pkgs/main/osx-arm64::pip-21.2.4-py38hca03da5_0
  pyjwt              pkgs/main/osx-arm64::pyjwt-2.1.0-py38hca03da5_0
  pyrsistent         pkgs/main/osx-arm64::pyrsistent-0.18.0-py38h1a28f6b_0
  python             pkgs/main/osx-arm64::python-3.8.11-hbdb9e5c_5
  python-dateutil    pkgs/main/noarch::python-dateutil-2.8.2-pyhd3eb1b0_0
  pytz               pkgs/main/noarch::pytz-2021.3-pyhd3eb1b0_0
  readline           pkgs/main/osx-arm64::readline-8.1.2-h1a28f6b_1
  setuptools         pkgs/main/osx-arm64::setuptools-58.0.4-py38hca03da5_1
  six                pkgs/main/noarch::six-1.16.0-pyhd3eb1b0_0
  sqlite             pkgs/main/osx-arm64::sqlite-3.37.2-h1058600_0
  tk                 pkgs/main/osx-arm64::tk-8.6.11-hb8d0fd4_0
  tranquilizer       conda-forge/noarch::tranquilizer-0.7.0-pyhd8ed1ab_0
  werkzeug           pkgs/main/noarch::werkzeug-1.0.1-pyhd3eb1b0_0
  wheel              pkgs/main/noarch::wheel-0.37.1-pyhd3eb1b0_0
  xz                 pkgs/main/osx-arm64::xz-5.2.5-h1a28f6b_0
  zipp               pkgs/main/noarch::zipp-3.7.0-pyhd3eb1b0_0
  zlib               pkgs/main/osx-arm64::zlib-1.2.11-h5a0b063_4


Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
#
# To activate this environment, use
#
#     $ conda activate /Users/adefusco/Desktop/envYaml/envs/envYaml
#
# To deactivate an active environment, use
#
#     $ conda deactivate

Collecting requests
  Using cached requests-2.27.1-py2.py3-none-any.whl (63 kB)
Requirement already satisfied: certifi>=2017.4.17 in ./envs/envYaml/lib/python3.8/site-packages (from requests) (2021.10.8)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.8-py2.py3-none-any.whl (138 kB)
Collecting idna<4,>=2.5
  Using cached idna-3.3-py3-none-any.whl (61 kB)
Collecting charset-normalizer~=2.0.0
  Downloading charset_normalizer-2.0.12-py3-none-any.whl (39 kB)
Installing collected packages: urllib3, idna, charset-normalizer, requests
Successfully installed charset-normalizer-2.0.12 idna-3.3 requests-2.27.1 urllib3-1.26.8
The project is ready to run commands.
Use `anaconda-project list-commands` to see what's available.
```

Now we can run a command available in the PATH for the conda environment.

```
> conda-project run python --version
Python 3.8.11

>  conda-project run tranquilizer cheese_shop.py --port 8080
 * Serving Flask app "tranquilizer.application" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: off
 * Running on http://0.0.0.0:8080/ (Press CTRL+C to quit) 
```

Finally, after adding packages to the the `environment.yml` file they can be installed. (use the `--refresh` to completely rebuild the env, prepare will not remove packages)

```
# add numpy to the dependencies section using an editor

> conda-project prepare
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/adefusco/Desktop/envYaml/envs/envYaml

  added / updated specs:
    - numpy


The following packages will be downloaded:

    package                    |            build
    ---------------------------|-----------------
    numpy-1.21.2               |   py38hb38b75b_0           9 KB
    numpy-base-1.21.2          |   py38h6269429_0         4.2 MB
    ------------------------------------------------------------
                                           Total:         4.2 MB

The following NEW packages will be INSTALLED:

  blas               conda-forge/osx-arm64::blas-2.113-openblas
  blas-devel         conda-forge/osx-arm64::blas-devel-3.9.0-13_osxarm64_openblas
  libblas            conda-forge/osx-arm64::libblas-3.9.0-13_osxarm64_openblas
  libcblas           conda-forge/osx-arm64::libcblas-3.9.0-13_osxarm64_openblas
  libgfortran        pkgs/main/osx-arm64::libgfortran-5.0.0-11_1_0_h6a59814_26
  libgfortran5       pkgs/main/osx-arm64::libgfortran5-11.1.0-h6a59814_26
  liblapack          conda-forge/osx-arm64::liblapack-3.9.0-13_osxarm64_openblas
  liblapacke         conda-forge/osx-arm64::liblapacke-3.9.0-13_osxarm64_openblas
  libopenblas        conda-forge/osx-arm64::libopenblas-0.3.18-openmp_h5dd58f0_0
  llvm-openmp        pkgs/main/osx-arm64::llvm-openmp-12.0.0-haf9daa7_1
  numpy              pkgs/main/osx-arm64::numpy-1.21.2-py38hb38b75b_0
  numpy-base         pkgs/main/osx-arm64::numpy-base-1.21.2-py38h6269429_0
  openblas           conda-forge/osx-arm64::openblas-0.3.18-openmp_h3b88efd_0



Downloading and Extracting Packages
numpy-base-1.21.2    | 4.2 MB    | ########## | 100% 
numpy-1.21.2         | 9 KB      | ########## | 100% 
Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
The project is ready to run commands.
Use `anaconda-project list-commands` to see what's available.
```

### locking dependencies

To write the lock file (fully specified cross-platform environments) `project-lock.yml`

```
> conda-project lock
Updating locked dependencies for env spec envYaml...
Resolving conda packages for osx-arm64
Resolving conda packages for linux-64
Resolving conda packages for osx-64
Resolving conda packages for win-64
Changes to locked dependencies for envYaml:
  platforms:
+   linux-64
+   osx-64
+   osx-arm64
+   win-64
```

the lock file also included all pip packages (i.e., pip freeze)

```
> tail project-lock.yml
      - setuptools=58.0.4=py38haa95532_0
      - sqlite=3.37.2=h2bbff1b_0
      - vc=14.2=h21ff451_1
      - vs2015_runtime=14.27.29016=h5e58377_2
      - wincertstore=0.2=py38haa95532_2
      pip:
      - charset-normalizer==2.0.12
      - idna==3.3
      - requests==2.27.1
      - urllib3==1.26.8
```

If the environment.yml file differs from its version when the `project-lock.yml` file was created then `conda-project` commands will print a warning.

```
> conda-project run python --version
Potential issues with this project:
  * project-lock.yml: Env spec 'envYaml' has changed since the lock file was last updated (env spec hash has changed from a8520e7c59d22b0f271b4098e0041ca14a7404a6 to 7aa631535b843f3889a7fcec42886043d5c8d12a)
  * project-lock.yml: Lock file is missing 1 packages for env spec envYaml on linux-64 (pandas)
  * project-lock.yml: Lock file is missing 1 packages for env spec envYaml on osx-64 (pandas)
  * project-lock.yml: Lock file is missing 1 packages for env spec envYaml on osx-arm64 (pandas)
  * project-lock.yml: Lock file is missing 1 packages for env spec envYaml on win-64 (pandas)
```

to remove the warning `update` will re-lock the packages and install the missing pacakges

```
> conda-project update
Updating locked dependencies for env spec envYaml...
Resolving conda packages for osx-arm64
Resolving conda packages for linux-64
Resolving conda packages for osx-64
Resolving conda packages for win-64
Changes to locked dependencies for envYaml:
  packages:
    all:
+     packaging=21.3=pyhd3eb1b0_0
+     pyparsing=3.0.4=pyhd3eb1b0_0
    linux-64:
+     bottleneck=1.3.2=py38heb32a55_1
+     numexpr=2.8.1=py38h6abb31d_0
+     pandas=1.3.5=py38h8c16a72_0
    osx-64:
+     bottleneck=1.3.2=py38hf1fa96c_1
+     numexpr=2.8.1=py38h2e5f0a9_0
+     pandas=1.3.5=py38h743cdd8_0
    osx-arm64:
+     bottleneck=1.3.2=py38heec5a64_1
+     numexpr=2.8.1=py38h144ceef_0
+     pandas=1.3.5=py38h9197a36_0
    win-64:
+     bottleneck=1.3.2=py38h2a96729_1
+     numexpr=2.8.1=py38hb80d3ca_0
+     pandas=1.3.5=py38h6214cd6_0
-   pip:
-     charset-normalizer==2.0.12
-     idna==3.3
-     requests==2.27.1
-     urllib3==1.26.8
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/adefusco/Desktop/envYaml/envs/envYaml

  added / updated specs:
    - bottleneck==1.3.2=py38heec5a64_1
    - numexpr==2.8.1=py38h144ceef_0
    - packaging==21.3=pyhd3eb1b0_0
    - pandas==1.3.5=py38h9197a36_0
    - pyparsing==3.0.4=pyhd3eb1b0_0


The following NEW packages will be INSTALLED:

  bottleneck         pkgs/main/osx-arm64::bottleneck-1.3.2-py38heec5a64_1
  numexpr            pkgs/main/osx-arm64::numexpr-2.8.1-py38h144ceef_0
  packaging          pkgs/main/noarch::packaging-21.3-pyhd3eb1b0_0
  pandas             pkgs/main/osx-arm64::pandas-1.3.5-py38h9197a36_0
  pyparsing          pkgs/main/noarch::pyparsing-3.0.4-pyhd3eb1b0_0


Preparing transaction: ...working... done
Verifying transaction: ...working... done
Executing transaction: ...working... done
Updated locked dependencies for env spec envYaml in project-lock.yml.
Update complete.
```

## environment.yml and project.yml

To extend the environment.yml file with specific project features like environment variables, supported platforms, commands, and data sets. For example

```yaml
name: envYaml

variables:
  PROJECT_VAR: 'value set in project.yml'

downloads:
  MPG_CSV: https://bit.ly/autompg-csv

commands:
  default:
    unix: env | grep PROJECT_VAR

platforms:
  - osx-64
  - osx-arm64
```

Beginning by running prepare we see that the environment is created and the dataset downloaded

```
# To activate this environment, use
#
#     $ conda activate /Users/adefusco/Desktop/envYaml/envs/envYaml
#
# To deactivate an active environment, use
#
#     $ conda deactivate

Collecting requests
  Using cached requests-2.27.1-py2.py3-none-any.whl (63 kB)
Requirement already satisfied: certifi>=2017.4.17 in ./envs/envYaml/lib/python3.8/site-packages (from requests) (2021.10.8)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.8-py2.py3-none-any.whl (138 kB)
Collecting charset-normalizer~=2.0.0
  Using cached charset_normalizer-2.0.12-py3-none-any.whl (39 kB)
Collecting idna<4,>=2.5
  Using cached idna-3.3-py3-none-any.whl (61 kB)
Installing collected packages: urllib3, idna, charset-normalizer, requests
Successfully installed charset-normalizer-2.0.12 idna-3.3 requests-2.27.1 urllib3-1.26.8
exoplanets.csv: 100%|████████████████████████████████████████████████████████████████████| 0.28/0.28 [00:00<00:00, 3.33s/MiB]
The project is ready to run commands.
Use `anaconda-project list-commands` to see what's available.
```

Now running the default command verifies that the env variable is set

```
> conda-project run
Previously downloaded file located at /Users/adefusco/Desktop/envYaml/exoplanets.csv
PROJECT_VAR=value set in project.yml
```

And finally, running lock will only lock for the provided platforms

```
> conda-project lock
Updating locked dependencies for env spec envYaml...
Resolving conda packages for osx-arm64
Resolving conda packages for osx-64
Changes to locked dependencies for envYaml:
  platforms:
+   osx-64
+   osx-arm64
```

# requirements.txt

If there is a `requirements.txt` in the project directory (and no `environment.yml`) all packages listed will be installed as pip packages.

```
requests
tranquilizer==0.4.2
```

Running the prepare will first create a Conda environment with the most recent version of Python (3.8) and pip and then add the packages in the `requirements.txt` file.

```
> conda-project prepare
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/adefusco/Development/AnacondaPlatform/anaconda-project/examples/reqs/envs/default

  added / updated specs:
    - python


The following NEW packages will be INSTALLED:

  ca-certificates    pkgs/main/osx-64::ca-certificates-2020.1.1-0
  certifi            pkgs/main/osx-64::certifi-2020.4.5.2-py38_0
  libcxx             pkgs/main/osx-64::libcxx-10.0.0-1
  libedit            pkgs/main/osx-64::libedit-3.1.20181209-hb402a30_0
  libffi             pkgs/main/osx-64::libffi-3.3-h0a44026_1
  ncurses            pkgs/main/osx-64::ncurses-6.2-h0a44026_1
  openssl            pkgs/main/osx-64::openssl-1.1.1g-h1de35cc_0
  pip                pkgs/main/osx-64::pip-20.0.2-py38_3
  python             pkgs/main/osx-64::python-3.8.3-h26836e1_1
```

And confirm the pip packages were installed

```
>conda list -p envs/default
# packages in environment at /Users/adefusco/Development/AnacondaPlatform/anaconda-project/examples/reqs/envs/default:
#
# Name                    Version                   Build  Channel
aniso8601                 8.0.0                    pypi_0    pypi
attrs                     19.3.0                   pypi_0    pypi
ca-certificates           2020.1.1                      0  
certifi                   2020.4.5.2               py38_0  
chardet                   3.0.4                    pypi_0    pypi
click                     7.1.2                    pypi_0    pypi
flask                     1.1.2                    pypi_0    pypi
flask-restplus            0.13.0                   pypi_0    pypi
```

If you require a different version of Python it can be supplied during prepare

```
>conda-project prepare --python=3.6
Collecting package metadata (current_repodata.json): ...working... done
Solving environment: ...working... done

## Package Plan ##

  environment location: /Users/adefusco/Development/AnacondaPlatform/anaconda-project/examples/reqs/envs/default

  added / updated specs:
    - python=3.6


The following NEW packages will be INSTALLED:

  ca-certificates    pkgs/main/osx-64::ca-certificates-2020.1.1-0
  certifi            pkgs/main/osx-64::certifi-2020.4.5.2-py36_0
  libcxx             pkgs/main/osx-64::libcxx-10.0.0-1
  libedit            pkgs/main/osx-64::libedit-3.1.20181209-hb402a30_0
  libffi             pkgs/main/osx-64::libffi-3.3-h0a44026_1
  ncurses            pkgs/main/osx-64::ncurses-6.2-h0a44026_1
  openssl            pkgs/main/osx-64::openssl-1.1.1g-h1de35cc_0
  pip                pkgs/main/osx-64::pip-20.0.2-py36_3
  python             pkgs/main/osx-64::python-3.6.10-hf48f09d_2
```


Again, you can run any executable in the environment

```
>conda-project run tranquilizer --version
tranquilizer 0.4.2
```

Again, you can add packages to `requirements.txt` and install them with prepare

```
# edit requirements.txt to add pytest

> conda-project prepare
The project is ready to run commands.
Use `anaconda-project list-commands` to see what's available.




> conda list -p envs/default py
# packages in environment at /Users/adefusco/Development/AnacondaPlatform/anaconda-project/examples/reqs/envs/default:
#
# Name                    Version                   Build  Channel
py                        1.8.2                    pypi_0    pypi
pyparsing                 2.4.7                    pypi_0    pypi
pyrsistent                0.16.0                   pypi_0    pypi
pytest                    5.4.3                    pypi_0    pypi
python                    3.6.10               hf48f09d_2  
python-dateutil           2.8.1                    pypi_0    pypi
pytz                      2020.1                   pypi_0    pypi
```