### PR TITLE
implicit use of "defaults" channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 We [keep a changelog.](http://keepachangelog.com/)
 
+## Version 0.11.1
+
+### Bug fixes 
+
+* [PR 388](https://github.com/Anaconda-Platform/anaconda-project/pull/388) implicit use of "defaults" channel. Resolves
+[387](https://github.com/Anaconda-Platform/anaconda-project/issues/387)
+
 ## Version 0.11.0
 
 ### Bug fixes

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -48,7 +48,7 @@ class CondaEnvMissingError(CondaError):
 def _implicit_defaults(channels):
     trimmed = [c for c in channels if c != 'nodefaults']
 
-    if 'nodefaults' not in channels:
+    if ('nodefaults' not in channels) and ('defaults' not in channels):
         trimmed.append('defaults')
 
     return trimmed

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -45,6 +45,15 @@ class CondaEnvMissingError(CondaError):
     pass
 
 
+def _implicit_defaults(channels):
+    trimmed = [c for c in channels if c != 'nodefaults']
+
+    if 'nodefaults' not in channels:
+        trimmed.append('defaults')
+
+    return trimmed
+
+
 # this function exists so we can monkeypatch it in tests
 def _get_conda_command(extra_args):
     # just use whatever conda is on the path
@@ -167,7 +176,7 @@ def create(prefix, pkgs=None, channels=(), stdout_callback=None, stderr_callback
         cmd_list.insert(1, '--override-channels')
 
     if channels:
-        for channel in channels:
+        for channel in _implicit_defaults(channels):
             cmd_list.extend(['--channel', channel])
     else:
         cmd_list.extend(['--channel', 'defaults'])
@@ -200,7 +209,7 @@ def install(prefix, pkgs=None, channels=(), stdout_callback=None, stderr_callbac
     cmd_list.extend(['--prefix', prefix])
 
     if channels:
-        for channel in channels:
+        for channel in _implicit_defaults(channels):
             cmd_list.extend(['--channel', channel])
     else:
         cmd_list.extend(['--channel', 'defaults'])

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -287,7 +287,7 @@ def resolve_dependencies(pkgs, channels=(), platform=None):
     cmd_list = ['create', '--override-channels', '--yes', '--quiet', '--json', '--dry-run', '--prefix', prefix]
 
     if channels:
-        for channel in channels:
+        for channel in _implicit_defaults(channels):
             cmd_list.extend(['--channel', channel])
     else:
         cmd_list.extend(['--channel', 'defaults'])

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -205,8 +205,12 @@ def install(prefix, pkgs=None, channels=(), stdout_callback=None, stderr_callbac
         raise TypeError('must specify a list of one or more packages to install into existing environment, not %r',
                         pkgs)
 
-    cmd_list = ['install', '--override-channels', '--yes']
+    cmd_list = ['install', '--yes']
     cmd_list.extend(['--prefix', prefix])
+
+    disable_override_channels = os.environ.get('ANACONDA_PROJECT_DISABLE_OVERRIDE_CHANNELS', False)
+    if not disable_override_channels:
+        cmd_list.insert(1, '--override-channels')
 
     if channels:
         for channel in _implicit_defaults(channels):
@@ -284,7 +288,11 @@ def resolve_dependencies(pkgs, channels=(), platform=None):
     # after we remove it, and then conda's mkdir would fail.
     os.rmdir(prefix)
 
-    cmd_list = ['create', '--override-channels', '--yes', '--quiet', '--json', '--dry-run', '--prefix', prefix]
+    cmd_list = ['create', '--yes', '--quiet', '--json', '--dry-run', '--prefix', prefix]
+
+    disable_override_channels = os.environ.get('ANACONDA_PROJECT_DISABLE_OVERRIDE_CHANNELS', False)
+    if not disable_override_channels:
+        cmd_list.insert(1, '--override-channels')
 
     if channels:
         for channel in _implicit_defaults(channels):

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -251,7 +251,8 @@ def test_conda_create_disable_override_channels(monkeypatch):
     monkeypatch.setenv('ANACONDA_PROJECT_DISABLE_OVERRIDE_CHANNELS', True)
 
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
-        assert ['create', '--yes', '--prefix', '/prefix', '--channel', 'foo', '--channel' ,'defaults', 'python'] == extra_args
+        assert ['create', '--yes', '--prefix', '/prefix', '--channel', 'foo', '--channel', 'defaults',
+                'python'] == extra_args
 
     monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
     conda_api.create(prefix='/prefix', pkgs=['python'], channels=['foo'])
@@ -259,7 +260,8 @@ def test_conda_create_disable_override_channels(monkeypatch):
 
 def test_conda_create_nodefaults(monkeypatch):
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
-        assert ['create', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo', 'python'] == extra_args
+        assert ['create', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo',
+                'python'] == extra_args
 
     monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
     conda_api.create(prefix='/prefix', pkgs=['python'], channels=['foo', 'nodefaults'])
@@ -267,9 +269,10 @@ def test_conda_create_nodefaults(monkeypatch):
 
 def test_conda_create_gets_channels(monkeypatch):
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
-        assert ['create', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo',
-                '--channel', 'defaults',
-                'python'] == extra_args
+        assert [
+            'create', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo', '--channel',
+            'defaults', 'python'
+        ] == extra_args
 
     monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
     conda_api.create(prefix='/prefix', pkgs=['python'], channels=['foo'])
@@ -277,8 +280,10 @@ def test_conda_create_gets_channels(monkeypatch):
 
 def test_conda_install_gets_channels(monkeypatch):
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
-        assert ['install', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo',
-                '--channel', 'defaults', 'python'] == extra_args
+        assert [
+            'install', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo', '--channel',
+            'defaults', 'python'
+        ] == extra_args
 
     monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
     conda_api.install(prefix='/prefix', pkgs=['python'], channels=['foo'])

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -257,6 +257,14 @@ def test_conda_create_disable_override_channels(monkeypatch):
     conda_api.create(prefix='/prefix', pkgs=['python'], channels=['foo'])
 
 
+def test_conda_create_nodefaults(monkeypatch):
+    def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
+        assert ['create', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo', 'python'] == extra_args
+
+    monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
+    conda_api.create(prefix='/prefix', pkgs=['python'], channels=['foo', 'nodefaults'])
+
+
 def test_conda_create_gets_channels(monkeypatch):
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
         assert ['create', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo',

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -278,6 +278,17 @@ def test_conda_create_gets_channels(monkeypatch):
     conda_api.create(prefix='/prefix', pkgs=['python'], channels=['foo'])
 
 
+def test_conda_create_with_defaults(monkeypatch):
+    def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
+        assert [
+            'create', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'defaults', '--channel',
+            'foo', 'python'
+        ] == extra_args
+
+    monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
+    conda_api.create(prefix='/prefix', pkgs=['python'], channels=['defaults', 'foo'])
+
+
 def test_conda_install_gets_channels(monkeypatch):
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
         assert [
@@ -287,6 +298,17 @@ def test_conda_install_gets_channels(monkeypatch):
 
     monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
     conda_api.install(prefix='/prefix', pkgs=['python'], channels=['foo'])
+
+
+def test_conda_install_with_defaults(monkeypatch):
+    def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
+        assert [
+            'install', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'defaults', '--channel',
+            'foo', 'python'
+        ] == extra_args
+
+    monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
+    conda_api.install(prefix='/prefix', pkgs=['python'], channels=['defaults', 'foo'])
 
 
 def test_resolve_root_prefix():

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -251,7 +251,7 @@ def test_conda_create_disable_override_channels(monkeypatch):
     monkeypatch.setenv('ANACONDA_PROJECT_DISABLE_OVERRIDE_CHANNELS', True)
 
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
-        assert ['create', '--yes', '--prefix', '/prefix', '--channel', 'foo', 'python'] == extra_args
+        assert ['create', '--yes', '--prefix', '/prefix', '--channel', 'foo', '--channel' ,'defaults', 'python'] == extra_args
 
     monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
     conda_api.create(prefix='/prefix', pkgs=['python'], channels=['foo'])
@@ -260,6 +260,7 @@ def test_conda_create_disable_override_channels(monkeypatch):
 def test_conda_create_gets_channels(monkeypatch):
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
         assert ['create', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo',
+                '--channel', 'defaults',
                 'python'] == extra_args
 
     monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
@@ -269,7 +270,7 @@ def test_conda_create_gets_channels(monkeypatch):
 def test_conda_install_gets_channels(monkeypatch):
     def mock_call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None, stderr_callback=None):
         assert ['install', '--override-channels', '--yes', '--prefix', '/prefix', '--channel', 'foo',
-                'python'] == extra_args
+                '--channel', 'defaults', 'python'] == extra_args
 
     monkeypatch.setattr('anaconda_project.internal.conda_api._call_conda', mock_call_conda)
     conda_api.install(prefix='/prefix', pkgs=['python'], channels=['foo'])

--- a/docs/source/user-guide/tasks/work-with-packages.rst
+++ b/docs/source/user-guide/tasks/work-with-packages.rst
@@ -114,7 +114,7 @@ Package Channels
   or in the project YAML file.  To support reproducible projects that build the same way for different users, Anaconda Project will not respect channels declared in your ``.condarc`` file.
 
 .. note::
-  *Backwards compatibility fix in version 0.11.1*. The ``defaults`` channel is always included when packages are installed
+  *Backwards compatibility fix in version 0.11.1*. The ``defaults`` channel is always appended when packages are installed
   or locked even if it is not specified in the ``channels:`` list. To avoid searching over the ``defaults`` channel add the chanel ``nodefaults``.
 
 

--- a/docs/source/user-guide/tasks/work-with-packages.rst
+++ b/docs/source/user-guide/tasks/work-with-packages.rst
@@ -114,14 +114,15 @@ Package Channels
   or in the project YAML file.  To support reproducible projects that build the same way for different users, Anaconda Project will not respect channels declared in your ``.condarc`` file.
 
 .. note::
-  *Backwards compatibility fix in version 0.11.1*. The ``defaults`` channel is always appended when packages are installed
-  or locked even if it is not specified in the ``channels:`` list. To avoid searching over the ``defaults`` channel add the chanel ``nodefaults``.
+  *Backwards compatibility fix in version 0.11.1*. The ``defaults`` channel is always appended to the list of channels
+  even if it is not specified in the ``channels:`` list in the project file or with the ``-c`` flag using the CLI.
+  If the ``defaults`` channel is specified no change is made. To avoid including the ``defaults`` channel add the
+  channel name ``nodefaults``.
 
 
 Up till now we have not instructed Conda to install packages from specific channels, so all packages are installed from
-the Conda default channels. The default channels
-will be used if there is no specific channel requested with ``anaconda-project add-packages`` and
-no ``channels:`` key in the ``anaconda-project.yml`` file, as in this example:
+the Conda default channels. If no channels are speicified in the project file or on the command line then the
+``defaults`` channel is used.
 
 .. code-block:: yaml
 
@@ -167,6 +168,33 @@ The resulting ``anaconda-project.yml`` file is now
     default: {}
 
 
+If you wish to avoid using the ``defaults`` channel you must add the channel ``nodefaults``. This will instruct
+Anaconda Project to not append the ``defaults`` channel automatically. The order in which ``nodefaults`` appears
+does not matter.
+
+For example to install packages only from the ``conda-forge`` channel::
+
+  anaconda-project add-packages -c conda-forge -c nodefaults fastapi
+
+The resulting ``anaconda-project.yml`` file is now
+
+.. code-block:: yaml
+
+  name: ExampleProject
+
+  packages:
+    - python=3.8
+    - notebook
+    - pandas
+    - pip:
+      - requests
+
+  channels:
+    - conda-forge
+    - nodefaults
+
+  env_specs:
+    default: {}
 
 
 *****************

--- a/docs/source/user-guide/tasks/work-with-packages.rst
+++ b/docs/source/user-guide/tasks/work-with-packages.rst
@@ -113,6 +113,11 @@ Package Channels
   *Breaking Change in version 0.11.0*. All channels you wish to search through for packages must be supplied on the CLI
   or in the project YAML file.  To support reproducible projects that build the same way for different users, Anaconda Project will not respect channels declared in your ``.condarc`` file.
 
+.. note::
+  *Backwards compatibility fix in version 0.11.1*. The ``defaults`` channel is always included when packages are installed
+  or locked even if it is not specified in the ``channels:`` list. To avoid searching over the ``defaults`` channel add the chanel ``nodefaults``.
+
+
 Up till now we have not instructed Conda to install packages from specific channels, so all packages are installed from
 the Conda default channels. The default channels
 will be used if there is no specific channel requested with ``anaconda-project add-packages`` and
@@ -160,6 +165,8 @@ The resulting ``anaconda-project.yml`` file is now
 
   env_specs:
     default: {}
+
+
 
 
 *****************

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ parentdir_prefix = anaconda_project-
 [tool:pytest]
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
-norecursedirs= .* *.egg* build bin dist conda.recipe scripts examples
+norecursedirs= .* *.egg* build bin dist conda.recipe scripts examples env
 addopts =
     -vvrfe
     --durations=10


### PR DESCRIPTION
This addresses #387 

The "defaults" is always appended to channels: list. This is disabled by adding a dummy channel called nodefaults.

@jbednar and @jlstevens I have dev build of the implementation of nodefaults.

```
conda install -c defusco/label/dev anaconda-project=0.11.0+2
```

I am working through the current test suite and will amend it for this case as well. Here is my test:

In version 0.11.0 the following project will not prepare or lock

```yaml
name: nodefaults

channels:
  - conda-forge

packages:
  - python=3.8
  - conda-token
  - ensureconda
```

the error from 0.11.0 is 

```
The following packages are not available from current channels:

  - conda-token

Current channels:

  - https://conda.anaconda.org/conda-forge/osx-arm64
  - https://conda.anaconda.org/conda-forge/noarch
```

Note that Conda's use of `nodefaults` is not identical to what is done above. In Conda

1. `nodefaults` can only be used within an environment.yml file
2. instead of appending just the `defaults` channel all channels from users .condarc file are added

Here ONLY `defaults` is added, any channels provided in condarc are still ignored.

With this dev release the above YAML file will lock and prepare.

To recover the behavior of 0.11.0 add a channel called `nodefaults`. This will prevent `defaults` from being added at the end of your channels list

```yaml
name: nodefaults

channels:
  - conda-forge
  - nodefaults

packages:
  - python=3.8
  - conda-token
  - ensureconda
```