### PR TITLE
DNM: feat: add project_info module for unified publication info across formats

### DIFF
--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2026, Anaconda, Inc. All rights reserved.
+#
+# Licensed under the terms of the BSD 3-Clause License.
+# The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Unified publication-info extraction for anaconda-project and pixi projects.
+
+The top-level :func:`publication_info` accepts a project directory, detects
+whether it is a pixi project (``pixi.toml`` present) or an anaconda-project
+(``anaconda-project.yml``), parses the relevant file, and returns a metadata
+dict with a shape compatible with :meth:`Project.publication_info`.
+
+The pixi branch reads ``pixi.toml`` directly rather than materializing a
+full :class:`Project` — anaconda-project is an established library for the
+legacy ``.yml`` format, and this module deliberately avoids expanding
+:class:`Project` to cover pixi. Consumers that need uniform metadata (e.g.
+anaconda-platform's publishing pipeline) get one entry point that works
+across both formats.
+
+The pixi branch also exposes a handful of pixi-native capabilities that
+anaconda-project does not support — TOML ``[feature.*]`` sections,
+``[environments]`` composition, and ``[activation.env]`` variables.
+"""
+from __future__ import absolute_import, print_function
+
+import os
+
+try:
+    import tomllib
+except ImportError:  # Python < 3.11
+    import tomli as tomllib
+
+
+PIXI_MANIFEST = 'pixi.toml'
+ANACONDA_PROJECT_MANIFEST = 'anaconda-project.yml'
+
+PROJECT_TYPE_KEY = 'project_type'
+PROJECT_TYPE_PIXI = 'pixi'
+PROJECT_TYPE_ANACONDA_PROJECT = 'anaconda-project'
+
+
+def detect_project_type(project_dir):
+    """Return the project type string for *project_dir*, or ``None`` if unknown.
+
+    Detection is by manifest presence; ``pixi.toml`` wins when both are present,
+    matching the dispatch used by :func:`publication_info`.
+    """
+    if os.path.isfile(os.path.join(project_dir, PIXI_MANIFEST)):
+        return PROJECT_TYPE_PIXI
+    if os.path.isfile(os.path.join(project_dir, ANACONDA_PROJECT_MANIFEST)):
+        return PROJECT_TYPE_ANACONDA_PROJECT
+    return None
+
+
+def publication_info(project_dir):
+    """Return a publication-info dict for the project at *project_dir*.
+
+    If ``pixi.toml`` is present, the pixi manifest is parsed directly. Otherwise
+    ``anaconda-project.yml`` is loaded through :class:`Project`. The returned
+    dict always includes a ``project_type`` key identifying which manifest
+    format was used.
+
+    Raises:
+        ValueError: the pixi manifest cannot be parsed.
+        FileNotFoundError: neither manifest is present.
+    """
+    project_type = detect_project_type(project_dir)
+    if project_type == PROJECT_TYPE_PIXI:
+        info = _pixi_publication_info(project_dir)
+    elif project_type == PROJECT_TYPE_ANACONDA_PROJECT:
+        info = _anaconda_project_publication_info(project_dir)
+    else:
+        raise FileNotFoundError(
+            'No {} or {} found in {}'.format(
+                PIXI_MANIFEST, ANACONDA_PROJECT_MANIFEST, project_dir
+            )
+        )
+    info[PROJECT_TYPE_KEY] = project_type
+    return info
+
+
+def _anaconda_project_publication_info(project_dir):
+    from anaconda_project.project import Project
+    return Project(project_dir).publication_info()
+
+
+def _pixi_publication_info(project_dir):
+    pixi_path = os.path.join(project_dir, PIXI_MANIFEST)
+    try:
+        with open(pixi_path, 'rb') as f:
+            data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError) as e:
+        raise ValueError('Failed to parse {}: {}'.format(pixi_path, e)) from e
+
+    workspace = data.get('workspace', {})
+    project_meta = data.get('project', {})
+    name = workspace.get('name', project_meta.get('name', os.path.basename(project_dir)))
+    description = workspace.get('description', project_meta.get('description', ''))
+    channels = workspace.get('channels', project_meta.get('channels', []))
+
+    tool_commands = data.get('tool', {}).get('anaconda', {}).get('commands', {})
+
+    commands = {}
+    state = {'first': True}
+
+    for task_name, task_def in data.get('tasks', {}).items():
+        cmd = _build_command(task_name, task_def, 'default', tool_commands, state)
+        if cmd is not None:
+            commands[task_name] = cmd
+
+    for feat_name, feat_def in data.get('feature', {}).items():
+        for task_name, task_def in feat_def.get('tasks', {}).items():
+            if task_name in commands:
+                continue
+            cmd = _build_command(task_name, task_def, feat_name, tool_commands, state)
+            if cmd is not None:
+                commands[task_name] = cmd
+
+    top_packages = [
+        _format_dep(pkg, spec) for pkg, spec in data.get('dependencies', {}).items()
+    ]
+    env_specs = {
+        'default': {
+            'packages': top_packages,
+            'channels': channels,
+        },
+    }
+    for env_name, env_def in data.get('environments', {}).items():
+        if env_name == 'default':
+            continue
+        features = env_def if isinstance(env_def, list) else env_def.get('features', [])
+        feature_pkgs = list(top_packages)
+        for feat in features:
+            feat_deps = data.get('feature', {}).get(feat, {}).get('dependencies', {})
+            feature_pkgs.extend(_format_dep(n, s) for n, s in feat_deps.items())
+        env_specs[env_name] = {
+            'packages': feature_pkgs,
+            'channels': channels,
+        }
+
+    variables = dict(data.get('activation', {}).get('env', {}))
+
+    return {
+        'name': name,
+        'description': description,
+        'commands': commands,
+        'env_specs': env_specs,
+        'variables': variables,
+    }
+
+
+def _build_command(task_name, task_def, env_spec, tool_commands, state):
+    if isinstance(task_def, str):
+        cmd_str = task_def
+    elif isinstance(task_def, dict):
+        cmd_str = task_def.get('cmd', '')
+        if task_def.get('environment'):
+            env_spec = task_def['environment']
+    else:
+        return None
+
+    tool_meta = tool_commands.get(task_name, {})
+
+    notebook = tool_meta.get('notebook')
+    if notebook is None:
+        notebook = _infer_notebook(cmd_str)
+
+    supports_http = tool_meta.get('supports_http_options')
+    if supports_http is None:
+        supports_http = notebook is not None or _looks_like_http(cmd_str)
+
+    is_default = tool_meta.get('default', state['first'])
+
+    description = tool_meta.get('description', '')
+    if not description:
+        description = 'Notebook %s' % notebook if notebook else cmd_str
+
+    state['first'] = False
+
+    return {
+        'unix': cmd_str,
+        'env_spec': env_spec,
+        'supports_http_options': supports_http,
+        'notebook': notebook,
+        'default': is_default,
+        'description': description,
+    }
+
+
+def _format_dep(name, spec):
+    if isinstance(spec, str) and spec not in ('*', ''):
+        if spec[0].isdigit():
+            return '{}={}'.format(name, spec)
+        return '{}{}'.format(name, spec)
+    return name
+
+
+def _infer_notebook(cmd_str):
+    for token in cmd_str.split():
+        if token.endswith('.ipynb'):
+            return token
+    return None
+
+
+def _looks_like_http(cmd_str):
+    http_indicators = [
+        'bokeh serve', 'panel serve', 'streamlit run',
+        'flask run', 'uvicorn', 'gunicorn',
+        'python -m http.server', 'voila',
+    ]
+    cmd_lower = cmd_str.lower()
+    return any(ind in cmd_lower for ind in http_indicators)

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -1,0 +1,417 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2026, Anaconda, Inc. All rights reserved.
+#
+# Licensed under the terms of the BSD 3-Clause License.
+# The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Tests for anaconda_project.project_info."""
+from __future__ import absolute_import, print_function
+
+import os
+import tempfile
+import textwrap
+
+import pytest
+
+from anaconda_project.project_info import (
+    PROJECT_TYPE_ANACONDA_PROJECT,
+    PROJECT_TYPE_KEY,
+    PROJECT_TYPE_PIXI,
+    _format_dep,
+    _infer_notebook,
+    _looks_like_http,
+    detect_project_type,
+    publication_info,
+)
+
+
+def _write_pixi_toml(tmpdir, content):
+    path = os.path.join(tmpdir, 'pixi.toml')
+    with open(path, 'w') as f:
+        f.write(content)
+    return tmpdir
+
+
+def _write_anaconda_project(tmpdir, content):
+    path = os.path.join(tmpdir, 'anaconda-project.yml')
+    with open(path, 'w') as f:
+        f.write(content)
+    return tmpdir
+
+
+class TestFormatDep:
+    def test_wildcard(self):
+        assert _format_dep('numpy', '*') == 'numpy'
+
+    def test_version_with_operator(self):
+        assert _format_dep('python', '>=3.12') == 'python>=3.12'
+
+    def test_version_with_equals(self):
+        assert _format_dep('pandas', '==2.1.0') == 'pandas==2.1.0'
+
+    def test_bare_version_number(self):
+        assert _format_dep('flask', '3.0.*') == 'flask=3.0.*'
+
+    def test_dict_spec(self):
+        assert _format_dep('torch', {'version': '>=2.0'}) == 'torch'
+
+    def test_none_spec(self):
+        assert _format_dep('requests', None) == 'requests'
+
+    def test_empty_string(self):
+        assert _format_dep('pkg', '') == 'pkg'
+
+
+class TestInferNotebook:
+    def test_notebook_detected(self):
+        assert _infer_notebook('jupyter notebook analysis.ipynb') == 'analysis.ipynb'
+
+    def test_notebook_with_path(self):
+        assert _infer_notebook('voila notebooks/demo.ipynb') == 'notebooks/demo.ipynb'
+
+    def test_no_notebook(self):
+        assert _infer_notebook('python app.py') is None
+
+    def test_ipynb_substring_not_matched(self):
+        assert _infer_notebook('echo ipynb_files') is None
+
+
+class TestLooksLikeHttp:
+    def test_panel_serve(self):
+        assert _looks_like_http('panel serve dashboard.py') is True
+
+    def test_bokeh_serve(self):
+        assert _looks_like_http('bokeh serve app') is True
+
+    def test_flask_run(self):
+        assert _looks_like_http('flask run --port 8080') is True
+
+    def test_uvicorn(self):
+        assert _looks_like_http('uvicorn main:app') is True
+
+    def test_gunicorn(self):
+        assert _looks_like_http('gunicorn app:app') is True
+
+    def test_streamlit(self):
+        assert _looks_like_http('streamlit run app.py') is True
+
+    def test_voila(self):
+        assert _looks_like_http('voila notebook.ipynb') is True
+
+    def test_plain_python(self):
+        assert _looks_like_http('python app.py') is False
+
+    def test_python_http_server(self):
+        assert _looks_like_http('python -m http.server 8000') is True
+
+
+class TestPublicationInfoBasic:
+    def test_minimal_project(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "test"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert info['name'] == 'test'
+            assert info['description'] == ''
+            assert info['commands'] == {}
+            assert info['env_specs'] == {'default': {'packages': [], 'channels': ['conda-forge']}}
+            assert info['variables'] == {}
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
+
+    def test_name_from_project_section(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[project]\nname = "from-project"\n\n[workspace]\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert info['name'] == 'from-project'
+
+    def test_workspace_name_takes_precedence(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[project]\nname = "project-name"\n\n[workspace]\nname = "workspace-name"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert info['name'] == 'workspace-name'
+
+    def test_fallback_to_directory_name(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td, '[workspace]\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n'
+            )
+            info = publication_info(td)
+            assert info['name'] == os.path.basename(td)
+
+    def test_description(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[project]\nname = "x"\ndescription = "A test project"\n\n[workspace]\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert info['description'] == 'A test project'
+
+
+class TestPublicationInfoDependencies:
+    def test_simple_deps(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[dependencies]\npython = ">=3.12"\nnumpy = "*"\n',
+            )
+            info = publication_info(td)
+            pkgs = info['env_specs']['default']['packages']
+            assert 'python>=3.12' in pkgs
+            assert 'numpy' in pkgs
+
+    def test_channels(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["defaults", "conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert info['env_specs']['default']['channels'] == ['defaults', 'conda-forge']
+
+
+class TestPublicationInfoTasks:
+    def test_string_task(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks]\nhello = "echo hi"\n',
+            )
+            info = publication_info(td)
+            assert 'hello' in info['commands']
+            assert info['commands']['hello']['unix'] == 'echo hi'
+            assert info['commands']['hello']['default'] is True
+
+    def test_dict_task(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks.serve]\ncmd = "flask run"\n',
+            )
+            info = publication_info(td)
+            assert info['commands']['serve']['unix'] == 'flask run'
+            assert info['commands']['serve']['supports_http_options'] is True
+
+    def test_first_task_is_default(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks]\nfirst = "echo 1"\nsecond = "echo 2"\n',
+            )
+            info = publication_info(td)
+            assert info['commands']['first']['default'] is True
+            assert info['commands']['second']['default'] is False
+
+    def test_notebook_inference(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks]\nnb = "voila report.ipynb"\n',
+            )
+            info = publication_info(td)
+            assert info['commands']['nb']['notebook'] == 'report.ipynb'
+            assert info['commands']['nb']['supports_http_options'] is True
+
+    def test_task_with_environment(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks.serve]\ncmd = "python app.py"\nenvironment = "prod"\n',
+            )
+            info = publication_info(td)
+            assert info['commands']['serve']['env_spec'] == 'prod'
+
+
+class TestPublicationInfoFeatures:
+    def test_feature_tasks_included(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "multi"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [tasks]
+                serve = "panel serve app.py"
+
+                [feature.ml.tasks.train]
+                cmd = "python train.py"
+
+                [feature.ml.dependencies]
+                scikit-learn = "*"
+
+                [environments]
+                default = { solve-group = "default" }
+                ml = { features = ["ml"], solve-group = "default" }
+            """))
+            info = publication_info(td)
+            assert 'serve' in info['commands']
+            assert 'train' in info['commands']
+            assert info['commands']['train']['env_spec'] == 'ml'
+            assert info['commands']['train']['unix'] == 'python train.py'
+
+    def test_global_task_not_overridden_by_feature(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [tasks]
+                run = "echo global"
+
+                [feature.alt.tasks.run]
+                cmd = "echo feature"
+            """))
+            info = publication_info(td)
+            assert info['commands']['run']['unix'] == 'echo global'
+            assert info['commands']['run']['env_spec'] == 'default'
+
+    def test_feature_env_specs(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [dependencies]
+                python = ">=3.12"
+
+                [feature.gpu.dependencies]
+                pytorch = "*"
+
+                [environments]
+                default = { solve-group = "default" }
+                gpu = { features = ["gpu"], solve-group = "default" }
+            """))
+            info = publication_info(td)
+            assert 'gpu' in info['env_specs']
+            assert 'pytorch' in info['env_specs']['gpu']['packages']
+            assert 'python>=3.12' in info['env_specs']['gpu']['packages']
+
+
+class TestPublicationInfoVariables:
+    def test_activation_env(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[activation.env]\nDATA_DIR = "./data"\nDEBUG = "1"\n',
+            )
+            info = publication_info(td)
+            assert info['variables'] == {'DATA_DIR': './data', 'DEBUG': '1'}
+
+
+class TestPublicationInfoToolAnaconda:
+    def test_tool_anaconda_overrides(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [tasks]
+                serve = "python app.py"
+
+                [tool.anaconda.commands.serve]
+                supports_http_options = true
+                description = "Run the web app"
+                default = true
+                notebook = "app.ipynb"
+            """))
+            info = publication_info(td)
+            cmd = info['commands']['serve']
+            assert cmd['supports_http_options'] is True
+            assert cmd['description'] == 'Run the web app'
+            assert cmd['notebook'] == 'app.ipynb'
+
+
+class TestPublicationInfoErrors:
+    def test_missing_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            with pytest.raises(FileNotFoundError):
+                publication_info(td)
+
+    def test_invalid_toml(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, 'pixi.toml')
+            with open(path, 'w') as f:
+                f.write('this is not valid toml [[[')
+            with pytest.raises(ValueError, match='Failed to parse'):
+                publication_info(td)
+
+    def test_empty_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '')
+            info = publication_info(td)
+            assert info['name'] == os.path.basename(td)
+            assert info['commands'] == {}
+
+
+class TestDetectProjectType:
+    def test_detects_pixi(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            assert detect_project_type(td) == PROJECT_TYPE_PIXI
+
+    def test_detects_anaconda_project(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, 'name: t\n')
+            assert detect_project_type(td) == PROJECT_TYPE_ANACONDA_PROJECT
+
+    def test_pixi_wins_when_both_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            _write_anaconda_project(td, 'name: t\n')
+            assert detect_project_type(td) == PROJECT_TYPE_PIXI
+
+    def test_neither_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            assert detect_project_type(td) is None
+
+
+class TestAnacondaProjectBranch:
+    def test_anaconda_project_publication_info(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, textwrap.dedent("""\
+                name: sample
+                description: An anaconda-project sample
+
+                commands:
+                  run:
+                    unix: python app.py
+
+                env_specs:
+                  default:
+                    channels:
+                      - defaults
+                    packages:
+                      - python=3.12
+                      - flask
+            """))
+            info = publication_info(td)
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_ANACONDA_PROJECT
+            assert info['name'] == 'sample'
+            assert info['description'] == 'An anaconda-project sample'
+            assert 'run' in info['commands']
+            assert info['commands']['run']['unix'] == 'python app.py'
+            assert 'default' in info['env_specs']
+            assert 'flask' in info['env_specs']['default']['packages']
+
+
+class TestProjectTypeKey:
+    def test_pixi_tagged(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            assert publication_info(td)[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -33,6 +33,7 @@ requirements:
     - tornado >=4.2
     - jinja2
     - tqdm
+    - tomli  # [py<311]
 
 test:
   requires:

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(name='anaconda-project',
                      "tornado>=4.2",
                      "jinja2",
                      "tqdm",
+                     "tomli; python_version < '3.11'",
                  ],
                  entry_points={"console_scripts": [
                      "anaconda-project = anaconda_project.cli:main",


### PR DESCRIPTION
## Summary

> **DNM** — Stacks on top of #424 (`export-pixi` command). Targets `feature/export-pixi` so the diff shows only the new module. Rebase onto `master` once #424 merges.
>
> **Sister PR:** [anaconda-platform#7168](https://github.com/anaconda/anaconda-platform/pull/7168) — platform-side consumer that will adopt this module after release.

Introduces `anaconda_project.project_info` — a unified publication-info reader for both `anaconda-project.yml` and `pixi.toml` projects.

### Why

Aaron's `export-pixi` (#424) teaches anaconda-project to *write* pixi.toml. This PR teaches it to *read* both formats through a single entry point. Downstream tooling — notably anaconda-platform's publishing pipeline — currently ships three identical copies of a standalone pixi.toml parser (in `editor/scripts/`, `create_project/`, and `sync/anaconda_platform/sync/git_scripts/`). Moving the parser here lets those copies go away and gives any other anaconda-project consumer the same uniform API.

Deliberately **not** wiring pixi into the `Project` class. That class is tightly coupled to the legacy yml schema; folding pixi into it would obligate us to wire up pixi support across prepare/provide/requirements/downloads/services/etc. This module is a narrow, pixi-aware metadata reader sitting alongside `Project`, not replacing it.

### API

```python
from anaconda_project.project_info import (
    publication_info,
    detect_project_type,
    PROJECT_TYPE_PIXI,
    PROJECT_TYPE_ANACONDA_PROJECT,
)

info = publication_info('/path/to/project')
info['project_type']  # "pixi" or "anaconda-project"
info['name'], info['description'], info['commands'], info['env_specs'], info['variables']
```

* `publication_info(project_dir)` — parses `pixi.toml` directly when present; otherwise delegates to `Project(project_dir).publication_info()`. Every result carries a `project_type` key so callers can branch without sniffing the filesystem.
* `detect_project_type(project_dir)` — returns `"pixi"`, `"anaconda-project"`, or `None`.

### What the pixi branch covers

| pixi.toml section | Maps to |
|---|---|
| `[workspace]` / `[project]` | `name`, `description`, `channels` |
| `[dependencies]` | `env_specs.default.packages` |
| `[tasks]` | `commands` (string or `{cmd, environment}` dict forms) |
| `[feature.X.tasks]` | `commands` scoped to feature `X` |
| `[feature.X.dependencies]` | `env_specs[env].packages` via `[environments]` composition |
| `[environments]` | additional entries in `env_specs` |
| `[activation.env]` | `variables` |
| `[tool.anaconda.commands.X]` | overrides for `description`, `default`, `notebook`, `supports_http_options` |

Notebook inference (`.ipynb` tokens in the task string) and HTTP-ness inference (`bokeh serve`, `panel serve`, `streamlit run`, `uvicorn`, `gunicorn`, `flask run`, `voila`, `python -m http.server`) are applied when the corresponding `[tool.anaconda.commands.X]` overrides aren't set.

### Dependency changes

Adds `tomli; python_version < '3.11'` to `install_requires` (and the corresponding conda recipe entry) for Python 3.10 support. Python 3.11+ uses stdlib `tomllib`.

## Test plan

* [x] 46 tests in `anaconda_project/test/test_project_info.py`, covering format detection, basic metadata, dependencies, tasks, features, environments, variables, tool.anaconda overrides, errors, and both format branches
* [x] `pytest anaconda_project/test/test_project_info.py` — 46 passed
* [ ] CI green
