### PR TITLE
Disable-channel-override

### DIFF
--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -160,7 +160,11 @@ def create(prefix, pkgs=None, channels=(), stdout_callback=None, stderr_callback
     if os.path.exists(prefix):
         raise CondaEnvExistsError('Conda environment [%s] already exists' % prefix)
 
-    cmd_list = ['create', '--override-channels', '--yes', '--prefix', prefix]
+    cmd_list = ['create', '--yes', '--prefix', prefix]
+
+    disable_override_channels = os.environ.get('ANACONDA_PROJECT_DISABLE_OVERRIDE_CHANNELS', False)
+    if not disable_override_channels:
+        cmd_list.insert(1, '--override-channels')
 
     if channels:
         for channel in channels:

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -251,8 +251,7 @@ def test_conda_create_disable_override_channels(monkeypatch):
     monkeypatch.setenv('ANACONDA_PROJECT_DISABLE_OVERRIDE_CHANNELS', True)
 
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
-        assert ['create', '--yes', '--prefix', '/prefix', '--channel', 'foo',
-                'python'] == extra_args
+        assert ['create', '--yes', '--prefix', '/prefix', '--channel', 'foo', 'python'] == extra_args
 
     monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
     conda_api.create(prefix='/prefix', pkgs=['python'], channels=['foo'])

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -247,6 +247,17 @@ sys.exit(0)
     with_directory_contents(dict(), do_test)
 
 
+def test_conda_create_disable_override_channels(monkeypatch):
+    monkeypatch.setenv('ANACONDA_PROJECT_DISABLE_OVERRIDE_CHANNELS', True)
+
+    def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
+        assert ['create', '--yes', '--prefix', '/prefix', '--channel', 'foo',
+                'python'] == extra_args
+
+    monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
+    conda_api.create(prefix='/prefix', pkgs=['python'], channels=['foo'])
+
+
 def test_conda_create_gets_channels(monkeypatch):
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
         assert ['create', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo',

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -7,8 +7,16 @@ Configuration
 Environment variables
 ---------------------
 
-Anaconda Project has two modifiable configuration settings, both of which
+Anaconda Project has modifiable configuration settings, which
 are currently controlled exclusively by environment variables.
+
+``ANACONDA_PROJECT_DISABLE_OVERRIDE_CHANNELS``
+  Starting in version 0.11.0 Anaconda Project ignores any CondaRC
+  configuration settings for ``channels:`` by default. Packages will only be
+  installed from channels listed in the ``anaconda-project.yml`` file.
+  Set this environment variable to a true value (1, or ``'True'``) to disable
+  the override and allow the user or global CondaRC configuration to control
+  channels from which Anaconda Project can install packages.
 
 ``ANACONDA_PROJECT_ENVS_PATH``
   This variable provides a list of directories to search for environments


### PR DESCRIPTION
Enable the use of ANACONDA_PROJECT_DISABLE_OVERRIDE_CHANNELS to allow anaconda-project to respect the condarc channels definition in addition to what is written in the `channels:` key in the anaconda-project.yml file. 

The default behavior is to ignore any conda configuration of channels.