### PR TITLE
Display download bar in all cases and make the timeout configurable via an env var

### DIFF
--- a/anaconda_project/internal/http_client.py
+++ b/anaconda_project/internal/http_client.py
@@ -109,7 +109,10 @@ class FileDownloader(object):
                 self._progress = tqdm(**self._progress_kwargs)
 
         try:
-            timeout_in_seconds = 60 * 10  # pretty long because we could be dealing with huge files
+            timeout_in_seconds = int(os.getenv(
+                'ANACONDA_PROJECT_DOWNLOADS_TIMEOUT',
+                60 * 10  # pretty long because we could be dealing with huge files
+            ))
             request = httpclient.HTTPRequest(url=self._url,
                                              header_callback=read_header,
                                              streaming_callback=writer,


### PR DESCRIPTION
We have observed two issues when files are downloaded in the *prepare* phase:

1. Responses without `Content-Length` lead to no download bar being displayed at all
2. Downloads longer than 10 minutes time out

This PR addresses 1) by displaying a progress bar in any case, so the user is aware of some sort of progress. They can also see if it hands and decide to abort if so.

![image](https://github.com/Anaconda-Platform/anaconda-project/assets/35924738/44b5257d-b60b-4803-95c9-caf9b8f25bd8)

2 isn't fully addressed, instead, the default timeout of 600s is made configurable via the `ANACONDA_PROJECT_DOWNLOADS_TIMEOUT` environment variable. I guess the best approach would be to implement a timeout that is raised only when nothing happens between receiving two chunks, instead of setting a global request timeout.
