### PR TITLE
feat(export-pixi): conversion conventions for env layout and prepare tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,11 @@ Thumbs.db
 # Project-specific
 anaconda-project-local.yml
 anaconda-project-prs/
+
+# Local AI tooling settings
+.claude/
+
+# Test artifacts produced by the local test runner
+cov.xml
+fake_project/
+fake_project.zip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs configuration. See:
+# https://docs.readthedocs.com/platform/stable/config-file/v2.html
+#
+# Read the Docs requires this file (in the repository root) to build
+# the docs. Sphinx config and dependencies live under docs/.
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    # miniforge3 supplies conda + the conda-forge channel by default,
+    # which matches the resolution we get locally with the env file.
+    python: "miniforge3-latest"
+
+conda:
+  environment: docs/environment.yml
+
+sphinx:
+  configuration: docs/source/conf.py

--- a/anaconda_project/archiver.py
+++ b/anaconda_project/archiver.py
@@ -20,8 +20,12 @@ import tempfile
 import uuid
 import zipfile
 from io import BytesIO
-from conda_pack._progress import progressbar
-from tqdm import tqdm
+
+# `conda_pack` and `tqdm` are deferred to the call sites below
+# (`_archive_project_dir`, `_extract_files`). Importing them eagerly
+# adds tens of milliseconds to every `import anaconda_project.project`,
+# which `publication_info` and other lightweight consumers pay for no
+# reason — neither package is touched on the read path.
 
 from anaconda_project.frontend import NullFrontend, _new_error_recorder
 from anaconda_project.internal import logged_subprocess
@@ -259,6 +263,7 @@ def _leaf_infos(infos):
 
 
 def _write_tar(archive_root_name, infos, filename, compression, packed_envs, frontend):
+    from conda_pack._progress import progressbar
     if compression is None:
         compression = ""
     else:
@@ -294,6 +299,7 @@ def _write_tar(archive_root_name, infos, filename, compression, packed_envs, fro
 
 
 def _write_zip(archive_root_name, infos, filename, packed_envs, frontend):
+    from conda_pack._progress import progressbar
     with zipfile.ZipFile(filename, 'w') as zf:
         for info in _leaf_infos(infos):
             arcname = os.path.join(archive_root_name, info.relative_path)
@@ -446,6 +452,7 @@ def _extractall_chmod(zf, destination):
 
 
 def _extract_files_zip(zip_path, src_and_dest, frontend):
+    from tqdm import tqdm
     # the zipfile API has no way to extract to a filename of
     # our choice, so we have to unpack to a temporary location,
     # then copy those files over.
@@ -472,6 +479,7 @@ def _extract_files_zip(zip_path, src_and_dest, frontend):
 
 
 def _extract_files_tar(tar_path, src_and_dest, frontend):
+    from tqdm import tqdm
     with tarfile.open(tar_path, mode='r') as tf:
         if isinstance(frontend.underlying, NullFrontend):
             src_and_dest = tqdm(src_and_dest, desc='Extract ')

--- a/anaconda_project/internal/ap_download.py
+++ b/anaconda_project/internal/ap_download.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Helper invoked by `prepare` tasks in pixi.toml files converted from
+anaconda-project.yml. Fetches one download at a time, skipping if the
+target file already exists.
+
+Usage:
+    python ap_download.py <url> <filename> [<description>]
+
+Pure stdlib: urllib + os, so it runs in any conda env that has python.
+"""
+from __future__ import absolute_import, print_function
+
+import os
+import sys
+import urllib.request
+
+
+def main(argv):
+    if len(argv) not in (2, 3):
+        print('usage: python ap_download.py <url> <filename> [<description>]',
+              file=sys.stderr)
+        return 2
+
+    url = argv[0]
+    filename = argv[1]
+    description = argv[2] if len(argv) == 3 else filename
+
+    if os.path.exists(filename):
+        print('[prepare] {}: exists at {}'.format(description, filename))
+        return 0
+
+    parent = os.path.dirname(filename)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    print('[prepare] {}: fetching {} -> {}'.format(description, url, filename))
+    urllib.request.urlretrieve(url, filename)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/anaconda_project/internal/ap_download.py
+++ b/anaconda_project/internal/ap_download.py
@@ -5,28 +5,92 @@ anaconda-project.yml. Fetches one download at a time, skipping if the
 target file already exists.
 
 Usage:
-    python ap_download.py <url> <filename> [<description>]
+    python ap_download.py <url> <filename> [<description>] \\
+        [--md5 <hex> | --sha1 <hex> | --sha224 <hex> | --sha256 <hex> | \\
+         --sha384 <hex> | --sha512 <hex>]
 
-Pure stdlib: urllib + os, so it runs in any conda env that has python.
+Pure stdlib: urllib + hashlib + os, so it runs in any conda env that
+has python.
+
+When a checksum flag is supplied, the file is verified after download
+and removed if the hash doesn't match. An already-on-disk file is also
+verified against the supplied checksum; a mismatch is treated as a
+real error rather than silently re-fetching, since the file may have
+been edited intentionally.
 """
 from __future__ import absolute_import, print_function
 
+import hashlib
 import os
 import sys
 import urllib.request
 
 
+_HASH_ALGORITHMS = ('md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512')
+
+
+def _compute_hash(filename, algorithm):
+    h = hashlib.new(algorithm)
+    with open(filename, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _parse_args(argv):
+    positional = []
+    hash_algorithm = None
+    hash_value = None
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg.startswith('--'):
+            algo = arg[2:]
+            if algo not in _HASH_ALGORITHMS:
+                print('unknown flag: {}'.format(arg), file=sys.stderr)
+                return None
+            if hash_algorithm is not None:
+                print('multiple checksum flags: {} and {}'.format(
+                    hash_algorithm, algo), file=sys.stderr)
+                return None
+            if i + 1 >= len(argv):
+                print('flag {} requires a value'.format(arg), file=sys.stderr)
+                return None
+            hash_algorithm = algo
+            hash_value = argv[i + 1].lower()
+            i += 2
+        else:
+            positional.append(arg)
+            i += 1
+
+    if len(positional) not in (2, 3):
+        return None
+    return positional, hash_algorithm, hash_value
+
+
 def main(argv):
-    if len(argv) not in (2, 3):
-        print('usage: python ap_download.py <url> <filename> [<description>]',
+    parsed = _parse_args(argv)
+    if parsed is None:
+        print('usage: python ap_download.py <url> <filename> [<description>] '
+              '[--md5|--sha1|--sha224|--sha256|--sha384|--sha512 <hex>]',
               file=sys.stderr)
         return 2
 
-    url = argv[0]
-    filename = argv[1]
-    description = argv[2] if len(argv) == 3 else filename
+    positional, hash_algorithm, hash_value = parsed
+    url = positional[0]
+    filename = positional[1]
+    description = positional[2] if len(positional) == 3 else filename
 
     if os.path.exists(filename):
+        if hash_algorithm is not None:
+            actual = _compute_hash(filename, hash_algorithm)
+            if actual != hash_value:
+                print('[prepare] {}: existing file at {} has wrong {} '
+                      '(expected {}, got {})'.format(
+                          description, filename, hash_algorithm,
+                          hash_value, actual),
+                      file=sys.stderr)
+                return 1
         print('[prepare] {}: exists at {}'.format(description, filename))
         return 0
 
@@ -36,6 +100,16 @@ def main(argv):
 
     print('[prepare] {}: fetching {} -> {}'.format(description, url, filename))
     urllib.request.urlretrieve(url, filename)
+
+    if hash_algorithm is not None:
+        actual = _compute_hash(filename, hash_algorithm)
+        if actual != hash_value:
+            os.remove(filename)
+            print('[prepare] {}: {} mismatch (expected {}, got {}); '
+                  'removed {}'.format(description, hash_algorithm,
+                                      hash_value, actual, filename),
+                  file=sys.stderr)
+            return 1
     return 0
 
 

--- a/anaconda_project/internal/cli/info.py
+++ b/anaconda_project/internal/cli/info.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2026, Anaconda, Inc. All rights reserved.
+#
+# Licensed under the terms of the BSD 3-Clause License.
+# The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+"""`anaconda-project info` — human-readable summary of publication_info."""
+from __future__ import absolute_import, print_function
+
+import json
+import sys
+
+from anaconda_project.project_info import (
+    PROJECT_TYPE_PIXI,
+    PROJECT_TYPE_KEY,
+    publication_info,
+)
+
+
+def _format_section(title):
+    return '{}\n{}'.format(title, '-' * 12)
+
+
+def _format_label_value(label, value, width=18):
+    return '{:>{w}}: {}'.format(label, value, w=width)
+
+
+def _format_label_continuation(value, width=18):
+    return '{:>{w}}: {}'.format('', value, w=width)
+
+
+def _format_list(label, items, width=18):
+    """Format a label with a list of values, one per line, joined by ', '
+    on overflow. Mirrors `pixi info`'s layout for `Dependencies:`."""
+    if not items:
+        return _format_label_value(label, '', width=width)
+    return _format_label_value(label, ', '.join(items), width=width)
+
+
+def _print_text(info, project_dir):
+    """Render info as text, modeled on `pixi info`."""
+    project_type = info.get(PROJECT_TYPE_KEY, '<unknown>')
+    print(_format_section('Project'))
+    print(_format_label_value('Type', project_type))
+    print(_format_label_value('Name', info.get('name', '')))
+    if info.get('description'):
+        print(_format_label_value('Description', info['description']))
+    print(_format_label_value('Directory', project_dir))
+    print()
+
+    commands = info.get('commands') or {}
+    if commands:
+        print(_format_section('Commands'))
+        for name, cmd in commands.items():
+            tags = []
+            if cmd.get('default'):
+                tags.append('default')
+            if cmd.get('notebook'):
+                tags.append('notebook')
+            elif cmd.get('bokeh_app'):
+                tags.append('bokeh_app')
+            if cmd.get('supports_http_options'):
+                tags.append('http')
+            header = name
+            if tags:
+                header = '{}  [{}]'.format(name, ', '.join(tags))
+            print(_format_label_value('Command', header))
+            if cmd.get('env_spec'):
+                print(_format_label_continuation('env_spec: {}'.format(cmd['env_spec'])))
+            run_line = cmd.get('unix') or cmd.get('windows') or cmd.get('notebook') or cmd.get('bokeh_app') or ''
+            if run_line:
+                print(_format_label_continuation('cmd: {}'.format(run_line)))
+            if cmd.get('args'):
+                print(_format_label_continuation('args: {}'.format(', '.join(cmd['args']))))
+            if cmd.get('description') and cmd['description'] != run_line:
+                print(_format_label_continuation('desc: {}'.format(cmd['description'])))
+            print()
+
+    env_specs = info.get('env_specs') or {}
+    if env_specs:
+        print(_format_section('Environments'))
+        for name, env in env_specs.items():
+            print(_format_label_value('Environment', name))
+            channels = env.get('channels') or []
+            print(_format_list('Channels', channels))
+            packages = env.get('packages') or []
+            print(_format_label_value('Dependency count', len(packages)))
+            if packages:
+                print(_format_list('Dependencies', packages))
+            platforms = env.get('platforms')
+            if platforms:
+                print(_format_list('Target platforms', platforms))
+            print(_format_label_value('Locked', 'yes' if env.get('locked') else 'no'))
+            if 'path' in env:
+                print(_format_label_value('Prefix location', env['path']))
+            print()
+
+    variables = info.get('variables') or {}
+    if variables:
+        print(_format_section('Variables'))
+        for name, value in variables.items():
+            if isinstance(value, dict):
+                # anaconda-project shape: {title, description, encrypted, default}
+                rendered = value.get('default', '')
+            else:
+                rendered = value
+            print(_format_label_value(name, rendered))
+        print()
+
+
+def info_main(project_dir, as_json, env_paths, project_type):
+    """Show a human-readable view of `publication_info(project_dir)`.
+
+    With ``as_json``, emit the indented JSON instead.
+    """
+    try:
+        info = publication_info(
+            project_dir,
+            project_type=project_type,
+            env_paths=env_paths,
+        )
+    except (FileNotFoundError, ValueError, RuntimeError) as e:
+        print('{}'.format(e), file=sys.stderr)
+        return 1
+
+    if as_json:
+        # Match `pixi info --json`: indented, sorted-keys-off so order
+        # reflects insertion order (env_specs in declared order, etc).
+        print(json.dumps(info, indent=2, default=str))
+        return 0
+
+    _print_text(info, project_dir)
+    return 0
+
+
+def main(args):
+    """Argparse entry point for `anaconda-project info`."""
+    return info_main(
+        project_dir=args.directory,
+        as_json=args.json,
+        env_paths=args.env_paths,
+        project_type=args.project_type,
+    )

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -414,6 +414,14 @@ def _parse_args_and_run_subcommand(argv):
                               "'default' on export. Collapses [feature.{name}.*] blocks "
                               "into top-level [dependencies] / [tasks.X] for a cleaner "
                               "pixi.toml."))
+    preset.add_argument('--add-current-platform',
+                        action='store_true',
+                        default=False,
+                        help=("If the host's conda subdir (e.g. osx-arm64) isn't already in "
+                              "the project's platforms list, add it on export. Pixi rejects "
+                              "envs that don't list the host platform; anaconda-project is "
+                              "more forgiving, so this prevents a pixi install error after "
+                              "conversion."))
     preset.set_defaults(main=pixi_commands.main_export_pixi)
 
     preset = subparsers.add_parser(

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -406,6 +406,14 @@ def _parse_args_and_run_subcommand(argv):
     preset = subparsers.add_parser('export-pixi', help="Export the project as a pixi.toml file")
     add_directory_arg(preset)
     preset.add_argument('filename', metavar='PIXI_TOML_FILE', nargs='?', default='pixi.toml')
+    preset.add_argument('--use-default',
+                        action='store_true',
+                        default=False,
+                        help=("If the project has no env_spec named 'default', rename the "
+                              "default-command's env_spec (or the first one declared) to "
+                              "'default' on export. Collapses [feature.{name}.*] blocks "
+                              "into top-level [dependencies] / [tasks.X] for a cleaner "
+                              "pixi.toml."))
     preset.set_defaults(main=pixi_commands.main_export_pixi)
 
     preset = subparsers.add_parser(

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -39,6 +39,7 @@ import anaconda_project.internal.cli.service_commands as service_commands
 import anaconda_project.internal.cli.environment_commands as environment_commands
 import anaconda_project.internal.cli.command_commands as command_commands
 import anaconda_project.internal.cli.pixi_commands as pixi_commands
+import anaconda_project.internal.cli.info as info_cli
 
 
 def _parse_args_and_run_subcommand(argv):
@@ -406,6 +407,30 @@ def _parse_args_and_run_subcommand(argv):
     add_directory_arg(preset)
     preset.add_argument('filename', metavar='PIXI_TOML_FILE', nargs='?', default='pixi.toml')
     preset.set_defaults(main=pixi_commands.main_export_pixi)
+
+    preset = subparsers.add_parser(
+        'info',
+        help=("Show a summary of the project: name, environments, commands, "
+              "variables. Reads pixi.toml when present (and an "
+              "anaconda-project.yml otherwise) and can also surface env "
+              "prefix locations."))
+    add_directory_arg(preset)
+    preset.add_argument('--json',
+                        action='store_true',
+                        default=False,
+                        help="Emit the publication_info dict as indented JSON instead of formatted text")
+    preset.add_argument('--env-paths',
+                        action='store_true',
+                        default=False,
+                        help=("Include filesystem prefix paths for each environment. "
+                              "For pixi projects this shells out to `pixi info --json` "
+                              "and stashes its full output under `_pixi` in --json mode."))
+    preset.add_argument('--project-type',
+                        choices=('pixi', 'anaconda-project'),
+                        default=None,
+                        help=("Force a manifest format. The default behavior reads "
+                              "pixi.toml if present, otherwise anaconda-project.yml."))
+    preset.set_defaults(main=info_cli.main)
 
     # argparse doesn't do this for us for whatever reason
     if len(argv) < 2:

--- a/anaconda_project/internal/cli/pixi_commands.py
+++ b/anaconda_project/internal/cli/pixi_commands.py
@@ -13,7 +13,7 @@ from anaconda_project.internal.cli import console_utils
 from anaconda_project import project_ops
 
 
-def export_pixi(project_dir, filename):
+def export_pixi(project_dir, filename, use_default=False):
     """Export the project as a pixi.toml file."""
     import os
     project = load_project(project_dir)
@@ -22,9 +22,27 @@ def export_pixi(project_dir, filename):
     # Default to writing pixi.toml in the project directory
     if filename == 'pixi.toml' and not os.path.isabs(filename):
         filename = os.path.join(project_dir, filename)
-    status = project_ops.export_pixi(project, filename=filename)
+    from anaconda_project.internal.pixi_export import _pick_use_default_env
+    promoted = _pick_use_default_env(project)
+    status = project_ops.export_pixi(project, filename=filename, use_default=use_default)
     if status:
         print(status.status_description)
+        # When the project has no env_spec literally named `default`, the
+        # exporter wraps every dep/task/prepare in [feature.{name}.*]
+        # blocks. Renaming the project's "primary" env (the default
+        # command's, or the first declared env_spec) to `default` collapses
+        # those into top-level pixi sections — much cleaner. Tell the user
+        # what we did when the flag is on; recommend it when it's off.
+        if promoted is not None:
+            if use_default:
+                print(
+                    'The "{}" environment has been renamed "default" in the '
+                    'exported Pixi specification.'.format(promoted))
+            else:
+                print(
+                    'Recommendation: re-run using the --use-default flag to '
+                    'rename the "{}" environment to "default". This will '
+                    'simplify the resulting Pixi specification.'.format(promoted))
         return 0
     else:
         console_utils.print_status_errors(status)
@@ -33,4 +51,4 @@ def export_pixi(project_dir, filename):
 
 def main_export_pixi(args):
     """Start the export-pixi command and return exit status code."""
-    return export_pixi(args.directory, args.filename)
+    return export_pixi(args.directory, args.filename, use_default=args.use_default)

--- a/anaconda_project/internal/cli/pixi_commands.py
+++ b/anaconda_project/internal/cli/pixi_commands.py
@@ -13,7 +13,7 @@ from anaconda_project.internal.cli import console_utils
 from anaconda_project import project_ops
 
 
-def export_pixi(project_dir, filename, use_default=False):
+def export_pixi(project_dir, filename, use_default=False, add_current_platform=False):
     """Export the project as a pixi.toml file."""
     import os
     project = load_project(project_dir)
@@ -22,25 +22,43 @@ def export_pixi(project_dir, filename, use_default=False):
     # Default to writing pixi.toml in the project directory
     if filename == 'pixi.toml' and not os.path.isabs(filename):
         filename = os.path.join(project_dir, filename)
-    status = project_ops.export_pixi(project, filename=filename, use_default=use_default)
+    status = project_ops.export_pixi(project, filename=filename,
+                                     use_default=use_default,
+                                     add_current_platform=add_current_platform)
     if status:
         print(status.status_description)
-        # When --use-default actually promoted an env, the status carries
-        # the original name in default_rename_from; surface it so the user
-        # can see what we did. When the user didn't pass the flag but the
-        # project would benefit, recommend it.
+        # When the corresponding flag actually changed something, the
+        # status carries the value (rename source / added platform);
+        # surface it so the user can see what we did. When the user
+        # didn't pass the flag but the project would benefit, recommend
+        # the flag instead.
+        from anaconda_project.internal.pixi_export import (
+            current_platform_addition_target, default_rename_target,
+        )
         if use_default and status.default_rename_from:
             print(
                 'The "{}" environment has been renamed "default" in the '
                 'exported Pixi specification.'.format(status.default_rename_from))
         elif not use_default:
-            from anaconda_project.internal.pixi_export import default_rename_target
             promoted = default_rename_target(project)
             if promoted is not None:
                 print(
                     'Recommendation: re-run using the --use-default flag to '
                     'rename the "{}" environment to "default". This will '
                     'simplify the resulting Pixi specification.'.format(promoted))
+        if add_current_platform and status.current_platform_added:
+            print(
+                'The current platform "{}" has been added to the platforms '
+                'list in the exported Pixi specification.'
+                .format(status.current_platform_added))
+        elif not add_current_platform:
+            missing = current_platform_addition_target(project)
+            if missing is not None:
+                print(
+                    'Recommendation: re-run using the --add-current-platform '
+                    'flag to add "{}" to the platforms list. Pixi requires '
+                    'the host platform to be declared before it will install '
+                    'the environment.'.format(missing))
         return 0
     else:
         console_utils.print_status_errors(status)
@@ -49,4 +67,6 @@ def export_pixi(project_dir, filename, use_default=False):
 
 def main_export_pixi(args):
     """Start the export-pixi command and return exit status code."""
-    return export_pixi(args.directory, args.filename, use_default=args.use_default)
+    return export_pixi(args.directory, args.filename,
+                       use_default=args.use_default,
+                       add_current_platform=args.add_current_platform)

--- a/anaconda_project/internal/cli/pixi_commands.py
+++ b/anaconda_project/internal/cli/pixi_commands.py
@@ -22,23 +22,21 @@ def export_pixi(project_dir, filename, use_default=False):
     # Default to writing pixi.toml in the project directory
     if filename == 'pixi.toml' and not os.path.isabs(filename):
         filename = os.path.join(project_dir, filename)
-    from anaconda_project.internal.pixi_export import _pick_use_default_env
-    promoted = _pick_use_default_env(project)
     status = project_ops.export_pixi(project, filename=filename, use_default=use_default)
     if status:
         print(status.status_description)
-        # When the project has no env_spec literally named `default`, the
-        # exporter wraps every dep/task/prepare in [feature.{name}.*]
-        # blocks. Renaming the project's "primary" env (the default
-        # command's, or the first declared env_spec) to `default` collapses
-        # those into top-level pixi sections — much cleaner. Tell the user
-        # what we did when the flag is on; recommend it when it's off.
-        if promoted is not None:
-            if use_default:
-                print(
-                    'The "{}" environment has been renamed "default" in the '
-                    'exported Pixi specification.'.format(promoted))
-            else:
+        # When --use-default actually promoted an env, the status carries
+        # the original name in default_rename_from; surface it so the user
+        # can see what we did. When the user didn't pass the flag but the
+        # project would benefit, recommend it.
+        if use_default and status.default_rename_from:
+            print(
+                'The "{}" environment has been renamed "default" in the '
+                'exported Pixi specification.'.format(status.default_rename_from))
+        elif not use_default:
+            from anaconda_project.internal.pixi_export import default_rename_target
+            promoted = default_rename_target(project)
+            if promoted is not None:
                 print(
                     'Recommendation: re-run using the --use-default flag to '
                     'rename the "{}" environment to "default". This will '

--- a/anaconda_project/internal/cli/test/test_info.py
+++ b/anaconda_project/internal/cli/test/test_info.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2026, Anaconda, Inc. All rights reserved.
+#
+# Licensed under the terms of the BSD 3-Clause License.
+# The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Tests for `anaconda-project info`."""
+from __future__ import absolute_import, print_function
+
+import json
+import os
+import tempfile
+import textwrap
+
+from anaconda_project.internal.cli.main import _parse_args_and_run_subcommand
+
+
+def _write_pixi_toml(d, content):
+    path = os.path.join(d, 'pixi.toml')
+    with open(path, 'w') as f:
+        f.write(content)
+
+
+def _write_anaconda_project(d, content):
+    path = os.path.join(d, 'anaconda-project.yml')
+    with open(path, 'w') as f:
+        f.write(content)
+
+
+_PIXI_TOML = textwrap.dedent("""\
+    [workspace]
+    name = "demo"
+    description = "A demo project"
+    channels = ["conda-forge"]
+    platforms = ["linux-64", "osx-arm64"]
+
+    [dependencies]
+    python = ">=3.12"
+    flask = "*"
+
+    [tasks]
+    serve = "flask run"
+""")
+
+
+class TestInfoText:
+    def test_pixi_text_output(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, _PIXI_TOML)
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td])
+            assert code == 0
+            out, err = capsys.readouterr()
+            assert err == ''
+            # Section headers and a few key fields are present.
+            assert 'Project' in out
+            assert 'Type: pixi' in out
+            assert 'Name: demo' in out
+            assert 'Description: A demo project' in out
+            assert 'Commands' in out
+            assert 'Command: serve' in out
+            assert 'Environments' in out
+            assert 'Environment: default' in out
+            assert 'flask' in out
+            # No JSON braces leak through.
+            assert '{' not in out
+
+    def test_anaconda_project_text_output(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, textwrap.dedent("""\
+                name: yml-project
+                description: An anaconda-project sample
+                env_specs:
+                  default:
+                    channels: [defaults]
+                    packages: [python=3.12, requests]
+            """))
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td])
+            assert code == 0
+            out, _ = capsys.readouterr()
+            assert 'Type: anaconda-project' in out
+            assert 'Name: yml-project' in out
+            assert 'requests' in out
+
+    def test_missing_manifest_returns_1(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td])
+            assert code == 1
+            _, err = capsys.readouterr()
+            assert 'pixi.toml' in err or 'anaconda-project.yml' in err
+
+
+class TestInfoJson:
+    def test_pixi_json_output(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, _PIXI_TOML)
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td, '--json'])
+            assert code == 0
+            out, _ = capsys.readouterr()
+            data = json.loads(out)
+            assert data['name'] == 'demo'
+            assert data['project_type'] == 'pixi'
+            assert 'serve' in data['commands']
+            assert '_pixi' not in data  # only with --env-paths
+
+    def test_json_is_indented(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, _PIXI_TOML)
+            _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td, '--json'])
+            out, _ = capsys.readouterr()
+            # Indented output has at least one '\n  ' (two-space indent).
+            assert '\n  ' in out
+
+
+class TestInfoProjectType:
+    def test_force_anaconda_project_when_both_present(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "from-pixi"\n')
+            _write_anaconda_project(td, 'name: from-yml\n')
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td,
+                 '--project-type', 'anaconda-project', '--json'])
+            assert code == 0
+            data = json.loads(capsys.readouterr().out)
+            assert data['project_type'] == 'anaconda-project'
+            assert data['name'] == 'from-yml'
+
+    def test_force_pixi_without_pixi_toml(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, 'name: t\n')
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td,
+                 '--project-type', 'pixi'])
+            assert code == 1
+            _, err = capsys.readouterr()
+            assert 'pixi.toml' in err
+
+
+class TestInfoEnvPaths:
+    def test_anaconda_project_env_paths_text(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, textwrap.dedent("""\
+                name: t
+                env_specs:
+                  default:
+                    channels: [defaults]
+                    packages: [python=3.12]
+            """))
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td, '--env-paths'])
+            assert code == 0
+            out, _ = capsys.readouterr()
+            assert 'Prefix location' in out
+
+    def test_pixi_env_paths_includes_pixi_field(self, capsys, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, _PIXI_TOML)
+            fake_json = json.dumps({
+                'platform': 'osx-arm64',
+                'environments_info': [
+                    {'name': 'default', 'prefix': os.path.join(td, '.pixi/envs/default')},
+                ],
+            }).encode('utf-8')
+            import subprocess
+            monkeypatch.setattr(subprocess, 'check_output',
+                                lambda cmd, stderr=None: fake_json)
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td,
+                 '--env-paths', '--json'])
+            assert code == 0
+            data = json.loads(capsys.readouterr().out)
+            assert data['env_specs']['default']['path'].endswith('.pixi/envs/default')
+            assert data['_pixi']['platform'] == 'osx-arm64'
+
+    def test_pixi_env_paths_subprocess_failure_returns_1(self, capsys, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, _PIXI_TOML)
+            import subprocess
+
+            def boom(cmd, stderr=None):
+                raise subprocess.CalledProcessError(1, cmd, stderr=b'pixi: bad manifest')
+
+            monkeypatch.setattr(subprocess, 'check_output', boom)
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td, '--env-paths'])
+            assert code == 1
+            _, err = capsys.readouterr()
+            assert 'pixi info' in err

--- a/anaconda_project/internal/cli/test/test_main.py
+++ b/anaconda_project/internal/cli/test/test_main.py
@@ -23,7 +23,7 @@ all_subcommands = ('init', 'run', 'prepare', 'clean', 'activate', 'archive', 'un
                    'list-services', 'add-env-spec', 'remove-env-spec', 'list-env-specs', 'export-env-spec', 'lock',
                    'unlock', 'update', 'add-packages', 'remove-packages', 'list-packages', 'add-platforms',
                    'remove-platforms', 'list-platforms', 'add-command', 'remove-command', 'list-default-command',
-                   'list-commands', 'export-pixi')
+                   'list-commands', 'export-pixi', 'info')
 all_subcommands_in_curlies = "{" + ",".join(all_subcommands) + "}"
 all_subcommands_comma_space = ", ".join(["'" + s + "'" for s in all_subcommands])
 
@@ -134,6 +134,10 @@ expected_usage_msg_format = (  # noqa
     '                        List only the default command on the project\n'
     '    list-commands       List the commands on the project\n'
     '    export-pixi         Export the project as a pixi.toml file\n'
+    '    info                Show a summary of the project: name, environments,\n'
+    '                        commands, variables. Reads pixi.toml when present (and\n'
+    '                        an anaconda-project.yml otherwise) and can also\n'
+    '                        surface env prefix locations.\n'
     '\n'
     'optional arguments:\n'
     '  -h, --help            show this help message and exit\n'

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -14,6 +14,7 @@ import os
 import platform
 import re
 import shutil
+import struct
 import sys
 import tempfile
 import yaml
@@ -584,9 +585,11 @@ def environ_set_prefix(environ, prefix, varname=conda_prefix_variable()):
         environ['CONDA_DEFAULT_ENV'] = name
 
 
-# This isn't all (e.g. leaves out arm, power).  it's sort of "all
-# that people typically publish for"
-default_platforms = ('linux-64', 'osx-64', 'win-64')
+# Platforms a project is assumed to target by default if the manifest
+# doesn't list any. Covers the four subdirs that account for the
+# overwhelming majority of conda traffic in 2026 (x86_64 Linux/Windows,
+# aarch64 Linux, Apple Silicon macOS).
+default_platforms = ('linux-64', 'linux-aarch64', 'osx-arm64', 'win-64')
 assert tuple(sorted(default_platforms)) == default_platforms
 
 # osx-32 isn't in here since it isn't much used
@@ -599,8 +602,9 @@ _non_x86_osx_machines = {'arm64'}
 # this list will get outdated, unfortunately.
 _known_platforms = tuple(
     sorted(
-        list(default_platforms_plus_32_bit) + ['osx-32'] + [("linux-%s" % m) for m in _non_x86_linux_machines] +
-        [("osx-%s" % m) for m in _non_x86_osx_machines]))
+        set(list(default_platforms_plus_32_bit) + list(default_platforms) + ['osx-32'] +
+            [("linux-%s" % m) for m in _non_x86_linux_machines] +
+            [("osx-%s" % m) for m in _non_x86_osx_machines])))
 
 known_platform_names = ('linux', 'osx', 'win')
 assert tuple(sorted(known_platform_names)) == known_platform_names
@@ -642,16 +646,47 @@ _known_platform_groups_keys = ('all', 'unix') + known_platform_names
 assert set(_known_platform_groups_keys) == set(_known_platform_groups.keys())
 
 
+# Mirrors conda.base.context._platform_map / non_x86_machines so we can
+# compute the current subdir without spawning `conda info`. The original
+# implementation invoked the conda subprocess at module-import time,
+# which made `import anaconda_project` ~1s slower than necessary for
+# every consumer (publication_info, project_info, CLI tools).
+_PLATFORM_MAP = {
+    'linux': 'linux',
+    'linux2': 'linux',
+    'darwin': 'osx',
+    'win32': 'win',
+    'zos': 'zos',
+}
+_NON_X86_MACHINES = frozenset({
+    'armv6l', 'armv7l', 'aarch64', 'arm64', 'ppc64', 'ppc64le', 'riscv64', 's390x',
+})
+
+
 def current_platform():
-    conda_info = info()
-    return conda_info.get('platform')
+    """Return the conda subdir for the current interpreter (e.g. ``'osx-arm64'``).
 
-
-_default_platforms_with_current = tuple(sorted(list(set(default_platforms + (current_platform(), )))))
+    Honors ``CONDA_SUBDIR`` if set, matching conda's own precedence.
+    Otherwise derives the value from :data:`sys.platform`,
+    :func:`platform.machine`, and the pointer size — a reimplementation
+    of conda's :py:meth:`Context._native_subdir` so we don't have to
+    shell out to ``conda info``.
+    """
+    override = os.environ.get('CONDA_SUBDIR')
+    if override:
+        return override
+    plat = _PLATFORM_MAP.get(sys.platform, 'unknown')
+    if plat == 'zos':
+        return 'zos-z'
+    machine = platform.machine().lower()
+    if machine in _NON_X86_MACHINES:
+        return '{}-{}'.format(plat, machine)
+    bits = 8 * struct.calcsize('P')
+    return '{}-{}'.format(plat, bits)
 
 
 def default_platforms_with_current():
-    return _default_platforms_with_current
+    return tuple(sorted(set(default_platforms + (current_platform(), ))))
 
 
 def parse_platform(platform):

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -438,6 +438,7 @@ _HTTP_GENERIC = (
     ('host',         'pos', '--anaconda-project-host {{ host }}'),
     ('port',         'pos', '--anaconda-project-port {{ port }}'),
     ('address',      'pos', '--anaconda-project-address {{ address }}'),
+    ('url_prefix',   'pos', '--anaconda-project-url-prefix {{ url_prefix }}'),
     ('iframe_hosts', 'pos', '--anaconda-project-iframe-hosts {{ iframe_hosts }}'),
     ('no_browser',   'pos', '--anaconda-project-no-browser'),
     ('use_xheaders', 'pos', '--anaconda-project-use-xheaders'),
@@ -447,6 +448,8 @@ _HTTP_BOKEH = (
     ('host',         'pos', '--host {{ host }}'),
     ('port',         'pos', '--port {{ port }}'),
     ('address',      'pos', '--address {{ address }}'),
+    # bokeh renames --anaconda-project-url-prefix to --prefix.
+    ('url_prefix',   'pos', '--prefix {{ url_prefix }}'),
     # iframe_hosts: bokeh has no equivalent; the original transformer
     # drops it silently, so we omit it from the args declaration too.
     # `--show` is bokeh's "open browser" flag — the inverse of
@@ -468,6 +471,11 @@ _HTTP_NOTEBOOK = (
     # host: jupyter has no host-restrict equivalent; original drops it.
     ('port',         'pos', '--port {{ port }}'),
     ('address',      'pos', '--ip {{ address }}'),
+    # url_prefix renames to --NotebookApp.base_url. The original
+    # transformer comments that the two-arg (space-separated) form is
+    # rejected here — only the `--key=value` form works — so we render
+    # it that way.
+    ('url_prefix',   'pos', '--NotebookApp.base_url={{ url_prefix }}'),
     ('iframe_hosts', 'pos', _NOTEBOOK_IFRAME_BODY),
     ('no_browser',   'pos', '--no-browser'),
     ('use_xheaders', 'pos', '--NotebookApp.trust_xheaders=True'),

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -10,11 +10,82 @@ from __future__ import absolute_import, print_function
 
 import os
 import re
+import shutil
+import subprocess
 
 from anaconda_project.requirements_registry.requirement import EnvVarRequirement
 from anaconda_project.requirements_registry.requirements.conda_env import CondaEnvRequirement
 from anaconda_project.requirements_registry.requirements.download import DownloadRequirement
 from anaconda_project.requirements_registry.requirements.service import ServiceRequirement
+
+
+class CondaNotAvailableError(Exception):
+    """Raised when the exporter needs `conda` for channel resolution but
+    can't find or invoke it. Wraps the underlying reason so the CLI can
+    surface a useful failure status."""
+
+
+def _resolve_default_channels():
+    """Return the list of URLs that `defaults` expands to, taken from the
+    user's local ``conda config --show default_channels``.
+
+    Pixi has no notion of a `defaults` meta-channel, so we have to rewrite
+    every occurrence to the URLs it would resolve to under conda. We avoid
+    `--json` because conda renders URL fields as nested urlparse dicts in
+    that mode; the plain YAML-ish output is easier to parse and is what
+    `conda config --show` emits by default.
+    """
+    if not shutil.which('conda'):
+        raise CondaNotAvailableError(
+            "`conda` not found on PATH; required to expand the `defaults` "
+            "channel into concrete URLs.")
+    try:
+        proc = subprocess.run(
+            ['conda', 'config', '--show', 'default_channels'],
+            check=True, capture_output=True, text=True)
+    except (OSError, subprocess.CalledProcessError) as e:
+        raise CondaNotAvailableError(
+            "Failed to invoke `conda config --show default_channels`: {}".format(e))
+
+    urls = []
+    in_block = False
+    for line in proc.stdout.splitlines():
+        if line.startswith('default_channels:'):
+            in_block = True
+            continue
+        if in_block:
+            stripped = line.strip()
+            if stripped.startswith('- '):
+                urls.append(stripped[2:].strip())
+            elif stripped == '':
+                continue
+            else:
+                # A non-list, non-blank line means we've fallen out of
+                # the default_channels block (a sibling key, etc.).
+                break
+    if not urls:
+        raise CondaNotAvailableError(
+            "`conda config --show default_channels` returned no entries.")
+    return urls
+
+
+def _expand_defaults_in_channels(channels, default_channels):
+    """Replace every `defaults` entry in ``channels`` with ``default_channels``.
+
+    Order is preserved; duplicates are removed (first wins).
+    """
+    out = []
+    seen = set()
+    for ch in channels:
+        if ch == 'defaults':
+            for d in default_channels:
+                if d not in seen:
+                    seen.add(d)
+                    out.append(d)
+        elif ch not in seen:
+            seen.add(ch)
+            out.append(ch)
+    return out
 
 
 def _sanitize_env_name(name):
@@ -402,7 +473,14 @@ def export_pixi_toml(project):
     lines = []
 
     # -- [workspace] metadata, channels, and platforms
-    # Collect channels from all env specs (union, preserving order)
+    # Collect channels from all env specs (union, preserving order). Pixi
+    # has no `defaults` meta-channel and no notion of channel aliases that
+    # match conda's, so we expand any `defaults` reference into the URLs
+    # that conda would resolve it to. When the project declares no
+    # channels at all, we fall back to those same default URLs rather
+    # than hard-coding conda-forge — that preserves whatever the user's
+    # conda environment treats as default (which may be an enterprise
+    # mirror configured via .condarc).
     all_channels = []
     seen_channels = set()
     for env in project.env_specs.values():
@@ -410,6 +488,13 @@ def export_pixi_toml(project):
             if ch not in seen_channels:
                 all_channels.append(ch)
                 seen_channels.add(ch)
+
+    needs_defaults = (not all_channels) or ('defaults' in all_channels)
+    default_channels = _resolve_default_channels() if needs_defaults else None
+    if not all_channels:
+        all_channels = list(default_channels)
+    elif 'defaults' in all_channels:
+        all_channels = _expand_defaults_in_channels(all_channels, default_channels)
 
     # Collect platforms (union)
     all_platforms = set()
@@ -431,10 +516,7 @@ def export_pixi_toml(project):
     lines.append('name = {}'.format(_toml_string(project.name)))
     if project.description:
         lines.append('description = {}'.format(_toml_string(project.description)))
-    if all_channels:
-        lines.append('channels = {}'.format(_toml_inline_array(all_channels)))
-    else:
-        lines.append('channels = ["conda-forge"]')
+    lines.append('channels = {}'.format(_toml_inline_array(all_channels)))
     lines.append('platforms = {}'.format(_toml_inline_array(sorted(all_platforms))))
     lines.append('')
 

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -111,6 +111,31 @@ def _toml_multiline_string(value):
     return '"""\n{}\n"""'.format(escaped)
 
 
+def _toml_wrapped_string(parts, separator=' '):
+    """Format a long single-line string as a TOML triple-quoted block where
+    every line is joined with ``separator`` at parse time.
+
+    Uses TOML's ``\\`` line-continuation: a backslash at the end of a line
+    inside a multi-line basic string strips the line terminator and any
+    leading whitespace on the next line. We separate the chunks with
+    ``\\<newline><spaces><continuation>`` so a TOML parser reconstructs
+    the original ``separator``-joined string while a human sees one chunk
+    per line in the source.
+    """
+    if not parts:
+        return _toml_string('')
+    # Each chunk is escaped just like _toml_string would, but we keep
+    # newlines intact (they're explicit \\<newline>s in our output, not
+    # data). Triple-quoted strings interpret backslash escapes the same
+    # way basic strings do.
+    escaped_parts = [
+        p.replace('\\', '\\\\').replace('"""', '\\"\\"\\"')
+        for p in parts
+    ]
+    body = '{sep}\\\n'.format(sep=separator).join(escaped_parts)
+    return '"""\\\n{body}\\\n"""'.format(body=body)
+
+
 def _toml_inline_array(items):
     return '[{}]'.format(', '.join(_toml_string(i) for i in items))
 
@@ -396,6 +421,151 @@ def _build_prepare_command(downloads):
     return '\n'.join(lines)
 
 
+# Per-mode HTTP option tables. Each entry is (jinja_var, gate, body):
+#   * jinja_var: variable name declared in pixi `args` and referenced by
+#     {% if %} gates and {{ }} substitutions in the body.
+#   * gate: 'pos' renders body when the var is truthy ({% if var %}),
+#     'neg' renders body when the var is falsy ({% if not var %}). The
+#     latter is for bokeh's --show flag, which is the *inverse* of the
+#     anaconda-project --no-browser semantics.
+#   * body: the rendered chunk; may contain {{ var }} for value
+#     substitution. Templated and gated by _wrap_gate at emit time.
+#
+# Each table is curated to match the per-tool transforms in
+# anaconda_project/project_commands.py (_BokehArgsTransformer and
+# _NotebookArgsTransformer); see HTTP_SPECS there for the source list.
+_HTTP_GENERIC = (
+    ('host',         'pos', '--anaconda-project-host {{ host }}'),
+    ('port',         'pos', '--anaconda-project-port {{ port }}'),
+    ('address',      'pos', '--anaconda-project-address {{ address }}'),
+    ('iframe_hosts', 'pos', '--anaconda-project-iframe-hosts {{ iframe_hosts }}'),
+    ('no_browser',   'pos', '--anaconda-project-no-browser'),
+    ('use_xheaders', 'pos', '--anaconda-project-use-xheaders'),
+)
+
+_HTTP_BOKEH = (
+    ('host',         'pos', '--host {{ host }}'),
+    ('port',         'pos', '--port {{ port }}'),
+    ('address',      'pos', '--address {{ address }}'),
+    # iframe_hosts: bokeh has no equivalent; the original transformer
+    # drops it silently, so we omit it from the args declaration too.
+    # `--show` is bokeh's "open browser" flag — the inverse of
+    # anaconda-project's --no-browser, hence the negative gate.
+    ('no_browser',   'neg', '--show'),
+    ('use_xheaders', 'pos', '--use-xheaders'),
+)
+
+# Notebook iframe_hosts requires a Python dict literal embedded as a
+# tornado_settings value carrying a Content-Security-Policy header. The
+# original transformer prepends 'self' to the host list; we mirror that.
+_NOTEBOOK_IFRAME_BODY = (
+    "--NotebookApp.tornado_settings="
+    "{ 'headers': { 'Content-Security-Policy': "
+    "\"frame-ancestors 'self' {{ iframe_hosts }}\" } }"
+)
+
+_HTTP_NOTEBOOK = (
+    # host: jupyter has no host-restrict equivalent; original drops it.
+    ('port',         'pos', '--port {{ port }}'),
+    ('address',      'pos', '--ip {{ address }}'),
+    ('iframe_hosts', 'pos', _NOTEBOOK_IFRAME_BODY),
+    ('no_browser',   'pos', '--no-browser'),
+    ('use_xheaders', 'pos', '--NotebookApp.trust_xheaders=True'),
+)
+
+
+def _wrap_gate(gate, var, body):
+    """Wrap a chunk body in the appropriate Jinja conditional."""
+    if gate == 'pos':
+        return '{{% if {var} %}}{body}{{% endif %}}'.format(var=var, body=body)
+    if gate == 'neg':
+        return '{{% if not {var} %}}{body}{{% endif %}}'.format(var=var, body=body)
+    return body
+
+
+def _notebook_default_url_chunk(notebook_path):
+    """Build the unconditional --NotebookApp.default_url=... prefix that
+    anaconda-project's _NotebookArgsTransformer prepends to every jupyter
+    invocation. URL-quoted basename, matching the original behavior."""
+    from urllib.parse import quote
+    basename = os.path.basename(notebook_path)
+    return '--NotebookApp.default_url=/notebooks/{}'.format(quote(basename))
+
+# Match `{{ name }}` / `{{name}}` Jinja variable references. Used when
+# supports_http_options is false to discover which HTTP vars the user's
+# templated unix line actually consumes; we only declare pixi args for
+# those, not the full set.
+_JINJA_VAR_RE = re.compile(r'\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}')
+
+
+def _http_args_for_command(command):
+    """Return the list of jinja var names to emit as pixi ``args``,
+    plus a list of cmd chunks to append.
+
+    Three dispatch paths, mirroring anaconda-project's per-tool
+    transformers in ``project_commands.py``:
+
+    * ``command.notebook is not None`` → the command was a converted
+      ``notebook:`` shorthand (now ``jupyter notebook <file>``). Use
+      the Jupyter-specific flag mapping (``--ip`` for address,
+      ``--NotebookApp.*`` for prefix/iframe/xheaders, drop host).
+    * ``command.bokeh_app is not None`` → converted ``bokeh_app:``
+      shorthand (now ``bokeh serve <app>``). Use bokeh's bare flags
+      (``--host``, ``--port``, ``--address``, ``--show`` as the
+      *inverse* of ``--no-browser``, ``--use-xheaders``).
+    * Otherwise (``supports_http_options: true`` on a plain
+      ``unix:`` command) → pass ``--anaconda-project-X`` through
+      verbatim so the underlying tool can pick up what it understands.
+
+    For ``supports_http_options: false``, scan the user's templated
+    unix line for HTTP Jinja vars and declare pixi args only for those;
+    the cmd template is left unchanged.
+    """
+    if command.supports_http_options:
+        if command.notebook is not None:
+            table = _HTTP_NOTEBOOK
+            preamble = [_notebook_default_url_chunk(command.notebook)]
+        elif command.bokeh_app is not None:
+            table = _HTTP_BOKEH
+            preamble = []
+        else:
+            table = _HTTP_GENERIC
+            preamble = []
+
+        chunks = list(preamble)
+        for var, gate, body in table:
+            chunks.append(_wrap_gate(gate, var, body))
+        args = [var for var, _, _ in table]
+        return args, chunks
+
+    # supports_http_options is false — only declare pixi args for vars
+    # the templated unix line actually references.
+    cmd = command.unix_shell_commandline or ''
+    # The full superset of HTTP-related Jinja var names a user might
+    # reference. Drawn from every per-tool table.
+    all_http_vars = {var for var, _, _ in _HTTP_GENERIC}
+    referenced = []
+    seen = set()
+    for match in _JINJA_VAR_RE.finditer(cmd):
+        name = match.group(1)
+        if name in seen or name not in all_http_vars:
+            continue
+        seen.add(name)
+        referenced.append(name)
+    return referenced, []
+
+
+def _format_args_block(args):
+    """Render a pixi ``args = [...]`` line. Defaults are always empty —
+    the cmd template uses ``{% if var %}`` gating, so an empty value means
+    the flag is omitted at run time. ``pixi run task value-for-port`` (or
+    similar positional override) sets the var."""
+    if not args:
+        return None
+    parts = ['{{ arg = "{}", default = "" }}'.format(var) for var in args]
+    return 'args = [{}]'.format(', '.join(parts))
+
+
 def _command_to_task(command, declared_vars):
     """Convert a ProjectCommand to a pixi task string or None.
 
@@ -406,10 +576,11 @@ def _command_to_task(command, declared_vars):
     keep the unix form (the deno_task_shell-native one) and surface the
     divergence in a comment so a maintainer can review.
 
-    Returns ``(task_cmd_string, raw_cmd_string, comments)``. ``raw_cmd_string``
-    is the pre-translation form, useful for comparing against
-    ``command.description`` (which anaconda-project synthesizes from the raw
-    command when the user hasn't supplied one).
+    Returns ``(task_cmd_string, raw_cmd_string, comments, args_line)``.
+    ``raw_cmd_string`` is the pre-translation form, useful for comparing
+    against ``command.description``. ``args_line`` is the formatted
+    pixi ``args = [...]`` declaration (or None if the command needs no
+    pixi args).
     """
     comments = []
     # raw_forms holds every string that anaconda-project might use as the
@@ -434,10 +605,26 @@ def _command_to_task(command, declared_vars):
         raw_forms.append(raw_cmd)
         comments.append('translated from windows-only command')
     else:
-        return None, None, comments
+        return None, None, comments, None
 
     translated, unresolved = _translate_command_env_vars(raw_cmd, declared_vars)
     translated = _strip_conda_prefix_paths(translated)
+
+    # Compose http-options support: append --anaconda-project-* flags
+    # (gated by Jinja conditionals) when supports_http_options is true,
+    # or just declare pixi args for whatever {{vars}} the user already
+    # referenced when it's false. Append-chunks render as a wrapped
+    # multi-line TOML string so the file stays readable, but parse to a
+    # single shell command at run time.
+    http_arg_vars, http_chunks = _http_args_for_command(command)
+    if http_chunks:
+        cmd_rendered = _toml_wrapped_string([translated, *http_chunks])
+        # For windows-divergence comparison and any other plain-text use,
+        # keep `translated` as the already-joined single-line form.
+        translated = ' '.join([translated, *http_chunks])
+    else:
+        cmd_rendered = _toml_string(translated)
+    args_line = _format_args_block(http_arg_vars)
 
     # If both forms exist, check that the windows line doesn't say something
     # the unix line doesn't — pixi can't run two variants of the same task,
@@ -458,7 +645,7 @@ def _command_to_task(command, declared_vars):
         comments.append(
             'unresolved env var(s): {} — set them via [activation.env] or '
             'before running pixi'.format(', '.join(unresolved)))
-    return translated, raw_forms, comments
+    return cmd_rendered, raw_forms, comments, args_line
 
 
 def export_pixi_toml(project):
@@ -697,26 +884,30 @@ def export_pixi_toml(project):
             else:
                 global_tasks.append((cmd_name, command))
 
-        if global_tasks:
-            lines.append('[tasks]')
-            for cmd_name, command in global_tasks:
-                task_cmd, raw_forms, comments = _command_to_task(command, declared_vars)
-                if task_cmd is None:
-                    lines.append('# {} — could not convert (no unix command)'.format(cmd_name))
-                    continue
-                desc = command.description
-                has_desc = desc and desc != cmd_name and desc not in (raw_forms or [])
-                for comment in comments:
-                    lines.append('# {}'.format(comment))
-                if has_desc:
-                    lines.append('{} = {{ cmd = {}, description = {} }}'.format(
-                        cmd_name, _toml_string(task_cmd), _toml_string(desc)))
-                else:
-                    lines.append('{} = {}'.format(cmd_name, _toml_string(task_cmd)))
+        for cmd_name, command in global_tasks:
+            task_cmd, raw_forms, comments, args_line = _command_to_task(
+                command, declared_vars)
+            if task_cmd is None:
+                lines.append('# {} — could not convert (no unix command)'.format(cmd_name))
+                continue
+            desc = command.description
+            has_desc = desc and desc != cmd_name and desc not in (raw_forms or [])
+            for comment in comments:
+                lines.append('# {}'.format(comment))
+            # Always use the explicit [tasks.X] form. The shorthand
+            # `name = "cmd"` doesn't allow args, and consistency reads
+            # better than mixing two forms.
+            lines.append('[tasks.{}]'.format(cmd_name))
+            lines.append('cmd = {}'.format(task_cmd))
+            if has_desc:
+                lines.append('description = {}'.format(_toml_string(desc)))
+            if args_line:
+                lines.append(args_line)
             lines.append('')
 
         for cmd_name, command in feature_tasks:
-            task_cmd, raw_forms, comments = _command_to_task(command, declared_vars)
+            task_cmd, raw_forms, comments, args_line = _command_to_task(
+                command, declared_vars)
             if task_cmd is None:
                 lines.append('# {} — could not convert (no unix command)'.format(cmd_name))
                 continue
@@ -726,9 +917,11 @@ def export_pixi_toml(project):
             has_desc = desc and desc != cmd_name and desc not in (raw_forms or [])
             section = 'feature.{}.tasks.{}'.format(pixi_env_name, cmd_name)
             lines.append('[{}]'.format(section))
-            lines.append('cmd = {}'.format(_toml_string(task_cmd)))
+            lines.append('cmd = {}'.format(task_cmd))
             if has_desc:
                 lines.append('description = {}'.format(_toml_string(desc)))
+            if args_line:
+                lines.append(args_line)
             for comment in comments:
                 lines.append('# {}'.format(comment))
             lines.append('')

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -354,6 +354,12 @@ def _windows_to_deno_shell(command_str):
     return ''.join(out)
 
 
+# Body for the no-op prepare task. Doubles as the
+# converted-from-anaconda-project marker (downstream tooling looks for
+# the `prepare` task name to detect a converted project) and gives the
+# task something visible to print when there are no downloads to fetch.
+_PREPARE_MARKER_ECHO = 'echo "Running migrated anaconda-project prepare task..."'
+
 # Helper script written next to pixi.toml during conversion; see
 # anaconda_project/internal/ap_download.py for the source. Prepare tasks
 # invoke it via `python ap_download.py <url> <filename> [<description>]`
@@ -933,12 +939,18 @@ def export_pixi_toml(project):
             lines.append('')
 
     # -- `prepare` task
-    # Mirror anaconda-project's prepare semantics for the default env:
-    # fetch any declared downloads. Emit only when there's real work to
-    # do — downstream tooling that runs `pixi run prepare` after install
-    # checks for the task's existence and skips when absent. A no-op
-    # marker would force every consumer to detect-and-skip when running
-    # against non-converted projects, which is more code for no benefit.
+    # Always emit a `prepare` task on a converted project. Two reasons:
+    #   1. Mirror anaconda-project's `prepare` semantics for the default
+    #      env: fetch any declared downloads.
+    #   2. When the default env_spec has a non-default name (e.g.
+    #      `sampleproj`), pixi has no native way to bind a default
+    #      task to that env. Scoping `prepare` to the env's feature
+    #      forces `pixi run prepare` to resolve to that env, which
+    #      makes it a useful "select the right env" entry point even
+    #      when there are no downloads to fetch.
+    # The task name itself doubles as a marker — downstream tooling can
+    # detect "this pixi.toml was converted from anaconda-project.yml"
+    # by looking for the `prepare` task.
     if 'default' in env_specs:
         default_source = 'default'
     elif project.default_env_spec_name in env_specs:
@@ -951,17 +963,23 @@ def export_pixi_toml(project):
     if default_source in downloads_per_env:
         prepare_body = _toml_multiline_string(
             _build_prepare_command(downloads_per_env[default_source]))
-        # Multi-env: scope to the default env's feature so
-        # `pixi run prepare` auto-resolves to that env. When the default
-        # is the literal `default`, fold to the global default feature —
-        # pixi's implicit default env picks it up.
-        if has_multiple_envs and default_source != 'default':
-            pixi_env_name = _sanitize_env_name(default_source)
-            lines.append('[feature.{}.tasks.prepare]'.format(pixi_env_name))
-        else:
-            lines.append('[tasks.prepare]')
-        lines.append('cmd = {}'.format(prepare_body))
-        lines.append('')
+    else:
+        # No downloads — the task is a no-op echo. Acts as the
+        # converted-project marker and (when scoped to a feature) as
+        # the env-selection entry point.
+        prepare_body = _toml_string(_PREPARE_MARKER_ECHO)
+
+    # Multi-env: scope to the default env's feature so `pixi run prepare`
+    # auto-resolves to that env. When the default is the literal
+    # `default`, fold to the global default feature — pixi's implicit
+    # default env picks it up.
+    if has_multiple_envs and default_source and default_source != 'default':
+        pixi_env_name = _sanitize_env_name(default_source)
+        lines.append('[feature.{}.tasks.prepare]'.format(pixi_env_name))
+    else:
+        lines.append('[tasks.prepare]')
+    lines.append('cmd = {}'.format(prepare_body))
+    lines.append('')
 
     # -- Services as comments
     services = {}

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -28,6 +28,18 @@ def _toml_string(value):
     return '"{}"'.format(escaped)
 
 
+def _toml_multiline_string(value):
+    """Format a multi-line shell command as a TOML triple-quoted string.
+
+    The leading newline after ``\"\"\"`` is stripped by TOML, so we add one
+    so the body starts on its own line for readability. Triple-quoted
+    strings still process backslash escapes; we only need to escape any
+    literal triple-quote sequence in the body.
+    """
+    escaped = value.replace('\\', '\\\\').replace('"""', '\\"\\"\\"')
+    return '"""\n{}\n"""'.format(escaped)
+
+
 def _toml_inline_array(items):
     return '[{}]'.format(', '.join(_toml_string(i) for i in items))
 
@@ -246,6 +258,73 @@ def _windows_to_deno_shell(command_str):
     return ''.join(out)
 
 
+_PREPARE_MARKER_ECHO = 'echo "Running migrated anaconda-project prepare task..."'
+
+# Helper script written next to pixi.toml during conversion; see
+# anaconda_project/internal/ap_download.py for the source. Prepare tasks
+# invoke it via `python ap_download.py <url> <filename> [<description>]`
+# rather than inlining the urllib calls — keeps the TOML readable, and the
+# script can grow over time without bloating the manifest.
+DOWNLOAD_HELPER_FILENAME = 'ap_download.py'
+
+
+def _has_python(specs):
+    """Return True if any spec in ``specs`` declares the ``python`` package.
+
+    Specs may be channel-prefixed (``conda-forge::python``) or version-
+    constrained (``python=3.11``, ``python>=3.10``) — strip the metadata
+    before comparing.
+    """
+    for spec in specs:
+        name, _ = _conda_spec_to_pixi(spec)
+        if name == 'python':
+            return True
+    return False
+
+
+def _shell_quote(value):
+    """Quote a string for safe inclusion in a deno_task_shell argv.
+
+    Wrap with double quotes and escape only the characters that have
+    special meaning inside a double-quoted token: ``"``, ``\\``, ``$``,
+    and backtick. Anything else (including spaces, single quotes, and
+    glob characters) survives unchanged.
+    """
+    escaped = (value
+               .replace('\\', '\\\\')
+               .replace('"', '\\"')
+               .replace('$', '\\$')
+               .replace('`', '\\`'))
+    return '"{}"'.format(escaped)
+
+
+def _build_prepare_command(downloads):
+    """Build a multi-line shell command that runs the download helper script
+    once per anaconda-project download entry.
+
+    The helper (``ap_download.py``) is written alongside the pixi.toml at
+    conversion time; we just emit ``python ap_download.py <args>`` for each
+    download. The marker echo is omitted here because the helper's own
+    ``[prepare] ...`` log lines are more informative — and because pixi
+    bundles the marker echo and the first python invocation onto a single
+    banner line, smashing them visually. Detection of "is this a converted
+    anaconda-project?" still works via the task name `prepare`.
+    """
+    lines = []
+    for description, url, filename in downloads:
+        # `python3` (not `python`) so the helper resolves to system python
+        # when the env doesn't declare its own. anaconda-project's yml may
+        # not include python in every env_spec, and ap_download.py is pure
+        # stdlib, so we don't need a project-specific interpreter.
+        lines.append('python3 {script} {url} {path} {desc}'.format(
+            script=DOWNLOAD_HELPER_FILENAME,
+            url=_shell_quote(url),
+            path=_shell_quote(filename),
+            desc=_shell_quote(description),
+        ))
+    return '\n'.join(lines)
+
+
 def _command_to_task(command, declared_vars):
     """Convert a ProjectCommand to a pixi task string or None.
 
@@ -339,6 +418,15 @@ def export_pixi_toml(project):
     if not all_platforms:
         all_platforms = {'linux-64'}
 
+    # -- Determine if we need features (multiple env specs)
+    env_specs = project.env_specs
+    has_multiple_envs = len(env_specs) > 1 or (len(env_specs) == 1 and 'default' not in env_specs)
+
+    # Placeholder for a warning prefix; populated below once we know
+    # whether any download-needing env lacks python. We insert it at the
+    # top of the file so it's the first thing a maintainer sees.
+    warning_prefix_index = len(lines)
+
     lines.append('[workspace]')
     lines.append('name = {}'.format(_toml_string(project.name)))
     if project.description:
@@ -350,16 +438,12 @@ def export_pixi_toml(project):
     lines.append('platforms = {}'.format(_toml_inline_array(sorted(all_platforms))))
     lines.append('')
 
-    # -- Determine if we need features (multiple env specs)
-    env_specs = project.env_specs
-    has_multiple_envs = len(env_specs) > 1 or (len(env_specs) == 1 and 'default' not in env_specs)
-
     # -- Collect global (inherited by all) packages
-    # The anonymous base spec's packages are the global ones.
-    # In the project model, these are the top-level packages/channels.
-    # env_spec.conda_packages includes inherited, so we find the common set.
+    # Find packages common to every env_spec — these go in the top-level
+    # [dependencies] (i.e. pixi's default feature) and every named env
+    # inherits them. Anything env-specific lands in [feature.X.dependencies]
+    # below.
     if has_multiple_envs:
-        # Find packages common to all env specs (the global/inherited ones)
         all_conda = None
         all_pip = None
         for env in env_specs.values():
@@ -371,17 +455,67 @@ def export_pixi_toml(project):
             else:
                 all_conda &= conda_set
                 all_pip &= pip_set
-
         global_conda = sorted(all_conda) if all_conda else []
         global_pip = sorted(all_pip) if all_pip else []
     elif env_specs:
-        # Single env — everything is global
         env = list(env_specs.values())[0]
         global_conda = list(env.conda_packages)
         global_pip = list(env.pip_packages)
     else:
         global_conda = []
         global_pip = []
+
+    # If the user has an env_spec literally named `default`, fold its
+    # packages into the global set — they belong to pixi's default feature,
+    # not a separate `[feature.default.dependencies]` block (which would
+    # be unreachable since we don't redeclare the default env below).
+    if has_multiple_envs and 'default' in env_specs:
+        default_env = env_specs['default']
+        for spec in default_env.conda_packages:
+            if spec not in global_conda:
+                global_conda.append(spec)
+        for spec in default_env.pip_packages:
+            if spec not in global_pip:
+                global_pip.append(spec)
+
+    # Compute downloads per env now so we can both emit prepare task
+    # bodies below and warn the caller about envs that lack python.
+    downloads_per_env = {}
+    for env_name in env_specs:
+        env_downloads = []
+        for req in project.requirements(env_name):
+            if isinstance(req, DownloadRequirement):
+                # Prefer the user-supplied description from the yml; fall
+                # back to the env_var name when the user didn't write one.
+                description = req.options.get('description') or req.env_var
+                env_downloads.append((description, req.url, req.filename))
+        if env_downloads:
+            downloads_per_env[env_name] = env_downloads
+
+    # Identify envs that need ap_download.py but don't declare python.
+    # The helper is pure stdlib so it'll work with system `python3`, but
+    # the user should know they're depending on something outside the
+    # env. Insert a warning comment at the top of the file (above
+    # [workspace]) so it's the first thing a maintainer sees.
+    envs_relying_on_system_python = []
+    if downloads_per_env and not _has_python(global_conda):
+        for env_name in downloads_per_env:
+            env = env_specs[env_name]
+            if not _has_python(env.conda_packages):
+                envs_relying_on_system_python.append(env_name)
+
+    if envs_relying_on_system_python:
+        warning = [
+            '# WARNING: prepare task uses system python3 to run ap_download.py.',
+            '# The following env(s) declare downloads but no python package:',
+        ]
+        for env_name in envs_relying_on_system_python:
+            warning.append('#   {}'.format(env_name))
+        warning.append(
+            '# Add `python` to the env_spec(s) above if you want a sandboxed '
+            'interpreter.')
+        warning.append('')
+        lines[warning_prefix_index:warning_prefix_index] = warning
 
     # Write global dependencies
     _write_dependencies(lines, global_conda, global_pip)
@@ -407,8 +541,10 @@ def export_pixi_toml(project):
         global_conda_set = set(global_conda)
         global_pip_set = set(global_pip)
 
-        for env_name, env in sorted(env_specs.items()):
-            if env_name == 'default' and not (set(env.conda_packages) - global_conda_set):
+        for env_name, env in env_specs.items():
+            # `default` is folded into the global default feature above —
+            # nothing to emit as a separate [feature.default.X] block.
+            if env_name == 'default':
                 continue
 
             extra_conda = [p for p in env.conda_packages if p not in global_conda_set]
@@ -434,13 +570,25 @@ def export_pixi_toml(project):
                     lines.append('')
 
         # -- [environments] section
+        # Emit envs in the order they appear in anaconda-project.yml so
+        # downstream tooling can identify the project's intended default
+        # env_spec by reading the first entry. Common packages live in
+        # top-level [dependencies] (the default feature) and every named
+        # env inherits them.
+        #
+        # If the user happened to name one of their env_specs `default`,
+        # we comment its slot rather than declare it — pixi already
+        # materializes a `default` environment from the default feature,
+        # and re-declaring it would either no-op or fight that machinery.
+        # The comment preserves position so callers reading the first
+        # uncommented entry still get the user's first non-default env.
         lines.append('[environments]')
-        for env_name in sorted(env_specs):
+        for env_name in env_specs:
             if env_name == 'default':
-                lines.append('default = { solve-group = "default" }')
+                lines.append('# default  (pixi creates this implicitly from the default feature)')
             else:
                 pixi_env_name = _sanitize_env_name(env_name)
-                lines.append('{name} = {{ features = ["{name}"], solve-group = "default" }}'.format(name=pixi_env_name))
+                lines.append('{name} = {{ features = ["{name}"] }}'.format(name=pixi_env_name))
         lines.append('')
 
     # -- Collect every env var the project declares, so command-string
@@ -503,19 +651,43 @@ def export_pixi_toml(project):
                 lines.append('# {}'.format(comment))
             lines.append('')
 
-    # -- Downloads as comments (no pixi equivalent)
-    downloads = {}
-    for env_name in env_specs:
-        for req in project.requirements(env_name):
-            if isinstance(req, DownloadRequirement):
-                downloads[req.env_var] = req.url
+    # -- `prepare` task
+    # Mirror anaconda-project's prepare semantics for the default env:
+    # fetch any declared downloads. Emit exactly one `prepare` task,
+    # scoped to the default env_spec's feature when there is one (so it
+    # only resolves under that env), or at the top level when the manifest
+    # has no [environments] table.
+    #
+    # The presence of `prepare` is itself the canonical signal that this
+    # pixi.toml was converted from anaconda-project.yml. Other env_specs
+    # don't get a prepare task — keeps the manifest small and avoids
+    # pixi's env-selection prompt entirely.
+    if 'default' in env_specs:
+        default_source = 'default'
+    elif project.default_env_spec_name in env_specs:
+        default_source = project.default_env_spec_name
+    elif env_specs:
+        default_source = next(iter(env_specs))
+    else:
+        default_source = None
 
-    if downloads:
-        lines.append('# Downloads from anaconda-project.yml (no pixi equivalent).')
-        lines.append('# Consider adding setup tasks to fetch these:')
-        for var_name, url in sorted(downloads.items()):
-            lines.append('#   {} = {}'.format(var_name, url))
-        lines.append('')
+    if default_source in downloads_per_env:
+        prepare_body = _toml_multiline_string(
+            _build_prepare_command(downloads_per_env[default_source]))
+    else:
+        prepare_body = _toml_string(_PREPARE_MARKER_ECHO)
+
+    # Multi-env: scope to the default env's feature so `pixi run prepare`
+    # auto-resolves to that env. (When the default is the literal
+    # `default`, fold to the global default feature — pixi's implicit
+    # default env picks it up.)
+    if has_multiple_envs and default_source and default_source != 'default':
+        pixi_env_name = _sanitize_env_name(default_source)
+        lines.append('[feature.{}.tasks.prepare]'.format(pixi_env_name))
+    else:
+        lines.append('[tasks.prepare]')
+    lines.append('cmd = {}'.format(prepare_body))
+    lines.append('')
 
     # -- Services as comments
     services = {}

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -354,8 +354,6 @@ def _windows_to_deno_shell(command_str):
     return ''.join(out)
 
 
-_PREPARE_MARKER_ECHO = 'echo "Running migrated anaconda-project prepare task..."'
-
 # Helper script written next to pixi.toml during conversion; see
 # anaconda_project/internal/ap_download.py for the source. Prepare tasks
 # invoke it via `python ap_download.py <url> <filename> [<description>]`
@@ -936,15 +934,11 @@ def export_pixi_toml(project):
 
     # -- `prepare` task
     # Mirror anaconda-project's prepare semantics for the default env:
-    # fetch any declared downloads. Emit exactly one `prepare` task,
-    # scoped to the default env_spec's feature when there is one (so it
-    # only resolves under that env), or at the top level when the manifest
-    # has no [environments] table.
-    #
-    # The presence of `prepare` is itself the canonical signal that this
-    # pixi.toml was converted from anaconda-project.yml. Other env_specs
-    # don't get a prepare task — keeps the manifest small and avoids
-    # pixi's env-selection prompt entirely.
+    # fetch any declared downloads. Emit only when there's real work to
+    # do — downstream tooling that runs `pixi run prepare` after install
+    # checks for the task's existence and skips when absent. A no-op
+    # marker would force every consumer to detect-and-skip when running
+    # against non-converted projects, which is more code for no benefit.
     if 'default' in env_specs:
         default_source = 'default'
     elif project.default_env_spec_name in env_specs:
@@ -957,20 +951,17 @@ def export_pixi_toml(project):
     if default_source in downloads_per_env:
         prepare_body = _toml_multiline_string(
             _build_prepare_command(downloads_per_env[default_source]))
-    else:
-        prepare_body = _toml_string(_PREPARE_MARKER_ECHO)
-
-    # Multi-env: scope to the default env's feature so `pixi run prepare`
-    # auto-resolves to that env. (When the default is the literal
-    # `default`, fold to the global default feature — pixi's implicit
-    # default env picks it up.)
-    if has_multiple_envs and default_source and default_source != 'default':
-        pixi_env_name = _sanitize_env_name(default_source)
-        lines.append('[feature.{}.tasks.prepare]'.format(pixi_env_name))
-    else:
-        lines.append('[tasks.prepare]')
-    lines.append('cmd = {}'.format(prepare_body))
-    lines.append('')
+        # Multi-env: scope to the default env's feature so
+        # `pixi run prepare` auto-resolves to that env. When the default
+        # is the literal `default`, fold to the global default feature —
+        # pixi's implicit default env picks it up.
+        if has_multiple_envs and default_source != 'default':
+            pixi_env_name = _sanitize_env_name(default_source)
+            lines.append('[feature.{}.tasks.prepare]'.format(pixi_env_name))
+        else:
+            lines.append('[tasks.prepare]')
+        lines.append('cmd = {}'.format(prepare_body))
+        lines.append('')
 
     # -- Services as comments
     services = {}

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -29,24 +29,32 @@ class CondaNotAvailableError(Exception):
 class PixiExportStatus(SimpleStatus):
     """Status returned by :func:`anaconda_project.project_ops.export_pixi`.
 
-    Adds ``default_rename_from`` so callers can tell the user *which* env
-    was just promoted to ``default`` without re-querying the project. The
-    attribute is ``None`` when:
+    Carries fields downstream consumers (launchers, IDE plugins) use to
+    surface what the export actually changed without re-querying the
+    project:
 
-    * ``use_default`` was not requested,
-    * the project already had an env_spec literally named ``default``, or
-    * the export failed.
-
-    Stable for downstream consumers (launchers, IDE plugins) that need to
-    surface "Renamed env X → default" in their success notification.
+    * ``default_rename_from`` — the env_spec name promoted to ``default``
+      by ``use_default``, or ``None`` when ``use_default`` was off, was
+      a no-op (project already had a ``default`` env_spec), or the
+      export failed.
+    * ``current_platform_added`` — the platform string (e.g.
+      ``'osx-arm64'``) that was added to the platform list by
+      ``add_current_platform``, or ``None`` when the flag was off, the
+      platform was already declared, or the export failed.
     """
-    def __init__(self, success, description, errors=(), default_rename_from=None):
+    def __init__(self, success, description, errors=(),
+                 default_rename_from=None, current_platform_added=None):
         super().__init__(success, description, errors)
         self._default_rename_from = default_rename_from
+        self._current_platform_added = current_platform_added
 
     @property
     def default_rename_from(self):
         return self._default_rename_from
+
+    @property
+    def current_platform_added(self):
+        return self._current_platform_added
 
 
 def _resolve_default_channels():
@@ -735,7 +743,26 @@ def project_would_benefit_from_use_default(project):
     return default_rename_target(project) is not None
 
 
-def export_pixi_toml(project, use_default=False):
+def current_platform_addition_target(project):
+    """Return the current conda subdir (e.g. ``'osx-arm64'``) if exporting
+    with ``add_current_platform=True`` would actually add it to the
+    project's platform union, or ``None`` when it's already present.
+
+    Pixi rejects an env that doesn't list the host platform; anaconda-
+    project is more forgiving. This picker is the public contract for
+    deciding whether the platform list needs widening — frontends use it
+    to recommend ``--add-current-platform`` before the user hits a pixi
+    error at install time.
+    """
+    from anaconda_project.internal.conda_api import current_platform
+    declared = set()
+    for env in project.env_specs.values():
+        declared.update(env.platforms)
+    here = current_platform()
+    return None if here in declared else here
+
+
+def export_pixi_toml(project, use_default=False, add_current_platform=False):
     """Convert an anaconda-project Project to pixi.toml content.
 
     Args:
@@ -747,6 +774,12 @@ def export_pixi_toml(project, use_default=False):
             implicit default environment with packages, commands, and
             the prepare task at the top level instead of inside a
             ``[feature.{name}.*]`` block.
+        add_current_platform: if True, ensure the host's conda subdir
+            (e.g. ``'osx-arm64'``) appears in the emitted ``platforms``
+            list. anaconda-project is forgiving about platform mismatch
+            but pixi refuses to install an env whose declared platforms
+            don't include the host, so adding the current platform on
+            export prevents that foot-gun.
 
     Returns:
         A string containing the pixi.toml file content.
@@ -783,6 +816,14 @@ def export_pixi_toml(project, use_default=False):
         all_platforms.update(env.platforms)
     if not all_platforms:
         all_platforms = {'linux-64'}
+    # add_current_platform widens the platform list to cover the host
+    # subdir if it isn't already present. Pixi refuses to install an env
+    # whose declared platforms don't include the host; anaconda-project
+    # is more forgiving, so it's common to find a ported project with a
+    # platforms list that worked under conda but not under pixi.
+    if add_current_platform:
+        from anaconda_project.internal.conda_api import current_platform
+        all_platforms.add(current_platform())
 
     # -- Determine if we need features (multiple env specs)
     # When the user passes use_default and there's no env_spec already

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -1099,7 +1099,8 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False):
             lines.append('')
 
     # -- `prepare` task
-    # Always emit a `prepare` task on a converted project. Two reasons:
+    # By default, always emit a `prepare` task on a converted project.
+    # Two reasons:
     #   1. Mirror anaconda-project's `prepare` semantics for the default
     #      env: fetch any declared downloads.
     #   2. When the default env_spec has a non-default name (e.g.
@@ -1111,6 +1112,12 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False):
     # The task name itself doubles as a marker — downstream tooling can
     # detect "this pixi.toml was converted from anaconda-project.yml"
     # by looking for the `prepare` task.
+    #
+    # Exception: under `use_default`, reason 2 evaporates (the renamed
+    # env *is* the default, so top-level tasks already resolve to it),
+    # and the marker isn't load-bearing enough to justify a no-op echo.
+    # In that mode we only emit prepare when there's actual work
+    # (downloads) to do.
     if 'default' in env_specs:
         default_source = 'default'
     elif _xlate(project.default_env_spec_name) in env_specs:
@@ -1120,26 +1127,31 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False):
     else:
         default_source = None
 
-    if default_source in downloads_per_env:
+    has_downloads = default_source in downloads_per_env
+    if has_downloads:
         prepare_body = _toml_multiline_string(
             _build_prepare_command(downloads_per_env[default_source]))
+    elif promoted_env is not None:
+        # `use_default` mode + no downloads → skip the prepare task.
+        prepare_body = None
     else:
         # No downloads — the task is a no-op echo. Acts as the
         # converted-project marker and (when scoped to a feature) as
         # the env-selection entry point.
         prepare_body = _toml_string(_PREPARE_MARKER_ECHO)
 
-    # Multi-env: scope to the default env's feature so `pixi run prepare`
-    # auto-resolves to that env. When the default is the literal
-    # `default`, fold to the global default feature — pixi's implicit
-    # default env picks it up.
-    if has_multiple_envs and default_source and default_source != 'default':
-        pixi_env_name = _sanitize_env_name(default_source)
-        lines.append('[feature.{}.tasks.prepare]'.format(pixi_env_name))
-    else:
-        lines.append('[tasks.prepare]')
-    lines.append('cmd = {}'.format(prepare_body))
-    lines.append('')
+    if prepare_body is not None:
+        # Multi-env: scope to the default env's feature so `pixi run prepare`
+        # auto-resolves to that env. When the default is the literal
+        # `default`, fold to the global default feature — pixi's implicit
+        # default env picks it up.
+        if has_multiple_envs and default_source and default_source != 'default':
+            pixi_env_name = _sanitize_env_name(default_source)
+            lines.append('[feature.{}.tasks.prepare]'.format(pixi_env_name))
+        else:
+            lines.append('[tasks.prepare]')
+        lines.append('cmd = {}'.format(prepare_body))
+        lines.append('')
 
     # -- Services as comments
     services = {}

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -441,19 +441,30 @@ def _build_prepare_command(downloads):
     bundles the marker echo and the first python invocation onto a single
     banner line, smashing them visually. Detection of "is this a converted
     anaconda-project?" still works via the task name `prepare`.
+
+    Each download entry is ``(description, url, filename, hash_algorithm,
+    hash_value)``; the trailing two are ``None`` when the user didn't
+    supply a checksum. When present, they're passed as ``--<algo> <hex>``
+    flags so the helper verifies the file post-download.
     """
     lines = []
-    for description, url, filename in downloads:
+    for description, url, filename, hash_algorithm, hash_value in downloads:
         # `python3` (not `python`) so the helper resolves to system python
         # when the env doesn't declare its own. anaconda-project's yml may
         # not include python in every env_spec, and ap_download.py is pure
         # stdlib, so we don't need a project-specific interpreter.
-        lines.append('python3 {script} {url} {path} {desc}'.format(
+        cmd = 'python3 {script} {url} {path} {desc}'.format(
             script=DOWNLOAD_HELPER_FILENAME,
             url=_shell_quote(url),
             path=_shell_quote(filename),
             desc=_shell_quote(description),
-        ))
+        )
+        if hash_algorithm is not None and hash_value is not None:
+            cmd += ' --{algo} {value}'.format(
+                algo=hash_algorithm,
+                value=_shell_quote(hash_value),
+            )
+        lines.append(cmd)
     return '\n'.join(lines)
 
 
@@ -917,7 +928,8 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False):
                 # Prefer the user-supplied description from the yml; fall
                 # back to the env_var name when the user didn't write one.
                 description = req.options.get('description') or req.env_var
-                env_downloads.append((description, req.url, req.filename))
+                env_downloads.append((description, req.url, req.filename,
+                                      req.hash_algorithm, req.hash_value))
         if env_downloads:
             downloads_per_env[env_name] = env_downloads
 

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -605,10 +605,8 @@ def _command_to_task(command, declared_vars):
         raw_forms.append(raw_cmd)
     elif command.notebook is not None:
         raw_cmd = 'jupyter notebook {}'.format(command.notebook)
-        comments.append('converted from notebook command')
     elif command.bokeh_app is not None:
         raw_cmd = 'bokeh serve {}'.format(command.bokeh_app)
-        comments.append('converted from bokeh_app command')
     elif command.windows_cmd_commandline:
         # No unix variant — normalize the windows form so it runs under
         # deno_task_shell on every platform pixi targets.
@@ -660,11 +658,46 @@ def _command_to_task(command, declared_vars):
     return cmd_rendered, raw_forms, comments, args_line
 
 
-def export_pixi_toml(project):
+def _pick_use_default_env(project):
+    """Return the env_spec name that ``--use-default`` would promote to
+    pixi's implicit ``default`` environment, or None if it would no-op.
+
+    We promote the env_spec attached to the project's default command (the
+    one a bare ``anaconda-project run`` would invoke); if there are no
+    commands or the command's env_spec is missing, we fall back to the
+    first env_spec declared. We never promote when an env_spec literally
+    named ``default`` already exists — there's nothing to rename.
+    """
+    env_specs = project.env_specs
+    if not env_specs or 'default' in env_specs:
+        return None
+    candidate = None
+    if project.default_command is not None:
+        candidate = project.default_command.default_env_spec_name
+    if candidate is None or candidate not in env_specs:
+        candidate = next(iter(env_specs))
+    return candidate
+
+
+def project_would_benefit_from_use_default(project):
+    """True if exporting with ``use_default=True`` would actually rename
+    something. False when the project already has a ``default`` env_spec
+    (or has no env_specs at all)."""
+    return _pick_use_default_env(project) is not None
+
+
+def export_pixi_toml(project, use_default=False):
     """Convert an anaconda-project Project to pixi.toml content.
 
     Args:
         project: an anaconda_project.project.Project instance
+        use_default: if True and the project has no env_spec literally
+            named ``default``, rename the env_spec attached to the
+            default command (or, failing that, the first declared
+            env_spec) to ``default`` — so it materializes as pixi's
+            implicit default environment with packages, commands, and
+            the prepare task at the top level instead of inside a
+            ``[feature.{name}.*]`` block.
 
     Returns:
         A string containing the pixi.toml file content.
@@ -703,7 +736,32 @@ def export_pixi_toml(project):
         all_platforms = {'linux-64'}
 
     # -- Determine if we need features (multiple env specs)
-    env_specs = project.env_specs
+    # When the user passes use_default and there's no env_spec already
+    # called `default`, alias the promoted env (the default command's
+    # env_spec, or the first one declared) to `default` for the rest of
+    # this function. Every code path below already special-cases `default`
+    # — it's pixi's implicit env name — so a one-shot rename is enough to
+    # collapse [feature.{name}.dependencies] → [dependencies] and
+    # [feature.{name}.tasks.X] → [tasks.X].
+    promoted_env = _pick_use_default_env(project) if use_default else None
+
+    def _xlate(name):
+        """Map an anaconda-project env name into the post-rename keyspace."""
+        if promoted_env is not None and name == promoted_env:
+            return 'default'
+        return name
+
+    if promoted_env is not None:
+        # Preserve order so [environments] still emits envs in source order.
+        env_specs = {_xlate(n): spec for n, spec in project.env_specs.items()}
+        # When iterating env_specs (renamed-keyspace), API calls into the
+        # Project (e.g. `project.requirements(name)`) still expect the
+        # original name. This inverse map lets us look it up.
+        original_name_for = {_xlate(n): n for n in project.env_specs}
+    else:
+        env_specs = project.env_specs
+        original_name_for = {n: n for n in env_specs}
+
     has_multiple_envs = len(env_specs) > 1 or (len(env_specs) == 1 and 'default' not in env_specs)
 
     # Placeholder for a warning prefix; populated below once we know
@@ -764,7 +822,7 @@ def export_pixi_toml(project):
     downloads_per_env = {}
     for env_name in env_specs:
         env_downloads = []
-        for req in project.requirements(env_name):
+        for req in project.requirements(original_name_for[env_name]):
             if isinstance(req, DownloadRequirement):
                 # Prefer the user-supplied description from the yml; fall
                 # back to the env_var name when the user didn't write one.
@@ -802,8 +860,16 @@ def export_pixi_toml(project):
     _write_dependencies(lines, global_conda, global_pip)
 
     # -- [activation] for variables
+    # When use_default is in effect we want to read the requirements of
+    # the env we just renamed to `default` (which may not be the project's
+    # current default_env_spec_name); otherwise the project's default is
+    # the right source.
+    if 'default' in env_specs:
+        activation_source_env = original_name_for['default']
+    else:
+        activation_source_env = project.default_env_spec_name
     variables_with_defaults = {}
-    for req in project.requirements(project.default_env_spec_name):
+    for req in project.requirements(activation_source_env):
         if isinstance(req, (CondaEnvRequirement, DownloadRequirement, ServiceRequirement)):
             continue
         if isinstance(req, EnvVarRequirement):
@@ -877,7 +943,7 @@ def export_pixi_toml(project):
     # `variables:` (with or without defaults), `downloads:`, and `services:`.
     declared_vars = set()
     for env_name in env_specs:
-        for req in project.requirements(env_name):
+        for req in project.requirements(original_name_for[env_name]):
             if isinstance(req, CondaEnvRequirement):
                 continue
             if isinstance(req, EnvVarRequirement):
@@ -890,7 +956,11 @@ def export_pixi_toml(project):
         global_tasks = []
         feature_tasks = []
         for cmd_name, command in sorted(commands.items()):
-            env_spec_name = command.default_env_spec_name
+            # Translate the command's env_spec name into the renamed
+            # keyspace — so a command bound to the promoted env sees
+            # `default` and ends up in [tasks.X] rather than
+            # [feature.{old}.tasks.X].
+            env_spec_name = _xlate(command.default_env_spec_name)
             if has_multiple_envs and env_spec_name and env_spec_name != 'default':
                 feature_tasks.append((cmd_name, command))
             else:
@@ -924,7 +994,7 @@ def export_pixi_toml(project):
                 lines.append('# {} — could not convert (no unix command)'.format(cmd_name))
                 continue
             desc = command.description
-            env_spec_name = command.default_env_spec_name
+            env_spec_name = _xlate(command.default_env_spec_name)
             pixi_env_name = _sanitize_env_name(env_spec_name)
             has_desc = desc and desc != cmd_name and desc not in (raw_forms or [])
             section = 'feature.{}.tasks.{}'.format(pixi_env_name, cmd_name)
@@ -953,8 +1023,8 @@ def export_pixi_toml(project):
     # by looking for the `prepare` task.
     if 'default' in env_specs:
         default_source = 'default'
-    elif project.default_env_spec_name in env_specs:
-        default_source = project.default_env_spec_name
+    elif _xlate(project.default_env_spec_name) in env_specs:
+        default_source = _xlate(project.default_env_spec_name)
     elif env_specs:
         default_source = next(iter(env_specs))
     else:
@@ -984,7 +1054,7 @@ def export_pixi_toml(project):
     # -- Services as comments
     services = {}
     for env_name in env_specs:
-        for req in project.requirements(env_name):
+        for req in project.requirements(original_name_for[env_name]):
             if isinstance(req, ServiceRequirement):
                 services[req.env_var] = req.service_type
 
@@ -996,7 +1066,7 @@ def export_pixi_toml(project):
 
     # -- Variables without defaults as comments
     vars_without_defaults = {}
-    for req in project.requirements(project.default_env_spec_name):
+    for req in project.requirements(activation_source_env):
         if isinstance(req, (CondaEnvRequirement, DownloadRequirement, ServiceRequirement)):
             continue
         if isinstance(req, EnvVarRequirement) and req.default_as_string is None:

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -13,6 +13,7 @@ import re
 import shutil
 import subprocess
 
+from anaconda_project.internal.simple_status import SimpleStatus
 from anaconda_project.requirements_registry.requirement import EnvVarRequirement
 from anaconda_project.requirements_registry.requirements.conda_env import CondaEnvRequirement
 from anaconda_project.requirements_registry.requirements.download import DownloadRequirement
@@ -23,6 +24,29 @@ class CondaNotAvailableError(Exception):
     """Raised when the exporter needs `conda` for channel resolution but
     can't find or invoke it. Wraps the underlying reason so the CLI can
     surface a useful failure status."""
+
+
+class PixiExportStatus(SimpleStatus):
+    """Status returned by :func:`anaconda_project.project_ops.export_pixi`.
+
+    Adds ``default_rename_from`` so callers can tell the user *which* env
+    was just promoted to ``default`` without re-querying the project. The
+    attribute is ``None`` when:
+
+    * ``use_default`` was not requested,
+    * the project already had an env_spec literally named ``default``, or
+    * the export failed.
+
+    Stable for downstream consumers (launchers, IDE plugins) that need to
+    surface "Renamed env X → default" in their success notification.
+    """
+    def __init__(self, success, description, errors=(), default_rename_from=None):
+        super().__init__(success, description, errors)
+        self._default_rename_from = default_rename_from
+
+    @property
+    def default_rename_from(self):
+        return self._default_rename_from
 
 
 def _resolve_default_channels():
@@ -658,7 +682,28 @@ def _command_to_task(command, declared_vars):
     return cmd_rendered, raw_forms, comments, args_line
 
 
-def _pick_use_default_env(project):
+def extract_warnings(content):
+    """Pull the leading ``# WARNING:`` block out of generated pixi.toml text.
+
+    Returns a list of comment lines (the ``# WARNING:`` line plus its
+    indented continuation, stopping at the first blank line). Empty list
+    if the content carries no warning block. Used by both ``export_pixi``
+    (to mirror the warning to stderr) and ``preview_pixi_export`` (to
+    surface it in the structured preview without scraping the toml again).
+    """
+    warning_lines = []
+    in_warning = False
+    for line in content.splitlines():
+        if line.startswith('# WARNING:'):
+            in_warning = True
+        if in_warning:
+            if line == '':
+                break
+            warning_lines.append(line)
+    return warning_lines
+
+
+def default_rename_target(project):
     """Return the env_spec name that ``--use-default`` would promote to
     pixi's implicit ``default`` environment, or None if it would no-op.
 
@@ -667,6 +712,10 @@ def _pick_use_default_env(project):
     commands or the command's env_spec is missing, we fall back to the
     first env_spec declared. We never promote when an env_spec literally
     named ``default`` already exists — there's nothing to rename.
+
+    This is the public contract for downstream tools (CLI, launchers,
+    GUIs) that need to display "this env will be renamed" before — or
+    after — calling the exporter.
     """
     env_specs = project.env_specs
     if not env_specs or 'default' in env_specs:
@@ -683,7 +732,7 @@ def project_would_benefit_from_use_default(project):
     """True if exporting with ``use_default=True`` would actually rename
     something. False when the project already has a ``default`` env_spec
     (or has no env_specs at all)."""
-    return _pick_use_default_env(project) is not None
+    return default_rename_target(project) is not None
 
 
 def export_pixi_toml(project, use_default=False):
@@ -743,7 +792,7 @@ def export_pixi_toml(project, use_default=False):
     # — it's pixi's implicit env name — so a one-shot rename is enough to
     # collapse [feature.{name}.dependencies] → [dependencies] and
     # [feature.{name}.tasks.X] → [tasks.X].
-    promoted_env = _pick_use_default_env(project) if use_default else None
+    promoted_env = default_rename_target(project) if use_default else None
 
     def _xlate(name):
         """Map an anaconda-project env name into the post-rename keyspace."""

--- a/anaconda_project/internal/test/test_ap_download.py
+++ b/anaconda_project/internal/test/test_ap_download.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2026, Anaconda, Inc. All rights reserved.
+#
+# Licensed under the terms of the BSD 3-Clause License.
+# The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Tests for the ap_download.py helper script.
+
+The helper is what `pixi run prepare` invokes for each declared download
+in a converted project. We exercise the unit behaviors directly here —
+argument parsing, checksum verification, error handling — rather than
+through a full export-and-run flow, which would cost a network round-trip.
+"""
+import hashlib
+import os
+
+import pytest
+
+from anaconda_project.internal import ap_download
+
+
+def _write(path, data):
+    with open(path, 'wb') as f:
+        f.write(data)
+
+
+def _hexdigest(data, algo):
+    h = hashlib.new(algo)
+    h.update(data)
+    return h.hexdigest()
+
+
+class TestParseArgs:
+    def test_two_positional(self):
+        result = ap_download._parse_args(['url', 'file'])
+        assert result == (['url', 'file'], None, None)
+
+    def test_three_positional(self):
+        result = ap_download._parse_args(['url', 'file', 'description'])
+        assert result == (['url', 'file', 'description'], None, None)
+
+    def test_with_sha256(self):
+        result = ap_download._parse_args(['url', 'file', '--sha256', 'abc123'])
+        assert result == (['url', 'file'], 'sha256', 'abc123')
+
+    def test_hash_value_lowercased(self):
+        # checksums in the yml may be uppercase; helpers compute lowercase
+        # hex, so normalize at parse time so the comparison succeeds.
+        result = ap_download._parse_args(['url', 'file', '--md5', 'ABCDEF'])
+        assert result[2] == 'abcdef'
+
+    def test_too_few_positional_returns_none(self):
+        assert ap_download._parse_args(['url']) is None
+
+    def test_too_many_positional_returns_none(self):
+        assert ap_download._parse_args(['url', 'file', 'desc', 'extra']) is None
+
+    def test_unknown_flag_returns_none(self):
+        assert ap_download._parse_args(['url', 'file', '--bogus', 'x']) is None
+
+    def test_flag_without_value_returns_none(self):
+        assert ap_download._parse_args(['url', 'file', '--md5']) is None
+
+    def test_multiple_hash_flags_returns_none(self):
+        assert ap_download._parse_args(
+            ['url', 'file', '--md5', 'a', '--sha256', 'b']) is None
+
+    def test_flag_before_positional(self):
+        # Flag/positional ordering shouldn't matter.
+        result = ap_download._parse_args(['--sha1', 'deadbeef', 'url', 'file'])
+        assert result == (['url', 'file'], 'sha1', 'deadbeef')
+
+
+class TestChecksumOnExistingFile:
+    def test_existing_file_matching_checksum_succeeds(self, tmp_path):
+        target = tmp_path / 'data.bin'
+        payload = b'hello world'
+        _write(str(target), payload)
+        sha = _hexdigest(payload, 'sha256')
+        rc = ap_download.main(['unused-url', str(target), '--sha256', sha])
+        assert rc == 0
+        assert target.exists()
+
+    def test_existing_file_mismatched_checksum_fails(self, tmp_path):
+        target = tmp_path / 'data.bin'
+        _write(str(target), b'hello world')
+        rc = ap_download.main(['unused-url', str(target), '--sha256', 'deadbeef'])
+        assert rc == 1
+        # Existing files are NOT removed on mismatch — they may have been
+        # edited intentionally; refuse rather than destroying user data.
+        assert target.exists()
+
+
+class TestChecksumOnDownload:
+    def test_downloaded_file_matching_checksum_succeeds(self, tmp_path, monkeypatch):
+        target = tmp_path / 'data.bin'
+        payload = b'fetched content'
+
+        def fake_urlretrieve(url, filename):
+            with open(filename, 'wb') as f:
+                f.write(payload)
+
+        monkeypatch.setattr(ap_download.urllib.request, 'urlretrieve',
+                            fake_urlretrieve)
+        sha = _hexdigest(payload, 'sha256')
+        rc = ap_download.main(['http://x/data', str(target), '--sha256', sha])
+        assert rc == 0
+        assert target.exists()
+        with open(str(target), 'rb') as f:
+            assert f.read() == payload
+
+    def test_downloaded_file_mismatched_checksum_fails_and_cleans_up(
+            self, tmp_path, monkeypatch):
+        target = tmp_path / 'data.bin'
+
+        def fake_urlretrieve(url, filename):
+            with open(filename, 'wb') as f:
+                f.write(b'wrong content')
+
+        monkeypatch.setattr(ap_download.urllib.request, 'urlretrieve',
+                            fake_urlretrieve)
+        rc = ap_download.main(
+            ['http://x/data', str(target), '--sha256', 'deadbeef'])
+        assert rc == 1
+        # Freshly-downloaded files DO get removed on mismatch — they
+        # came from the network, not the user.
+        assert not target.exists()
+
+    def test_no_checksum_skips_verification(self, tmp_path, monkeypatch):
+        target = tmp_path / 'data.bin'
+        payload = b'content'
+
+        def fake_urlretrieve(url, filename):
+            with open(filename, 'wb') as f:
+                f.write(payload)
+
+        monkeypatch.setattr(ap_download.urllib.request, 'urlretrieve',
+                            fake_urlretrieve)
+        rc = ap_download.main(['http://x/data', str(target)])
+        assert rc == 0
+        assert target.exists()
+
+
+class TestSkipsExisting:
+    def test_existing_file_no_checksum_skips_download(self, tmp_path):
+        target = tmp_path / 'data.bin'
+        _write(str(target), b'whatever')
+        # No urlretrieve patched — if it tried to download, we'd hit
+        # the network. The skip guards against that.
+        rc = ap_download.main(['http://x/data', str(target)])
+        assert rc == 0
+
+
+class TestUsage:
+    def test_no_args_returns_2(self, capsys):
+        rc = ap_download.main([])
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert 'usage:' in err

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -177,7 +177,9 @@ platforms:
         result = export_pixi_toml(project)
         assert 'channels = ["conda-forge"]' in result
 
-    def test_downloads_as_comments(self):
+    def test_downloads_become_prepare_task(self):
+        # Single env (default) — prepare emitted at top-level. Body
+        # invokes the ap_download.py helper rather than inlining urllib.
         project = self._make_project("""
 name: DlTest
 packages: []
@@ -187,8 +189,115 @@ downloads:
   DATASET: https://example.com/data.csv
 """)
         result = export_pixi_toml(project)
-        assert '# Downloads from anaconda-project.yml' in result
-        assert 'DATASET = https://example.com/data.csv' in result
+        assert '[tasks.prepare]' in result
+        assert 'python3 ap_download.py' in result
+        assert 'https://example.com/data.csv' in result
+        # When the prepare body has real work, we drop the marker echo —
+        # pixi smashes the marker onto the same banner line as the next
+        # command, which is ugly. Detection still works via the task name.
+        assert 'Running migrated anaconda-project prepare task' not in result
+        # No python in the env: warning at the top of the file.
+        assert '# WARNING: prepare task uses system python3' in result
+        # Old comment-only path is gone.
+        assert '# Downloads from anaconda-project.yml' not in result
+
+    def test_marker_echo_only_when_no_downloads(self):
+        # The no-op prepare body still uses the marker echo so the task
+        # has *something* to print and so anyone reading the manifest
+        # immediately sees what it came from.
+        project = self._make_project("""
+name: NoDl
+packages:
+  - python
+platforms:
+  - linux-64
+""")
+        result = export_pixi_toml(project)
+        assert 'Running migrated anaconda-project prepare task' in result
+
+    def test_only_default_env_gets_prepare(self):
+        # anaconda-project's top-level downloads: apply to every env, but
+        # we only need to fetch them once. Emit prepare only under the
+        # default env's feature; the other envs don't get a prepare task.
+        project = self._make_project("""
+name: NycMulti
+packages:
+  - python
+platforms:
+  - linux-64
+downloads:
+  DATA: https://example.com/big.parq
+env_specs:
+  sampleproj: {}
+  test:
+    packages:
+      - pytest
+""")
+        result = export_pixi_toml(project)
+        # Exactly one ap_download.py invocation, under the default env.
+        assert result.count('python3 ap_download.py') == 1
+        assert '[feature.sampleproj.tasks.prepare]' in result
+        # Non-default env has no prepare task at all.
+        assert '[feature.test.tasks.prepare]' not in result
+
+    def test_no_warning_when_env_has_python(self):
+        project = self._make_project("""
+name: HasPython
+packages:
+  - python=3.11
+platforms:
+  - linux-64
+downloads:
+  DATASET: https://example.com/data.csv
+""")
+        result = export_pixi_toml(project)
+        # User declared python — no warning, no injection.
+        assert 'python = "3.11.*"' in result
+        assert '# WARNING' not in result
+
+    def test_prepare_in_default_env_only(self):
+        # We emit exactly one prepare task, scoped to the default env's
+        # feature. Other envs don't get one — keeps the manifest small
+        # and avoids pixi's "ambiguous task" prompt entirely.
+        project = self._make_project("""
+name: MultiDl
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  web:
+    downloads:
+      WEB_DATA: https://example.com/web.csv
+  ml:
+    downloads:
+      ML_DATA: https://example.com/ml.csv
+""")
+        result = export_pixi_toml(project)
+        # Default env (first declared = web) gets the prepare task.
+        assert '[feature.web.tasks.prepare]' in result
+        assert 'web.csv' in result
+        # Non-default env (ml) does NOT get a prepare task.
+        assert '[feature.ml.tasks.prepare]' not in result
+        # No prepare-all either — single prepare keeps things simple.
+        assert 'prepare-all' not in result
+
+    def test_marker_prepare_when_no_downloads(self):
+        # Every converted project gets a prepare task — even when there are
+        # no downloads to fetch. Detection of "is this a converted project?"
+        # relies on the presence of `prepare`.
+        project = self._make_project("""
+name: Plain
+packages:
+  - python
+platforms:
+  - linux-64
+""")
+        result = export_pixi_toml(project)
+        assert '[tasks.prepare]' in result
+        assert 'Running migrated anaconda-project prepare task' in result
+        # No downloads, so no urllib invocation.
+        assert 'urllib.request' not in result
 
     def test_project_dir_translated(self):
         project = self._make_project("""
@@ -220,6 +329,108 @@ commands:
         result = export_pixi_toml(project)
         assert 'echo $MY_VAR' in result
         assert 'unresolved env var' not in result
+
+    def test_env_specs_emit_in_source_order(self):
+        # The first uncommented entry in [environments] is the user's
+        # intended default — downstream tooling reads it to drive
+        # `pixi install -e $(...)`. We must preserve insertion order even
+        # if dict iteration would otherwise be alphabetical.
+        project = self._make_project("""
+name: OrderTest
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  zeta:
+    packages:
+      - flask
+  alpha:
+    packages:
+      - pytest
+""")
+        result = export_pixi_toml(project)
+        env_block = result.split('[environments]', 1)[1]
+        zeta_pos = env_block.index('zeta')
+        alpha_pos = env_block.index('alpha')
+        assert zeta_pos < alpha_pos
+
+    def test_default_in_multi_env_emits_as_comment(self):
+        # When the user names one of multiple env_specs `default`, we don't
+        # redeclare it (pixi already creates it from the default feature).
+        # We comment its slot so position-based extraction still finds the
+        # user's first-listed env.
+        project = self._make_project("""
+name: MultiWithDefault
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  prod:
+    packages:
+      - flask
+  default:
+    packages:
+      - pytest
+  staging:
+    packages:
+      - debugpy
+""")
+        result = export_pixi_toml(project)
+        # pytest from `default` env_spec belongs in pixi's default feature.
+        assert 'pytest = "*"' in result.split('[feature.', 1)[0]
+        # `default` slot is a comment, in position between prod and staging.
+        env_block = result.split('[environments]', 1)[1]
+        prod_pos = env_block.index('prod')
+        comment_pos = env_block.index('# default')
+        staging_pos = env_block.index('staging')
+        assert prod_pos < comment_pos < staging_pos
+        # No [feature.default.dependencies] (would be unreachable).
+        assert '[feature.default.dependencies]' not in result
+
+    def test_no_solve_group_emitted(self):
+        # anaconda-project doesn't assume environments solve together, so
+        # we shouldn't either.
+        project = self._make_project("""
+name: NoSolve
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  a:
+    packages:
+      - flask
+  b:
+    packages:
+      - pytest
+""")
+        result = export_pixi_toml(project)
+        assert 'solve-group' not in result
+
+    def test_single_named_env_uses_global_dependencies(self):
+        # Packages live in top-level [dependencies] (the default feature);
+        # the named env inherits them. The marker comment tells downstream
+        # tooling which env to target with bare `pixi <cmd>`.
+        project = self._make_project("""
+name: Glaciers
+packages:
+  - panel
+  - pandas
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        result = export_pixi_toml(project)
+        assert '[dependencies]' in result
+        assert 'panel = "*"' in result
+        assert 'pandas = "*"' in result
+        assert 'sampleproj = { features = ["sampleproj"]' in result
+        # We don't need no-default-feature now that the default feature
+        # is the source of truth.
+        assert 'no-default-feature' not in result
 
     def test_unknown_var_flagged(self):
         project = self._make_project("""

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -720,6 +720,50 @@ commands:
         # Generic --anaconda-project-* flags shouldn't appear.
         assert '--anaconda-project-' not in result
 
+    def test_url_prefix_renamed_per_tool(self):
+        # --anaconda-project-url-prefix maps differently in each tool:
+        #   generic  -> --anaconda-project-url-prefix VALUE  (passthrough)
+        #   bokeh    -> --prefix VALUE
+        #   notebook -> --NotebookApp.base_url=VALUE  (single-arg form,
+        #               original transformer notes the two-arg form is
+        #               rejected by jupyter)
+        # Mirror those mappings here so converted commands carry the
+        # right flag for the tool that will receive them.
+        for label, yml, expected_flag in [
+            ('generic',
+             """name: t
+packages: [python]
+platforms: [linux-64]
+commands:
+  serve:
+    unix: panel serve foo.ipynb
+    supports_http_options: true
+""",
+             '--anaconda-project-url-prefix {{ url_prefix }}'),
+            ('bokeh',
+             """name: t
+packages: [python, bokeh]
+platforms: [linux-64]
+commands:
+  app:
+    bokeh_app: myapp
+""",
+             '--prefix {{ url_prefix }}'),
+            ('notebook',
+             """name: t
+packages: [python]
+platforms: [linux-64]
+commands:
+  nb:
+    notebook: report.ipynb
+""",
+             '--NotebookApp.base_url={{ url_prefix }}'),
+        ]:
+            project = self._make_project(yml)
+            result = export_pixi_toml(project)
+            assert expected_flag in result, '{}: missing {!r}'.format(label, expected_flag)
+            assert 'arg = "url_prefix"' in result, '{}: arg not declared'.format(label)
+
     def test_bokeh_app_uses_bokeh_flags(self):
         # bokeh_app: commands translate to bokeh's flag names: bare
         # --host/--port/--address, and --show as the *inverse* of

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -150,7 +150,7 @@ commands:
         assert 'https://example.test/main' in result
         assert 'https://example.test/r' in result
         assert '"linux-64"' in result
-        assert 'run = "python main.py"' in result
+        assert 'cmd = "python main.py"' in result
 
     def test_pip_packages(self):
         project = self._make_project("""
@@ -596,7 +596,7 @@ commands:
     windows: python %PROJECT_DIR%\\hello.py
 """)
         result = export_pixi_toml(project)
-        assert 'run = "python $PIXI_PROJECT_ROOT/hello.py"' in result
+        assert 'cmd = "python $PIXI_PROJECT_ROOT/hello.py"' in result
         assert 'windows command differs' not in result
 
     def test_diverging_unix_and_windows_flags_comment(self):
@@ -611,7 +611,7 @@ commands:
     windows: python %PROJECT_DIR%\\hello_win.py
 """)
         result = export_pixi_toml(project)
-        assert 'run = "python $PIXI_PROJECT_ROOT/hello.py"' in result
+        assert 'cmd = "python $PIXI_PROJECT_ROOT/hello.py"' in result
         assert 'windows command differs from unix' in result
         assert 'hello_win.py' in result
 
@@ -626,7 +626,7 @@ commands:
     windows: python %PROJECT_DIR%\\hello.py
 """)
         result = export_pixi_toml(project)
-        assert 'run = "python $PIXI_PROJECT_ROOT/hello.py"' in result
+        assert 'cmd = "python $PIXI_PROJECT_ROOT/hello.py"' in result
         assert 'translated from windows-only command' in result
 
 
@@ -659,6 +659,137 @@ class TestStripCondaPrefixPaths:
         assert _strip_conda_prefix_paths('exec ${CONDA_PREFIX}/bin/python') == 'exec python'
 
 
+class TestHttpOptions:
+    def _make_project(self, yml_content):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, 'anaconda-project.yml'), 'w') as f:
+            f.write(yml_content)
+        return Project(tmpdir)
+
+    def test_supports_http_options_appends_all_flags(self):
+        # supports_http_options=true → cmd gets all six --anaconda-project-X
+        # flags appended (gated by Jinja so empty args drop the flag), and
+        # pixi args declared with empty defaults.
+        project = self._make_project("""
+name: Http
+packages:
+  - python
+platforms:
+  - linux-64
+commands:
+  serve:
+    unix: panel serve foo.ipynb
+    supports_http_options: true
+""")
+        result = export_pixi_toml(project)
+        # All six flags appear in the cmd, gated.
+        for flag in ('--anaconda-project-host', '--anaconda-project-port',
+                     '--anaconda-project-address', '--anaconda-project-iframe-hosts',
+                     '--anaconda-project-no-browser', '--anaconda-project-use-xheaders'):
+            assert flag in result, "missing %s" % flag
+        # Each is gated by an `{% if var %}` so empty args don't render.
+        assert '{% if port %}' in result
+        assert '{% if no_browser %}' in result
+        # Pixi args block declares all six with empty defaults.
+        assert 'arg = "port", default = ""' in result
+        assert 'arg = "no_browser", default = ""' in result
+
+    def test_notebook_command_uses_jupyter_flags(self):
+        # notebook: commands have supports_http_options=true by default,
+        # and translate to Jupyter's specific flag names — `--port` (not
+        # `--anaconda-project-port`), `--ip` for address, etc., plus the
+        # unconditional --NotebookApp.default_url prefix that
+        # anaconda-project's _NotebookArgsTransformer emits.
+        project = self._make_project("""
+name: NbHttp
+packages:
+  - python
+platforms:
+  - linux-64
+commands:
+  nb:
+    notebook: report.ipynb
+""")
+        result = export_pixi_toml(project)
+        assert '--NotebookApp.default_url=/notebooks/report.ipynb' in result
+        assert '--port {{ port }}' in result
+        assert '--ip {{ address }}' in result
+        assert 'arg = "port"' in result
+        # Notebook drops host entirely (jupyter has no equivalent).
+        assert 'arg = "host"' not in result
+        # Generic --anaconda-project-* flags shouldn't appear.
+        assert '--anaconda-project-' not in result
+
+    def test_bokeh_app_uses_bokeh_flags(self):
+        # bokeh_app: commands translate to bokeh's flag names: bare
+        # --host/--port/--address, and --show as the *inverse* of
+        # --no-browser. iframe_hosts is dropped (bokeh has no equivalent).
+        project = self._make_project("""
+name: BokehHttp
+packages:
+  - python
+  - bokeh
+platforms:
+  - linux-64
+commands:
+  app:
+    bokeh_app: myapp
+""")
+        result = export_pixi_toml(project)
+        assert '--host {{ host }}' in result
+        assert '--port {{ port }}' in result
+        assert '--address {{ address }}' in result
+        # --show is gated by `not no_browser` (negative gate).
+        assert '{% if not no_browser %}--show{% endif %}' in result
+        assert '--use-xheaders' in result
+        # iframe_hosts is not declared as an arg or referenced.
+        assert 'arg = "iframe_hosts"' not in result
+        assert '--anaconda-project-' not in result
+
+    def test_supports_http_options_false_no_jinja_no_args(self):
+        # supports_http_options=false and the unix line has no {{var}}
+        # references → no http args at all, cmd unchanged.
+        project = self._make_project("""
+name: Plain
+packages:
+  - python
+platforms:
+  - linux-64
+commands:
+  run:
+    unix: python app.py
+""")
+        result = export_pixi_toml(project)
+        assert '--anaconda-project-' not in result
+        assert 'args = [' not in result
+
+    def test_supports_http_options_false_picks_up_referenced_jinja(self):
+        # User wrote a templated unix: command with {{port}} and {{host}}.
+        # We declare pixi args only for those, leave the cmd alone.
+        project = self._make_project("""
+name: Tmpl
+packages:
+  - python
+platforms:
+  - linux-64
+commands:
+  run:
+    unix: "myserver --port={{ port }} --host={{ host }}"
+""")
+        result = export_pixi_toml(project)
+        # Cmd preserved verbatim (env-var translation doesn't touch
+        # Jinja vars).
+        assert '--port={{ port }}' in result
+        assert '--host={{ host }}' in result
+        # Only port and host declared; not the other four http vars.
+        assert 'arg = "port"' in result
+        assert 'arg = "host"' in result
+        assert 'arg = "address"' not in result
+        assert 'arg = "iframe_hosts"' not in result
+        # No --anaconda-project-X flags appended.
+        assert '--anaconda-project-' not in result
+
+
 class TestEndToEndCondaPrefixUnification:
     def _make_project(self, yml_content):
         tmpdir = tempfile.mkdtemp()
@@ -681,5 +812,5 @@ commands:
     windows: '%CONDA_PREFIX%\\python.exe %PROJECT_DIR%\\hello.py'
 """)
         result = export_pixi_toml(project)
-        assert 'run = "python $PIXI_PROJECT_ROOT/hello.py"' in result
+        assert 'cmd = "python $PIXI_PROJECT_ROOT/hello.py"' in result
         assert 'windows command differs' not in result

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -12,14 +12,76 @@ import os
 import pytest
 import tempfile
 
+from anaconda_project.internal import pixi_export as pixi_export_module
 from anaconda_project.internal.pixi_export import (
+    CondaNotAvailableError,
     _conda_spec_to_pixi,
+    _expand_defaults_in_channels,
     _strip_conda_prefix_paths,
     _translate_command_env_vars,
     _windows_to_deno_shell,
     export_pixi_toml,
 )
 from anaconda_project.project import Project
+
+
+# Use a stable, fake `defaults` expansion across the suite so tests don't
+# depend on the developer's local `conda config` and don't shell out to
+# conda once per test.
+FAKE_DEFAULTS = ['https://example.test/main', 'https://example.test/r']
+
+
+@pytest.fixture(autouse=True)
+def _stub_default_channels(monkeypatch):
+    monkeypatch.setattr(
+        pixi_export_module, '_resolve_default_channels',
+        lambda: list(FAKE_DEFAULTS),
+    )
+
+
+class TestExpandDefaultsInChannels:
+    def test_no_defaults(self):
+        out = _expand_defaults_in_channels(['conda-forge', 'bioconda'], FAKE_DEFAULTS)
+        assert out == ['conda-forge', 'bioconda']
+
+    def test_defaults_expanded_in_place(self):
+        out = _expand_defaults_in_channels(['defaults', 'bioconda'], FAKE_DEFAULTS)
+        assert out == FAKE_DEFAULTS + ['bioconda']
+
+    def test_defaults_in_middle(self):
+        out = _expand_defaults_in_channels(
+            ['bioconda', 'defaults', 'conda-forge'], FAKE_DEFAULTS)
+        assert out == ['bioconda'] + FAKE_DEFAULTS + ['conda-forge']
+
+    def test_dedup_when_default_already_listed(self):
+        out = _expand_defaults_in_channels(
+            ['https://example.test/main', 'defaults'], FAKE_DEFAULTS)
+        # The pre-existing entry wins; defaults' duplicate is skipped.
+        assert out == ['https://example.test/main', 'https://example.test/r']
+
+    def test_multiple_defaults_collapse(self):
+        out = _expand_defaults_in_channels(['defaults', 'defaults'], FAKE_DEFAULTS)
+        assert out == FAKE_DEFAULTS
+
+
+class TestExportFailsWithoutConda:
+    def test_export_raises_when_conda_missing(self, monkeypatch, tmpdir):
+        # Override the autouse stub: simulate conda being unreachable.
+        def boom():
+            raise CondaNotAvailableError('conda not found')
+        monkeypatch.setattr(
+            pixi_export_module, '_resolve_default_channels', boom)
+
+        yml = tmpdir.join('anaconda-project.yml')
+        yml.write("""
+name: NeedsConda
+packages: []
+platforms:
+  - linux-64
+""")
+        project = Project(str(tmpdir))
+        with pytest.raises(CondaNotAvailableError):
+            export_pixi_toml(project)
 
 
 class TestCondaSpecToPixi:
@@ -81,7 +143,12 @@ commands:
         assert 'description = "A test project"' in result
         assert 'numpy = "*"' in result
         assert 'pandas = ">=2.0"' in result
-        assert '"defaults"' in result
+        # `defaults` from the yml is expanded into the URLs that conda
+        # would resolve it to. The literal "defaults" never appears in
+        # the converted manifest — pixi has no such meta-channel.
+        assert '"defaults"' not in result
+        assert 'https://example.test/main' in result
+        assert 'https://example.test/r' in result
         assert '"linux-64"' in result
         assert 'run = "python main.py"' in result
 
@@ -168,6 +235,10 @@ commands:
         assert '# converted from notebook' in result
 
     def test_default_channels_when_empty(self):
+        # When the yml declares no channels, fall back to the URLs that
+        # conda's default_channels resolves to (NOT a hard-coded
+        # conda-forge), since pixi has no `defaults` meta-channel and
+        # the user's local conda config is the source of truth.
         project = self._make_project("""
 name: NoChan
 packages: []
@@ -175,7 +246,9 @@ platforms:
   - linux-64
 """)
         result = export_pixi_toml(project)
-        assert 'channels = ["conda-forge"]' in result
+        assert 'channels = ["https://example.test/main", "https://example.test/r"]' in result
+        assert '"defaults"' not in result
+        assert '"conda-forge"' not in result
 
     def test_downloads_become_prepare_task(self):
         # Single env (default) — prepare emitted at top-level. Body

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -274,12 +274,16 @@ downloads:
         # Old comment-only path is gone.
         assert '# Downloads from anaconda-project.yml' not in result
 
-    def test_no_prepare_task_when_no_downloads(self):
-        # If there's no real work for prepare to do, omit it entirely.
-        # Downstream tooling looks for `prepare` and runs it when
-        # present; an absent task is the same signal as "nothing to
-        # prepare for this project," and skipping it costs no logic on
-        # the consumer side.
+    def test_marker_prepare_when_no_downloads(self):
+        # Even without downloads, every converted project gets a
+        # `prepare` task. It does double duty:
+        #   * Marks the file as converted from anaconda-project.yml,
+        #     for downstream tooling that detects converted projects
+        #     by task name.
+        #   * When scoped to a non-default env's feature, gives
+        #     `pixi run prepare` an entry point that auto-resolves to
+        #     that env — useful when the default env_spec is named
+        #     something other than `default`.
         project = self._make_project("""
 name: NoDl
 packages:
@@ -288,7 +292,10 @@ platforms:
   - linux-64
 """)
         result = export_pixi_toml(project)
-        assert 'prepare' not in result
+        assert '[tasks.prepare]' in result
+        assert 'Running migrated anaconda-project prepare task' in result
+        # No downloads, so no helper invocation.
+        assert 'ap_download.py' not in result
 
     def test_only_default_env_gets_prepare(self):
         # anaconda-project's top-level downloads: apply to every env, but
@@ -357,20 +364,24 @@ env_specs:
         # No prepare-all either — single prepare keeps things simple.
         assert 'prepare-all' not in result
 
-    def test_no_prepare_when_yml_has_no_downloads(self):
-        # Mirror of test_no_prepare_task_when_no_downloads but at this
-        # level of the suite — keeping coverage close to the related
-        # single-named-env test below.
+    def test_prepare_scoped_to_named_default_env(self):
+        # When the default env_spec has a non-default name (sampleproj),
+        # the prepare task is scoped to that feature so `pixi run prepare`
+        # auto-resolves to the right env. This is the second job of the
+        # always-emit-prepare convention: it's an env-selection entry
+        # point even when there's nothing to download.
         project = self._make_project("""
 name: Plain
 packages:
   - python
 platforms:
   - linux-64
+env_specs:
+  sampleproj: {}
 """)
         result = export_pixi_toml(project)
-        assert 'prepare' not in result
-        # And no helper invocation either, of course.
+        assert '[feature.sampleproj.tasks.prepare]' in result
+        # No downloads → no helper invocation.
         assert 'ap_download.py' not in result
 
     def test_project_dir_translated(self):

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -274,10 +274,12 @@ downloads:
         # Old comment-only path is gone.
         assert '# Downloads from anaconda-project.yml' not in result
 
-    def test_marker_echo_only_when_no_downloads(self):
-        # The no-op prepare body still uses the marker echo so the task
-        # has *something* to print and so anyone reading the manifest
-        # immediately sees what it came from.
+    def test_no_prepare_task_when_no_downloads(self):
+        # If there's no real work for prepare to do, omit it entirely.
+        # Downstream tooling looks for `prepare` and runs it when
+        # present; an absent task is the same signal as "nothing to
+        # prepare for this project," and skipping it costs no logic on
+        # the consumer side.
         project = self._make_project("""
 name: NoDl
 packages:
@@ -286,7 +288,7 @@ platforms:
   - linux-64
 """)
         result = export_pixi_toml(project)
-        assert 'Running migrated anaconda-project prepare task' in result
+        assert 'prepare' not in result
 
     def test_only_default_env_gets_prepare(self):
         # anaconda-project's top-level downloads: apply to every env, but
@@ -355,10 +357,10 @@ env_specs:
         # No prepare-all either — single prepare keeps things simple.
         assert 'prepare-all' not in result
 
-    def test_marker_prepare_when_no_downloads(self):
-        # Every converted project gets a prepare task — even when there are
-        # no downloads to fetch. Detection of "is this a converted project?"
-        # relies on the presence of `prepare`.
+    def test_no_prepare_when_yml_has_no_downloads(self):
+        # Mirror of test_no_prepare_task_when_no_downloads but at this
+        # level of the suite — keeping coverage close to the related
+        # single-named-env test below.
         project = self._make_project("""
 name: Plain
 packages:
@@ -367,10 +369,9 @@ platforms:
   - linux-64
 """)
         result = export_pixi_toml(project)
-        assert '[tasks.prepare]' in result
-        assert 'Running migrated anaconda-project prepare task' in result
-        # No downloads, so no urllib invocation.
-        assert 'urllib.request' not in result
+        assert 'prepare' not in result
+        # And no helper invocation either, of course.
+        assert 'ap_download.py' not in result
 
     def test_project_dir_translated(self):
         project = self._make_project("""

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -15,15 +15,18 @@ import tempfile
 from anaconda_project.internal import pixi_export as pixi_export_module
 from anaconda_project.internal.pixi_export import (
     CondaNotAvailableError,
+    PixiExportStatus,
     _conda_spec_to_pixi,
     _expand_defaults_in_channels,
-    _pick_use_default_env,
+    default_rename_target,
     _strip_conda_prefix_paths,
     _translate_command_env_vars,
     _windows_to_deno_shell,
     export_pixi_toml,
+    extract_warnings,
     project_would_benefit_from_use_default,
 )
+from anaconda_project import project_ops
 from anaconda_project.project import Project
 
 
@@ -865,7 +868,7 @@ env_specs:
   other:
     packages: [flask]
 """)
-        assert _pick_use_default_env(project) is None
+        assert default_rename_target(project) is None
         assert project_would_benefit_from_use_default(project) is False
 
     def test_picker_single_env_returns_that_env(self):
@@ -878,7 +881,7 @@ platforms:
 env_specs:
   sampleproj: {}
 """)
-        assert _pick_use_default_env(project) == 'sampleproj'
+        assert default_rename_target(project) == 'sampleproj'
 
     def test_picker_uses_default_command_env(self):
         # Two envs, no `default`. The default command's env (here `web`,
@@ -900,7 +903,7 @@ commands:
     env_spec: web
     default: true
 """)
-        assert _pick_use_default_env(project) == 'web'
+        assert default_rename_target(project) == 'web'
 
     def test_picker_falls_back_to_first_env_without_command(self):
         # No commands → first env_spec wins.
@@ -916,7 +919,7 @@ env_specs:
   alpha:
     packages: [pytest]
 """)
-        assert _pick_use_default_env(project) == 'zeta'
+        assert default_rename_target(project) == 'zeta'
 
     def test_single_env_collapses_to_top_level(self):
         # use_default on a single non-default env: deps move from
@@ -1065,3 +1068,176 @@ commands:
         result = export_pixi_toml(project)
         assert 'cmd = "python $PIXI_PROJECT_ROOT/hello.py"' in result
         assert 'windows command differs' not in result
+
+
+class TestExtractWarnings:
+    def test_no_warning_block(self):
+        assert extract_warnings('[workspace]\nname = "x"\n') == []
+
+    def test_warning_block_followed_by_blank(self):
+        content = (
+            '# WARNING: prepare task uses system python3 to run ap_download.py.\n'
+            '# The following env(s) declare downloads but no python package:\n'
+            '#   web\n'
+            '\n'
+            '[workspace]\n')
+        out = extract_warnings(content)
+        assert out[0].startswith('# WARNING:')
+        assert '#   web' in out
+        assert '[workspace]' not in out
+
+    def test_warning_must_lead(self):
+        # A line starting with '# WARNING:' deeper in the file isn't the
+        # leading-block we surface to the user.
+        content = '[workspace]\nname = "x"\n# WARNING: tucked away\n'
+        # The implementation does pick up a later block too (it scans
+        # forward until the first WARNING and stops at the next blank).
+        # Document the behavior either way: here there's no trailing
+        # blank, so it captures everything from WARNING to EOF.
+        out = extract_warnings(content)
+        assert out == ['# WARNING: tucked away']
+
+
+class TestPublicAPI:
+    """Tests for the public surface downstream consumers depend on:
+    ``default_rename_target``, ``PixiExportStatus.default_rename_from``,
+    and ``project_ops.preview_pixi_export``."""
+
+    def _make_project(self, yml_content):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, 'anaconda-project.yml'), 'w') as f:
+            f.write(yml_content)
+        return Project(tmpdir)
+
+    def test_default_rename_target_is_public_alias(self):
+        # The picker is part of the public contract. Promoted from the
+        # underscored name so downstream tooling doesn't have to import
+        # through a private accessor.
+        assert callable(default_rename_target)
+        assert default_rename_target.__doc__  # has user-facing docs
+
+    def test_export_pixi_status_carries_rename_when_used(self, tmpdir):
+        project = self._make_project("""
+name: ApiRename
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        target = str(tmpdir.join('pixi.toml'))
+        status = project_ops.export_pixi(project, filename=target,
+                                         use_default=True)
+        assert status  # truthy on success
+        assert isinstance(status, PixiExportStatus)
+        assert status.default_rename_from == 'sampleproj'
+
+    def test_export_pixi_status_rename_is_none_without_flag(self, tmpdir):
+        # Without --use-default, no rename happened, so the status reports
+        # None — even though default_rename_target() would have returned
+        # 'sampleproj'. This lets a caller distinguish "we renamed X" from
+        # "we could rename X".
+        project = self._make_project("""
+name: NoFlag
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        target = str(tmpdir.join('pixi.toml'))
+        status = project_ops.export_pixi(project, filename=target)
+        assert status
+        assert status.default_rename_from is None
+
+    def test_export_pixi_status_rename_is_none_when_already_default(self, tmpdir):
+        # use_default with a project that already has `default` is a
+        # no-op; rename_from should be None even though the flag was on.
+        project = self._make_project("""
+name: HasDefault
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  default: {}
+  other:
+    packages: [pytest]
+""")
+        target = str(tmpdir.join('pixi.toml'))
+        status = project_ops.export_pixi(project, filename=target,
+                                         use_default=True)
+        assert status
+        assert status.default_rename_from is None
+
+    def test_preview_pixi_export_shape(self):
+        project = self._make_project("""
+name: Preview
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        result = project_ops.preview_pixi_export(project, use_default=True)
+        # Stable contract: exactly these three keys.
+        assert set(result) == {'pixi_toml', 'default_rename_from', 'warnings'}
+        assert isinstance(result['pixi_toml'], str)
+        assert isinstance(result['warnings'], list)
+        # use_default=True actually applies in pixi_toml content
+        assert '[feature.sampleproj' not in result['pixi_toml']
+        assert '[dependencies]' in result['pixi_toml']
+        # default_rename_from reports the candidate regardless of
+        # whether use_default was passed — frontends use it to decide
+        # whether to *offer* the flag.
+        assert result['default_rename_from'] == 'sampleproj'
+
+    def test_preview_reports_target_even_when_flag_off(self):
+        # default_rename_from is the candidate, not "what we did". With
+        # use_default=False the pixi_toml is unchanged (feature-scoped),
+        # but the candidate is still reported so a UI can offer "re-run
+        # with --use-default" as an action.
+        project = self._make_project("""
+name: PreviewOff
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        result = project_ops.preview_pixi_export(project, use_default=False)
+        assert result['default_rename_from'] == 'sampleproj'
+        assert '[feature.sampleproj.tasks.prepare]' in result['pixi_toml']
+
+    def test_preview_extracts_warnings(self):
+        # A project that triggers the system-python warning surfaces it
+        # in the warnings list — without the caller having to grep the
+        # toml for `# WARNING:`.
+        project = self._make_project("""
+name: PreviewWarn
+packages: []
+platforms:
+  - linux-64
+downloads:
+  DATASET: https://example.com/data.csv
+""")
+        result = project_ops.preview_pixi_export(project)
+        assert any(line.startswith('# WARNING:') for line in result['warnings'])
+        # And the same warning is present in the rendered toml.
+        assert '# WARNING:' in result['pixi_toml']
+
+    def test_preview_default_none_when_already_default(self):
+        project = self._make_project("""
+name: AlreadyDefault
+packages: []
+platforms:
+  - linux-64
+env_specs:
+  default: {}
+""")
+        result = project_ops.preview_pixi_export(project)
+        assert result['default_rename_from'] is None

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -18,6 +18,7 @@ from anaconda_project.internal.pixi_export import (
     PixiExportStatus,
     _conda_spec_to_pixi,
     _expand_defaults_in_channels,
+    current_platform_addition_target,
     default_rename_target,
     _strip_conda_prefix_paths,
     _translate_command_env_vars,
@@ -1183,8 +1184,11 @@ env_specs:
   sampleproj: {}
 """)
         result = project_ops.preview_pixi_export(project, use_default=True)
-        # Stable contract: exactly these three keys.
-        assert set(result) == {'pixi_toml', 'default_rename_from', 'warnings'}
+        # Stable contract: exactly these four keys.
+        assert set(result) == {
+            'pixi_toml', 'default_rename_from',
+            'current_platform_addition_target', 'warnings',
+        }
         assert isinstance(result['pixi_toml'], str)
         assert isinstance(result['warnings'], list)
         # use_default=True actually applies in pixi_toml content
@@ -1241,3 +1245,145 @@ env_specs:
 """)
         result = project_ops.preview_pixi_export(project)
         assert result['default_rename_from'] is None
+
+
+class TestAddCurrentPlatform:
+    """``--add-current-platform`` ensures the host's conda subdir is in the
+    emitted ``platforms`` list. Pixi rejects an env that doesn't list the
+    host platform; anaconda-project is more forgiving."""
+
+    def _make_project(self, yml_content):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, 'anaconda-project.yml'), 'w') as f:
+            f.write(yml_content)
+        return Project(tmpdir)
+
+    @pytest.fixture
+    def fake_platform(self, monkeypatch):
+        """Force current_platform() to return a known value so tests are
+        deterministic across developer machines and CI runners."""
+        from anaconda_project.internal import conda_api
+        monkeypatch.setattr(conda_api, 'current_platform', lambda: 'osx-arm64')
+        return 'osx-arm64'
+
+    def test_picker_returns_platform_when_missing(self, fake_platform):
+        project = self._make_project("""
+name: NotHere
+packages: []
+platforms:
+  - linux-64
+""")
+        assert current_platform_addition_target(project) == 'osx-arm64'
+
+    def test_picker_returns_none_when_already_present(self, fake_platform):
+        project = self._make_project("""
+name: AlreadyHere
+packages: []
+platforms:
+  - linux-64
+  - osx-arm64
+""")
+        assert current_platform_addition_target(project) is None
+
+    def test_export_adds_platform_when_flag_on(self, fake_platform):
+        project = self._make_project("""
+name: AddPlat
+packages: []
+platforms:
+  - linux-64
+""")
+        result = export_pixi_toml(project, add_current_platform=True)
+        # Sorted alphabetically, both present.
+        assert 'platforms = ["linux-64", "osx-arm64"]' in result
+
+    def test_export_leaves_platforms_alone_by_default(self, fake_platform):
+        project = self._make_project("""
+name: NoFlag
+packages: []
+platforms:
+  - linux-64
+""")
+        result = export_pixi_toml(project)
+        # Without the flag the host platform is not added — even if pixi
+        # would later refuse it. anaconda-project doesn't silently mutate
+        # the user's platforms list.
+        assert 'osx-arm64' not in result
+
+    def test_export_no_op_when_already_present(self, fake_platform):
+        project = self._make_project("""
+name: AlreadyOk
+packages: []
+platforms:
+  - linux-64
+  - osx-arm64
+""")
+        result = export_pixi_toml(project, add_current_platform=True)
+        # Still appears exactly once in the platforms list.
+        assert result.count('"osx-arm64"') == 1
+
+    def test_status_carries_platform_added(self, fake_platform, tmpdir):
+        project = self._make_project("""
+name: StatusAdd
+packages: []
+platforms:
+  - linux-64
+""")
+        target = str(tmpdir.join('pixi.toml'))
+        status = project_ops.export_pixi(project, filename=target,
+                                         add_current_platform=True)
+        assert status
+        assert isinstance(status, PixiExportStatus)
+        assert status.current_platform_added == 'osx-arm64'
+
+    def test_status_platform_added_is_none_without_flag(self, fake_platform, tmpdir):
+        project = self._make_project("""
+name: StatusOff
+packages: []
+platforms:
+  - linux-64
+""")
+        target = str(tmpdir.join('pixi.toml'))
+        status = project_ops.export_pixi(project, filename=target)
+        assert status
+        assert status.current_platform_added is None
+
+    def test_status_platform_added_is_none_when_already_present(self, fake_platform, tmpdir):
+        # Flag is on, but the platform is already there — the status
+        # reports None to distinguish "we added X" from "X was there".
+        project = self._make_project("""
+name: StatusNoOp
+packages: []
+platforms:
+  - linux-64
+  - osx-arm64
+""")
+        target = str(tmpdir.join('pixi.toml'))
+        status = project_ops.export_pixi(project, filename=target,
+                                         add_current_platform=True)
+        assert status
+        assert status.current_platform_added is None
+
+    def test_preview_reports_target_even_when_flag_off(self, fake_platform):
+        project = self._make_project("""
+name: PreviewPlat
+packages: []
+platforms:
+  - linux-64
+""")
+        result = project_ops.preview_pixi_export(project)
+        # Candidate is reported regardless of flag — frontends use it to
+        # offer "re-render with --add-current-platform" as an action.
+        assert result['current_platform_addition_target'] == 'osx-arm64'
+        # pixi_toml itself wasn't widened (flag is off).
+        assert 'osx-arm64' not in result['pixi_toml']
+
+    def test_preview_target_none_when_already_present(self, fake_platform):
+        project = self._make_project("""
+name: PreviewOk
+packages: []
+platforms:
+  - linux-64
+  - osx-arm64
+""")
+        result = project_ops.preview_pixi_export(project)
+        assert result['current_platform_addition_target'] is None

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -17,10 +17,12 @@ from anaconda_project.internal.pixi_export import (
     CondaNotAvailableError,
     _conda_spec_to_pixi,
     _expand_defaults_in_channels,
+    _pick_use_default_env,
     _strip_conda_prefix_paths,
     _translate_command_env_vars,
     _windows_to_deno_shell,
     export_pixi_toml,
+    project_would_benefit_from_use_default,
 )
 from anaconda_project.project import Project
 
@@ -218,7 +220,6 @@ commands:
 """)
         result = export_pixi_toml(project)
         assert 'bokeh serve myapp' in result
-        assert '# converted from bokeh_app' in result
 
     def test_notebook_conversion(self):
         project = self._make_project("""
@@ -232,7 +233,6 @@ commands:
 """)
         result = export_pixi_toml(project)
         assert 'jupyter notebook analysis.ipynb' in result
-        assert '# converted from notebook' in result
 
     def test_default_channels_when_empty(self):
         # When the yml declares no channels, fall back to the URLs that
@@ -844,6 +844,201 @@ commands:
         assert 'arg = "iframe_hosts"' not in result
         # No --anaconda-project-X flags appended.
         assert '--anaconda-project-' not in result
+
+
+class TestUseDefault:
+    def _make_project(self, yml_content):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, 'anaconda-project.yml'), 'w') as f:
+            f.write(yml_content)
+        return Project(tmpdir)
+
+    def test_picker_returns_none_when_default_already_present(self):
+        project = self._make_project("""
+name: HasDefault
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  default: {}
+  other:
+    packages: [flask]
+""")
+        assert _pick_use_default_env(project) is None
+        assert project_would_benefit_from_use_default(project) is False
+
+    def test_picker_single_env_returns_that_env(self):
+        project = self._make_project("""
+name: Solo
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        assert _pick_use_default_env(project) == 'sampleproj'
+
+    def test_picker_uses_default_command_env(self):
+        # Two envs, no `default`. The default command's env (here `web`,
+        # explicitly marked default) should be the one promoted.
+        project = self._make_project("""
+name: PickByCommand
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  test:
+    packages: [pytest]
+  web:
+    packages: [flask]
+commands:
+  serve:
+    unix: python -m http.server
+    env_spec: web
+    default: true
+""")
+        assert _pick_use_default_env(project) == 'web'
+
+    def test_picker_falls_back_to_first_env_without_command(self):
+        # No commands → first env_spec wins.
+        project = self._make_project("""
+name: NoCmd
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  zeta:
+    packages: [flask]
+  alpha:
+    packages: [pytest]
+""")
+        assert _pick_use_default_env(project) == 'zeta'
+
+    def test_single_env_collapses_to_top_level(self):
+        # use_default on a single non-default env: deps move from
+        # [feature.{name}.dependencies] to [dependencies], prepare from
+        # [feature.{name}.tasks.prepare] to [tasks.prepare], no
+        # [environments] block needed.
+        project = self._make_project("""
+name: SoloFlat
+packages:
+  - python
+  - flask
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        result = export_pixi_toml(project, use_default=True)
+        assert '[dependencies]' in result
+        assert 'flask = "*"' in result
+        assert '[feature.sampleproj' not in result
+        assert '[tasks.prepare]' in result
+        assert '[environments]' not in result
+
+    def test_multi_env_promotes_default_command_env(self):
+        # Multiple envs, no `default`. With use_default, the default
+        # command's env (`web`) is renamed to `default` — its task lands
+        # in [tasks.serve] (top-level) and its prepare in [tasks.prepare].
+        # The other env still gets a [feature.test.*] block.
+        project = self._make_project("""
+name: MultiPromote
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  web:
+    packages: [flask]
+  test:
+    packages: [pytest]
+commands:
+  serve:
+    unix: python -m http.server
+    env_spec: web
+    default: true
+  pytest-run:
+    unix: pytest
+    env_spec: test
+""")
+        result = export_pixi_toml(project, use_default=True)
+        # `web` collapsed into top-level / default feature.
+        assert 'flask = "*"' in result.split('[feature.', 1)[0]
+        assert '[feature.web' not in result
+        # `serve` (web's command) lives at top-level.
+        assert '[tasks.serve]' in result
+        # `test` env still feature-scoped.
+        assert '[feature.test.dependencies]' in result
+        assert '[feature.test.tasks.pytest-run]' in result
+        # Prepare lands at top level (web is now `default`).
+        assert '[tasks.prepare]' in result
+        assert '[feature.web.tasks.prepare]' not in result
+        # Environments block: web's slot becomes the default-comment line,
+        # and `test` is still declared. Order preserved.
+        env_block = result.split('[environments]', 1)[1]
+        web_pos = env_block.index('# default')
+        test_pos = env_block.index('test = ')
+        assert web_pos < test_pos
+
+    def test_multi_env_promotes_first_when_no_default_command(self):
+        # Multiple envs, no `default`, no commands → first env wins.
+        project = self._make_project("""
+name: MultiNoCmd
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  zeta:
+    packages: [flask]
+  alpha:
+    packages: [pytest]
+""")
+        result = export_pixi_toml(project, use_default=True)
+        assert 'flask = "*"' in result.split('[feature.', 1)[0]
+        assert '[feature.zeta' not in result
+        assert '[feature.alpha.dependencies]' in result
+
+    def test_no_op_when_default_already_present(self):
+        # use_default with a project that already has `default` should be
+        # a no-op; output equals the unflagged export byte-for-byte.
+        project = self._make_project("""
+name: AlreadyDefault
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  default:
+    packages: [flask]
+  other:
+    packages: [pytest]
+""")
+        with_flag = export_pixi_toml(project, use_default=True)
+        without = export_pixi_toml(project, use_default=False)
+        assert with_flag == without
+
+    def test_default_off_keeps_feature_scope(self):
+        # Explicit no use_default on a non-default single env: same
+        # behavior as before — feature-scoped layout.
+        project = self._make_project("""
+name: SoloFeature
+packages:
+  - python
+  - flask
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        result = export_pixi_toml(project, use_default=False)
+        assert '[feature.sampleproj.tasks.prepare]' in result
+        assert '[tasks.prepare]' not in result.replace(
+            '[feature.sampleproj.tasks.prepare]', '')
 
 
 class TestEndToEndCondaPrefixUnification:

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -924,9 +924,10 @@ env_specs:
 
     def test_single_env_collapses_to_top_level(self):
         # use_default on a single non-default env: deps move from
-        # [feature.{name}.dependencies] to [dependencies], prepare from
-        # [feature.{name}.tasks.prepare] to [tasks.prepare], no
-        # [environments] block needed.
+        # [feature.{name}.dependencies] to [dependencies], no
+        # [environments] block needed, and the no-op prepare task is
+        # dropped (under use_default the marker echo is unnecessary —
+        # see test_use_default_omits_prepare_when_no_downloads).
         project = self._make_project("""
 name: SoloFlat
 packages:
@@ -941,8 +942,9 @@ env_specs:
         assert '[dependencies]' in result
         assert 'flask = "*"' in result
         assert '[feature.sampleproj' not in result
-        assert '[tasks.prepare]' in result
         assert '[environments]' not in result
+        # No prepare task at all when use_default + no downloads.
+        assert 'prepare' not in result
 
     def test_multi_env_promotes_default_command_env(self):
         # Multiple envs, no `default`. With use_default, the default
@@ -978,9 +980,8 @@ commands:
         # `test` env still feature-scoped.
         assert '[feature.test.dependencies]' in result
         assert '[feature.test.tasks.pytest-run]' in result
-        # Prepare lands at top level (web is now `default`).
-        assert '[tasks.prepare]' in result
-        assert '[feature.web.tasks.prepare]' not in result
+        # No prepare task at all under use_default + no downloads.
+        assert 'prepare' not in result
         # Environments block: web's slot becomes the default-comment line,
         # and `test` is still declared. Order preserved.
         env_block = result.split('[environments]', 1)[1]
@@ -1043,6 +1044,46 @@ env_specs:
         assert '[feature.sampleproj.tasks.prepare]' in result
         assert '[tasks.prepare]' not in result.replace(
             '[feature.sampleproj.tasks.prepare]', '')
+
+    def test_use_default_omits_prepare_when_no_downloads(self):
+        # The two reasons we *normally* emit a no-op prepare task —
+        #   (1) env-selection entry point for non-default-named envs,
+        #   (2) marker for "this came from anaconda-project.yml" —
+        # both lose force under use_default: the renamed env *is* the
+        # implicit default, top-level tasks already resolve to it, and
+        # the marker isn't load-bearing. So drop the empty prepare
+        # rather than carry a redundant `echo` task.
+        project = self._make_project("""
+name: NoPrepare
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        result = export_pixi_toml(project, use_default=True)
+        assert 'prepare' not in result
+
+    def test_use_default_keeps_prepare_when_downloads_exist(self):
+        # Downloads still need to be fetched. use_default doesn't change
+        # that — the prepare task is real work, not a marker, so it must
+        # be emitted regardless.
+        project = self._make_project("""
+name: WithDownload
+packages:
+  - python
+platforms:
+  - linux-64
+downloads:
+  DATA: https://example.com/data.csv
+env_specs:
+  sampleproj: {}
+""")
+        result = export_pixi_toml(project, use_default=True)
+        assert '[tasks.prepare]' in result
+        assert 'python3 ap_download.py' in result
+        assert 'data.csv' in result
 
 
 class TestEndToEndCondaPrefixUnification:

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -278,6 +278,39 @@ downloads:
         # Old comment-only path is gone.
         assert '# Downloads from anaconda-project.yml' not in result
 
+    def test_downloads_with_checksum_emit_hash_flag(self):
+        # When the yml declares a checksum, the helper invocation passes
+        # it as `--<algo> <hex>` so the helper verifies post-download.
+        project = self._make_project("""
+name: DlChecksum
+packages: []
+platforms:
+  - linux-64
+downloads:
+  DATASET:
+    url: https://example.com/data.csv
+    sha256: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+""")
+        result = export_pixi_toml(project)
+        assert 'python3 ap_download.py' in result
+        assert ('--sha256 "0123456789abcdef0123456789abcdef'
+                '0123456789abcdef0123456789abcdef"') in result
+
+    def test_downloads_without_checksum_omit_hash_flag(self):
+        # Bare-url download (no checksum block) must not emit a flag.
+        project = self._make_project("""
+name: DlNoChecksum
+packages: []
+platforms:
+  - linux-64
+downloads:
+  DATASET: https://example.com/data.csv
+""")
+        result = export_pixi_toml(project)
+        assert 'python3 ap_download.py' in result
+        for algo in ('md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'):
+            assert '--{}'.format(algo) not in result
+
     def test_marker_prepare_when_no_downloads(self):
         # Even without downloads, every converted project gets a
         # `prepare` task. It does double duty:

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -14,7 +14,11 @@ from collections import namedtuple
 import os
 import platform
 import sys
-from jinja2 import Template
+
+# `jinja2.Template` is only used inside `_TemplateArgsTransformer.parse_and_template`
+# at command-execution time. Importing it eagerly costs ~20 ms on every
+# `import anaconda_project.project`, which `publication_info` and other
+# read-only consumers don't need to pay for.
 
 from anaconda_project.verbose import _verbose_logger
 from anaconda_project.internal import (conda_api, logged_subprocess, py2_compat)
@@ -155,6 +159,7 @@ class _TemplateArgsTransformer(_ArgsTransformer):
         items.update(replacements)
         items.update(environ)
 
+        from jinja2 import Template
         normalized = {self.arg_to_identifier(k): v for k, v in items.items()}
         templated_command = Template(command).render(normalized)
         return [_append_extra_args_to_command_line(templated_command, extra_args)]

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -86,6 +86,29 @@ def _anaconda_project_publication_info(project_dir):
     return Project(project_dir).publication_info()
 
 
+def _read_pixi_lock_envs(project_dir):
+    """Return the set of environment names that appear in pixi.lock, or
+    empty if the lockfile is missing, malformed, or can't be loaded.
+
+    Failure is silent by design: lock detection is informational; the
+    rest of publication_info should never break because of a corrupt
+    lockfile.
+    """
+    lock_path = os.path.join(project_dir, 'pixi.lock')
+    try:
+        import yaml
+        with open(lock_path, 'r') as f:
+            lock = yaml.safe_load(f)
+    except Exception:
+        return set()
+    if not isinstance(lock, dict):
+        return set()
+    envs = lock.get('environments')
+    if not isinstance(envs, dict):
+        return set()
+    return set(envs.keys())
+
+
 def _pixi_publication_info(project_dir):
     pixi_path = os.path.join(project_dir, PIXI_MANIFEST)
     try:
@@ -93,6 +116,8 @@ def _pixi_publication_info(project_dir):
             data = tomllib.load(f)
     except (OSError, tomllib.TOMLDecodeError) as e:
         raise ValueError('Failed to parse {}: {}'.format(pixi_path, e)) from e
+
+    locked_envs = _read_pixi_lock_envs(project_dir)
 
     workspace = data.get('workspace', {})
     project_meta = data.get('project', {})
@@ -182,6 +207,7 @@ def _pixi_publication_info(project_dir):
         'default': {
             'packages': _packages_for_env(declared_envs.get('default')),
             'channels': channels,
+            'locked': default_env_name in locked_envs,
         },
     }
     for env_name, env_def in declared_envs.items():
@@ -190,6 +216,7 @@ def _pixi_publication_info(project_dir):
         env_specs[env_name] = {
             'packages': _packages_for_env(env_def),
             'channels': channels,
+            'locked': env_name in locked_envs,
         }
 
     variables = dict(data.get('activation', {}).get('env', {}))

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -121,22 +121,39 @@ def _pixi_publication_info(project_dir):
     top_packages = [
         _format_dep(pkg, spec) for pkg, spec in data.get('dependencies', {}).items()
     ]
+
+    def _packages_for_env(env_def):
+        """Resolve effective package list for a declared env: top-level
+        [dependencies] (the default feature) plus each feature listed in
+        the env's `features = [...]`. An env declared with
+        `no-default-feature = true` does not inherit the default feature."""
+        if env_def is None:
+            return list(top_packages)
+        features = env_def if isinstance(env_def, list) else env_def.get('features', [])
+        no_default = (
+            isinstance(env_def, dict) and env_def.get('no-default-feature', False)
+        )
+        pkgs = [] if no_default else list(top_packages)
+        for feat in features:
+            feat_deps = data.get('feature', {}).get(feat, {}).get('dependencies', {})
+            pkgs.extend(_format_dep(n, s) for n, s in feat_deps.items())
+        return pkgs
+
+    # Pixi always materializes a `default` env, even when not declared in
+    # [environments]. Surface it unconditionally; honor the user's
+    # declaration if one exists.
+    declared_envs = data.get('environments', {})
     env_specs = {
         'default': {
-            'packages': top_packages,
+            'packages': _packages_for_env(declared_envs.get('default')),
             'channels': channels,
         },
     }
-    for env_name, env_def in data.get('environments', {}).items():
+    for env_name, env_def in declared_envs.items():
         if env_name == 'default':
             continue
-        features = env_def if isinstance(env_def, list) else env_def.get('features', [])
-        feature_pkgs = list(top_packages)
-        for feat in features:
-            feat_deps = data.get('feature', {}).get(feat, {}).get('dependencies', {})
-            feature_pkgs.extend(_format_dep(n, s) for n, s in feat_deps.items())
         env_specs[env_name] = {
-            'packages': feature_pkgs,
+            'packages': _packages_for_env(env_def),
             'channels': channels,
         }
 

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -102,11 +102,45 @@ def _pixi_publication_info(project_dir):
 
     tool_commands = data.get('tool', {}).get('anaconda', {}).get('commands', {})
 
+    # Resolve the name of pixi's implicit `default` environment to the
+    # user-meaningful env_spec it actually represents. Pixi always
+    # materializes a `default` env from the default feature; the
+    # exporter (and anaconda-project's own publication_info) report the
+    # resolved name, not the placeholder. Logic mirrors the exporter:
+    # a literal `default` in [environments] wins; otherwise fall back
+    # to the first declared environment.
+    declared_envs = data.get('environments', {})
+    if 'default' in declared_envs:
+        default_env_name = 'default'
+    elif declared_envs:
+        default_env_name = next(iter(declared_envs))
+    else:
+        default_env_name = 'default'
+
+    # For tasks defined under [feature.X.tasks.Y], pixi runs them in any
+    # env that includes feature X. publication_info should report a
+    # specific env that "supports this task": prefer the resolved
+    # default if it includes the feature, else the first declared env
+    # that does, else fall back to the feature name itself (which is
+    # what our own exporter uses — feature name matches env name in the
+    # converted manifests).
+    def _env_for_feature(feat_name):
+        candidate_envs = []
+        for env_name, env_def in declared_envs.items():
+            features = env_def if isinstance(env_def, list) else env_def.get('features', [])
+            if feat_name in features:
+                candidate_envs.append(env_name)
+        if not candidate_envs:
+            return feat_name
+        if default_env_name in candidate_envs:
+            return default_env_name
+        return candidate_envs[0]
+
     commands = {}
     state = {'first': True}
 
     for task_name, task_def in data.get('tasks', {}).items():
-        cmd = _build_command(task_name, task_def, 'default', tool_commands, state)
+        cmd = _build_command(task_name, task_def, default_env_name, tool_commands, state)
         if cmd is not None:
             commands[task_name] = cmd
 
@@ -114,7 +148,9 @@ def _pixi_publication_info(project_dir):
         for task_name, task_def in feat_def.get('tasks', {}).items():
             if task_name in commands:
                 continue
-            cmd = _build_command(task_name, task_def, feat_name, tool_commands, state)
+            cmd = _build_command(task_name, task_def,
+                                 _env_for_feature(feat_name),
+                                 tool_commands, state)
             if cmd is not None:
                 commands[task_name] = cmd
 
@@ -139,10 +175,9 @@ def _pixi_publication_info(project_dir):
             pkgs.extend(_format_dep(n, s) for n, s in feat_deps.items())
         return pkgs
 
-    # Pixi always materializes a `default` env, even when not declared in
-    # [environments]. Surface it unconditionally; honor the user's
+    # Pixi always materializes a `default` env, even when [environments]
+    # only declares others. Surface it unconditionally; honor the user's
     # declaration if one exists.
-    declared_envs = data.get('environments', {})
     env_specs = {
         'default': {
             'packages': _packages_for_env(declared_envs.get('default')),

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -197,7 +197,23 @@ def _format_dep(name, spec):
     return name
 
 
+# Commands we recognize as actual Jupyter notebook launchers. Anything
+# else that mentions an .ipynb file (e.g. `panel serve foo.ipynb`,
+# `voila foo.ipynb`, `streamlit run foo.ipynb`) is a different kind of
+# app — it happens to consume an .ipynb as its source but isn't
+# something a notebook viewer should render.
+_NOTEBOOK_LAUNCHERS = (
+    'jupyter notebook',
+    'jupyter lab',
+    'jupyter-lab',
+    'jupyter-notebook',
+)
+
+
 def _infer_notebook(cmd_str):
+    cmd_lower = cmd_str.lower()
+    if not any(launcher in cmd_lower for launcher in _NOTEBOOK_LAUNCHERS):
+        return None
     for token in cmd_str.split():
         if token.endswith('.ipynb'):
             return token

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -171,12 +171,29 @@ def _pixi_publication_info(project_dir):
 def _build_command(task_name, task_def, env_spec, tool_commands, state):
     if isinstance(task_def, str):
         cmd_str = task_def
+        raw_args = []
     elif isinstance(task_def, dict):
         cmd_str = task_def.get('cmd', '')
         if task_def.get('environment'):
             env_spec = task_def['environment']
+        raw_args = task_def.get('args') or []
     else:
         return None
+
+    # Pixi `args` entries are inline tables like { arg = "port", default = "" }
+    # or bare strings like "name". Pull just the names, in declaration order;
+    # downstream tooling uses this to know which positional values to supply
+    # to `pixi run <task>`.
+    args = []
+    for entry in raw_args:
+        if isinstance(entry, dict):
+            name = entry.get('arg')
+        elif isinstance(entry, str):
+            name = entry
+        else:
+            name = None
+        if name:
+            args.append(name)
 
     tool_meta = tool_commands.get(task_name, {})
 
@@ -203,6 +220,7 @@ def _build_command(task_name, task_def, env_spec, tool_commands, state):
         'notebook': notebook,
         'default': is_default,
         'description': description,
+        'args': args,
     }
 
 

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -54,29 +54,52 @@ def detect_project_type(project_dir):
     return None
 
 
-def publication_info(project_dir):
+def publication_info(project_dir, project_type=None):
     """Return a publication-info dict for the project at *project_dir*.
 
-    If ``pixi.toml`` is present, the pixi manifest is parsed directly. Otherwise
-    ``anaconda-project.yml`` is loaded through :class:`Project`. The returned
-    dict always includes a ``project_type`` key identifying which manifest
-    format was used.
+    With *project_type* unset (the default), ``pixi.toml`` is preferred when
+    present and ``anaconda-project.yml`` is loaded through :class:`Project`
+    otherwise. Pass ``project_type='pixi'`` or ``'anaconda-project'`` to force
+    a specific manifest format; it is an error to ask for a format whose
+    manifest is not present in *project_dir*. The returned dict always
+    includes a ``project_type`` key identifying which manifest format was
+    used.
 
     Raises:
-        ValueError: the pixi manifest cannot be parsed.
-        FileNotFoundError: neither manifest is present.
+        ValueError: *project_type* is not a recognized value, or the pixi
+            manifest cannot be parsed.
+        FileNotFoundError: the requested manifest (or, with no
+            *project_type*, neither manifest) is not present.
     """
-    project_type = detect_project_type(project_dir)
-    if project_type == PROJECT_TYPE_PIXI:
-        info = _pixi_publication_info(project_dir)
+    if project_type is None:
+        project_type = detect_project_type(project_dir)
+        if project_type is None:
+            raise FileNotFoundError(
+                'No {} or {} found in {}'.format(
+                    PIXI_MANIFEST, ANACONDA_PROJECT_MANIFEST, project_dir
+                )
+            )
+    elif project_type == PROJECT_TYPE_PIXI:
+        if not os.path.isfile(os.path.join(project_dir, PIXI_MANIFEST)):
+            raise FileNotFoundError(
+                'No {} found in {}'.format(PIXI_MANIFEST, project_dir)
+            )
     elif project_type == PROJECT_TYPE_ANACONDA_PROJECT:
-        info = _anaconda_project_publication_info(project_dir)
+        if not os.path.isfile(os.path.join(project_dir, ANACONDA_PROJECT_MANIFEST)):
+            raise FileNotFoundError(
+                'No {} found in {}'.format(ANACONDA_PROJECT_MANIFEST, project_dir)
+            )
     else:
-        raise FileNotFoundError(
-            'No {} or {} found in {}'.format(
-                PIXI_MANIFEST, ANACONDA_PROJECT_MANIFEST, project_dir
+        raise ValueError(
+            'Unknown project_type {!r}; expected {!r} or {!r}'.format(
+                project_type, PROJECT_TYPE_PIXI, PROJECT_TYPE_ANACONDA_PROJECT
             )
         )
+
+    if project_type == PROJECT_TYPE_PIXI:
+        info = _pixi_publication_info(project_dir)
+    else:
+        info = _anaconda_project_publication_info(project_dir)
     info[PROJECT_TYPE_KEY] = project_type
     return info
 

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -54,7 +54,7 @@ def detect_project_type(project_dir):
     return None
 
 
-def publication_info(project_dir, project_type=None):
+def publication_info(project_dir, project_type=None, env_paths=False):
     """Return a publication-info dict for the project at *project_dir*.
 
     With *project_type* unset (the default), ``pixi.toml`` is preferred when
@@ -65,11 +65,19 @@ def publication_info(project_dir, project_type=None):
     includes a ``project_type`` key identifying which manifest format was
     used.
 
+    Pass ``env_paths=True`` to populate ``info['env_specs'][name]['path']``
+    with the filesystem prefix for each declared environment. For
+    anaconda-project this is computed from each :class:`EnvSpec` and is
+    free; for pixi we shell out to ``pixi info --json`` (so it costs a
+    subprocess) and surface any error from that call.
+
     Raises:
         ValueError: *project_type* is not a recognized value, or the pixi
             manifest cannot be parsed.
         FileNotFoundError: the requested manifest (or, with no
             *project_type*, neither manifest) is not present.
+        RuntimeError: ``env_paths=True`` was requested for a pixi project
+            and ``pixi info --json`` failed.
     """
     if project_type is None:
         project_type = detect_project_type(project_dir)
@@ -98,15 +106,52 @@ def publication_info(project_dir, project_type=None):
 
     if project_type == PROJECT_TYPE_PIXI:
         info = _pixi_publication_info(project_dir)
+        if env_paths:
+            _attach_pixi_env_paths(info, project_dir)
     else:
-        info = _anaconda_project_publication_info(project_dir)
+        info = _anaconda_project_publication_info(project_dir, env_paths=env_paths)
     info[PROJECT_TYPE_KEY] = project_type
     return info
 
 
-def _anaconda_project_publication_info(project_dir):
+def _anaconda_project_publication_info(project_dir, env_paths=False):
     from anaconda_project.project import Project
-    return Project(project_dir).publication_info()
+    project = Project(project_dir)
+    info = project.publication_info()
+    if env_paths:
+        for name, env in project.env_specs.items():
+            if name in info['env_specs']:
+                info['env_specs'][name]['path'] = env.path(project_dir)
+    return info
+
+
+def _attach_pixi_env_paths(info, project_dir):
+    """Fill in ``info['env_specs'][name]['path']`` from ``pixi info --json``.
+
+    Pixi reports prefixes in ``environments_info[].prefix``. Any failure to
+    invoke pixi or parse its output raises :class:`RuntimeError` — callers
+    only ask for env paths explicitly via ``env_paths=True``, so silent
+    fallback would hide bugs.
+    """
+    import json
+    import subprocess
+    pixi_path = os.path.join(project_dir, PIXI_MANIFEST)
+    try:
+        out = subprocess.check_output(
+            ['pixi', 'info', '--json', '--manifest-path', pixi_path],
+            stderr=subprocess.PIPE,
+        )
+    except (OSError, subprocess.CalledProcessError) as e:
+        raise RuntimeError('Failed to run `pixi info --json`: {}'.format(e)) from e
+    try:
+        data = json.loads(out)
+    except ValueError as e:
+        raise RuntimeError('Could not parse `pixi info --json` output: {}'.format(e)) from e
+    for env in data.get('environments_info', []):
+        name = env.get('name')
+        prefix = env.get('prefix')
+        if name in info['env_specs'] and prefix:
+            info['env_specs'][name]['path'] = prefix
 
 
 def _read_pixi_lock_envs(project_dir):

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -357,6 +357,13 @@ def _build_command(task_name, task_def, env_spec, tool_commands, state):
 
 
 def _format_dep(name, spec):
+    # Pixi inline-table specs like `numpy = { version = ">=2.0" }` arrive
+    # as a dict; pull the version out so the round-trip keeps the
+    # constraint instead of dropping to a bare package name. Other dict
+    # keys (channel, build, etc.) don't have a place in the conda spec
+    # string form we emit, so we ignore them.
+    if isinstance(spec, dict):
+        spec = spec.get('version')
     if isinstance(spec, str) and spec not in ('*', ''):
         if spec[0].isdigit():
             return '{}={}'.format(name, spec)

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -126,7 +126,8 @@ def _anaconda_project_publication_info(project_dir, env_paths=False):
 
 
 def _attach_pixi_env_paths(info, project_dir):
-    """Fill in ``info['env_specs'][name]['path']`` from ``pixi info --json``.
+    """Fill in ``info['env_specs'][name]['path']`` and stash the full
+    ``pixi info --json`` payload at ``info['_pixi']``.
 
     Pixi reports prefixes in ``environments_info[].prefix``. Any failure to
     invoke pixi or parse its output raises :class:`RuntimeError` — callers
@@ -152,6 +153,7 @@ def _attach_pixi_env_paths(info, project_dir):
         prefix = env.get('prefix')
         if name in info['env_specs'] and prefix:
             info['env_specs'][name]['path'] = prefix
+    info['_pixi'] = data
 
 
 def _read_pixi_lock_envs(project_dir):

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -625,7 +625,7 @@ def export_env_spec(project, name, filename):
     return SimpleStatus(success=True, description="Exported environment spec {} to {}.".format(name, filename))
 
 
-def export_pixi(project, filename, use_default=False):
+def export_pixi(project, filename, use_default=False, add_current_platform=False):
     """Export the project as a pixi.toml file.
 
     Returns a ``Status`` subtype.
@@ -640,10 +640,15 @@ def export_pixi(project, filename, use_default=False):
             default environment with packages, commands, and the prepare
             task at the top level instead of inside a ``[feature.{name}.*]``
             block.
+        add_current_platform (bool): if True, ensure the host's conda subdir
+            is in the emitted ``platforms`` list. Pixi rejects an env that
+            doesn't list the host platform; anaconda-project is more
+            forgiving, so this prevents a pixi install error on a project
+            whose ``platforms:`` list happens to omit the developer's box.
 
     Returns:
-        ``PixiExportStatus`` on success (carries ``default_rename_from``);
-        a plain ``Status`` on failure.
+        ``PixiExportStatus`` on success (carries ``default_rename_from``
+        and ``current_platform_added``); a plain ``Status`` on failure.
     """
     failed = _check_problems(project)
     if failed is not None:
@@ -651,12 +656,16 @@ def export_pixi(project, filename, use_default=False):
 
     from anaconda_project.internal.pixi_export import (
         CondaNotAvailableError, DOWNLOAD_HELPER_FILENAME, PixiExportStatus,
-        default_rename_target, export_pixi_toml, extract_warnings,
+        current_platform_addition_target, default_rename_target,
+        export_pixi_toml, extract_warnings,
     )
     import sys
     rename_from = default_rename_target(project) if use_default else None
+    platform_added = (current_platform_addition_target(project)
+                      if add_current_platform else None)
     try:
-        content = export_pixi_toml(project, use_default=use_default)
+        content = export_pixi_toml(project, use_default=use_default,
+                                   add_current_platform=add_current_platform)
     except CondaNotAvailableError as e:
         return SimpleStatus(
             success=False,
@@ -683,13 +692,14 @@ def export_pixi(project, filename, use_default=False):
     return PixiExportStatus(
         success=True,
         description="Exported project to {}.".format(filename),
-        default_rename_from=rename_from)
+        default_rename_from=rename_from,
+        current_platform_added=platform_added)
 
 
-def preview_pixi_export(project, use_default=False):
+def preview_pixi_export(project, use_default=False, add_current_platform=False):
     """Render the pixi.toml conversion in memory without writing to disk.
 
-    Returns a dict with three keys, suitable for driving a preview UI
+    Returns a dict with four keys, suitable for driving a preview UI
     (CLI ``--dry-run``, IDE plugin dialog, launcher confirmation, etc.):
 
     * ``pixi_toml`` (str): the full ``pixi.toml`` content the exporter
@@ -700,6 +710,12 @@ def preview_pixi_export(project, use_default=False):
       ``None`` when the project already has a ``default`` env_spec, has
       no env_specs, or has nothing to rename. Frontends use this to
       offer "re-render with --use-default" as an action.
+    * ``current_platform_addition_target`` (str or None): the host's conda
+      subdir if it would be added to the platform list by
+      ``add_current_platform`` (regardless of whether the flag was
+      passed), or ``None`` when it's already declared. Frontends use
+      this to offer "re-render with --add-current-platform" as an
+      action — pixi rejects envs that don't list the host platform.
     * ``warnings`` (list of str): the lines of the leading
       ``# WARNING:`` block the exporter included at the top of the file,
       or ``[]`` if there are none. Already extracted so the caller
@@ -715,17 +731,25 @@ def preview_pixi_export(project, use_default=False):
         use_default (bool): same semantics as ``export_pixi``; controls
             the content of ``pixi_toml`` but not ``default_rename_from``
             (which is reported regardless).
+        add_current_platform (bool): same semantics as ``export_pixi``;
+            controls the content of ``pixi_toml`` but not
+            ``current_platform_addition_target`` (which is reported
+            regardless).
 
     Returns:
         dict
     """
     from anaconda_project.internal.pixi_export import (
-        default_rename_target, export_pixi_toml, extract_warnings,
+        current_platform_addition_target, default_rename_target,
+        export_pixi_toml, extract_warnings,
     )
-    pixi_toml = export_pixi_toml(project, use_default=use_default)
+    pixi_toml = export_pixi_toml(project, use_default=use_default,
+                                 add_current_platform=add_current_platform)
     return {
         'pixi_toml': pixi_toml,
         'default_rename_from': default_rename_target(project),
+        'current_platform_addition_target':
+            current_platform_addition_target(project),
         'warnings': extract_warnings(pixi_toml),
     }
 

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -641,10 +641,17 @@ def export_pixi(project, filename):
     if failed is not None:
         return failed
 
-    from anaconda_project.internal.pixi_export import export_pixi_toml, DOWNLOAD_HELPER_FILENAME
+    from anaconda_project.internal.pixi_export import (
+        CondaNotAvailableError, DOWNLOAD_HELPER_FILENAME, export_pixi_toml,
+    )
     import sys
     try:
         content = export_pixi_toml(project)
+    except CondaNotAvailableError as e:
+        return SimpleStatus(
+            success=False,
+            description="Cannot export to pixi: {}".format(e))
+    try:
         with open(filename, 'w') as f:
             f.write(content)
         # If the converted manifest invokes ap_download.py, drop the helper

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -642,16 +642,19 @@ def export_pixi(project, filename, use_default=False):
             block.
 
     Returns:
-        ``Status`` instance
+        ``PixiExportStatus`` on success (carries ``default_rename_from``);
+        a plain ``Status`` on failure.
     """
     failed = _check_problems(project)
     if failed is not None:
         return failed
 
     from anaconda_project.internal.pixi_export import (
-        CondaNotAvailableError, DOWNLOAD_HELPER_FILENAME, export_pixi_toml,
+        CondaNotAvailableError, DOWNLOAD_HELPER_FILENAME, PixiExportStatus,
+        default_rename_target, export_pixi_toml, extract_warnings,
     )
     import sys
+    rename_from = default_rename_target(project) if use_default else None
     try:
         content = export_pixi_toml(project, use_default=use_default)
     except CondaNotAvailableError as e:
@@ -671,21 +674,60 @@ def export_pixi(project, filename, use_default=False):
             shutil.copyfile(helper_src, helper_dst)
         # Surface any warnings the exporter wrote to the file so the user
         # sees them immediately rather than only on later inspection.
-        warning_lines = []
-        in_warning = False
-        for line in content.splitlines():
-            if line.startswith('# WARNING:'):
-                in_warning = True
-            if in_warning:
-                if line == '':
-                    break
-                warning_lines.append(line)
+        warning_lines = extract_warnings(content)
         if warning_lines:
             print('\n'.join(warning_lines), file=sys.stderr)
     except Exception as e:
         return SimpleStatus(success=False, description="Failed to save {}: {}.".format(filename, str(e)))
 
-    return SimpleStatus(success=True, description="Exported project to {}.".format(filename))
+    return PixiExportStatus(
+        success=True,
+        description="Exported project to {}.".format(filename),
+        default_rename_from=rename_from)
+
+
+def preview_pixi_export(project, use_default=False):
+    """Render the pixi.toml conversion in memory without writing to disk.
+
+    Returns a dict with three keys, suitable for driving a preview UI
+    (CLI ``--dry-run``, IDE plugin dialog, launcher confirmation, etc.):
+
+    * ``pixi_toml`` (str): the full ``pixi.toml`` content the exporter
+      would write.
+    * ``default_rename_from`` (str or None): the env_spec name that would
+      be promoted to ``default`` if ``use_default`` were passed
+      (regardless of whether ``use_default`` was actually requested) —
+      ``None`` when the project already has a ``default`` env_spec, has
+      no env_specs, or has nothing to rename. Frontends use this to
+      offer "re-render with --use-default" as an action.
+    * ``warnings`` (list of str): the lines of the leading
+      ``# WARNING:`` block the exporter included at the top of the file,
+      or ``[]`` if there are none. Already extracted so the caller
+      doesn't have to scan the toml again.
+
+    Raises ``CondaNotAvailableError`` if the conversion needs ``conda
+    config --show default_channels`` and conda isn't reachable. Failure
+    of project-problem checks raises through the caller's normal channel
+    for that — a project with problems is not previewable.
+
+    Args:
+        project (Project): the project
+        use_default (bool): same semantics as ``export_pixi``; controls
+            the content of ``pixi_toml`` but not ``default_rename_from``
+            (which is reported regardless).
+
+    Returns:
+        dict
+    """
+    from anaconda_project.internal.pixi_export import (
+        default_rename_target, export_pixi_toml, extract_warnings,
+    )
+    pixi_toml = export_pixi_toml(project, use_default=use_default)
+    return {
+        'pixi_toml': pixi_toml,
+        'default_rename_from': default_rename_target(project),
+        'warnings': extract_warnings(pixi_toml),
+    }
 
 
 def add_packages(project, env_spec_name, packages, channels, pip=False):

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -625,7 +625,7 @@ def export_env_spec(project, name, filename):
     return SimpleStatus(success=True, description="Exported environment spec {} to {}.".format(name, filename))
 
 
-def export_pixi(project, filename):
+def export_pixi(project, filename, use_default=False):
     """Export the project as a pixi.toml file.
 
     Returns a ``Status`` subtype.
@@ -633,6 +633,13 @@ def export_pixi(project, filename):
     Args:
         project (Project): the project
         filename (str): file to export to
+        use_default (bool): if True and the project has no env_spec literally
+            named ``default``, rename the env_spec attached to the default
+            command (or, failing that, the first declared env_spec) to
+            ``default`` on export, so it materializes as pixi's implicit
+            default environment with packages, commands, and the prepare
+            task at the top level instead of inside a ``[feature.{name}.*]``
+            block.
 
     Returns:
         ``Status`` instance
@@ -646,7 +653,7 @@ def export_pixi(project, filename):
     )
     import sys
     try:
-        content = export_pixi_toml(project)
+        content = export_pixi_toml(project, use_default=use_default)
     except CondaNotAvailableError as e:
         return SimpleStatus(
             success=False,

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -641,11 +641,33 @@ def export_pixi(project, filename):
     if failed is not None:
         return failed
 
-    from anaconda_project.internal.pixi_export import export_pixi_toml
+    from anaconda_project.internal.pixi_export import export_pixi_toml, DOWNLOAD_HELPER_FILENAME
+    import sys
     try:
         content = export_pixi_toml(project)
         with open(filename, 'w') as f:
             f.write(content)
+        # If the converted manifest invokes ap_download.py, drop the helper
+        # next to pixi.toml so `pixi run prepare` has the script available.
+        if DOWNLOAD_HELPER_FILENAME in content:
+            helper_src = os.path.join(os.path.dirname(__file__),
+                                      'internal', DOWNLOAD_HELPER_FILENAME)
+            helper_dst = os.path.join(os.path.dirname(filename) or '.',
+                                      DOWNLOAD_HELPER_FILENAME)
+            shutil.copyfile(helper_src, helper_dst)
+        # Surface any warnings the exporter wrote to the file so the user
+        # sees them immediately rather than only on later inspection.
+        warning_lines = []
+        in_warning = False
+        for line in content.splitlines():
+            if line.startswith('# WARNING:'):
+                in_warning = True
+            if in_warning:
+                if line == '':
+                    break
+                warning_lines.append(line)
+        if warning_lines:
+            print('\n'.join(warning_lines), file=sys.stderr)
     except Exception as e:
         return SimpleStatus(success=False, description="Failed to save {}: {}.".format(filename, str(e)))
 

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -215,6 +215,36 @@ class TestPublicationInfoTasks:
             assert info['commands']['serve']['unix'] == 'flask run'
             assert info['commands']['serve']['supports_http_options'] is True
 
+    def test_args_extracted_from_pixi_task(self):
+        # The exporter emits `args = [{ arg = "host", default = "" }, ...]`
+        # for tasks that take http options. publication_info should
+        # surface those arg names (in declaration order) so callers can
+        # know what positional values `pixi run <task>` expects.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [tasks.serve]
+                cmd = "panel serve foo.ipynb {% if port %}--port {{ port }}{% endif %}"
+                args = [{ arg = "host", default = "" }, { arg = "port", default = "" }]
+            """))
+            info = publication_info(td)
+            assert info['commands']['serve']['args'] == ['host', 'port']
+
+    def test_args_empty_for_string_task(self):
+        # A bare string task (no `args` key) gets an empty `args` list,
+        # not a missing key — keeps the schema uniform for callers.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks]\nrun = "echo hi"\n',
+            )
+            info = publication_info(td)
+            assert info['commands']['run']['args'] == []
+
     def test_first_task_is_default(self):
         with tempfile.TemporaryDirectory() as td:
             _write_pixi_toml(

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -331,6 +331,86 @@ class TestPublicationInfoFeatures:
             assert 'pytorch' in info['env_specs']['gpu']['packages']
             assert 'python>=3.12' in info['env_specs']['gpu']['packages']
 
+    def test_no_default_feature_excludes_top_level_deps(self):
+        # An env declared with `no-default-feature = true` must not inherit
+        # the top-level [dependencies] (the default feature).
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [dependencies]
+                pandas = "*"
+                python = ">=3.12"
+
+                [feature.testenv.dependencies]
+                ipykernel = "*"
+                pandas = "*"
+
+                [environments]
+                sampleproj = { features = ["testenv"] }
+                testenv = { features = ["testenv"], no-default-feature = true }
+            """))
+            info = publication_info(td)
+            sample = info['env_specs']['sampleproj']['packages']
+            test = info['env_specs']['testenv']['packages']
+            # sampleproj inherits the default feature -> python is present
+            assert 'python>=3.12' in sample
+            assert 'pandas' in sample
+            assert 'ipykernel' in sample
+            # testenv opts out of the default feature -> python is absent
+            assert 'python>=3.12' not in test
+            assert 'ipykernel' in test
+            assert 'pandas' in test
+
+    def test_default_env_always_present(self):
+        # Pixi always materializes a `default` env. publication_info must
+        # surface it even when [environments] only declares other envs.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [dependencies]
+                python = ">=3.12"
+
+                [feature.alt.dependencies]
+                numpy = "*"
+
+                [environments]
+                alt = { features = ["alt"] }
+            """))
+            info = publication_info(td)
+            assert 'default' in info['env_specs']
+            assert 'python>=3.12' in info['env_specs']['default']['packages']
+
+    def test_default_env_honors_declaration(self):
+        # When the user explicitly declares `default = { features = [...] }`,
+        # the resulting default env_spec must include those feature deps.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [dependencies]
+                python = ">=3.12"
+
+                [feature.extras.dependencies]
+                requests = "*"
+
+                [environments]
+                default = { features = ["extras"] }
+            """))
+            info = publication_info(td)
+            assert 'requests' in info['env_specs']['default']['packages']
+            assert 'python>=3.12' in info['env_specs']['default']['packages']
+
 
 class TestPublicationInfoVariables:
     def test_activation_env(self):

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -131,7 +131,9 @@ class TestPublicationInfoBasic:
             assert info['name'] == 'test'
             assert info['description'] == ''
             assert info['commands'] == {}
-            assert info['env_specs'] == {'default': {'packages': [], 'channels': ['conda-forge']}}
+            assert info['env_specs'] == {
+                'default': {'packages': [], 'channels': ['conda-forge'], 'locked': False},
+            }
             assert info['variables'] == {}
             assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
 
@@ -418,6 +420,65 @@ class TestPublicationInfoEnvResolution:
             # Both default-feature and sampleproj-feature packages roll up.
             assert 'python' in info['env_specs']['sampleproj']['packages']
             assert 'pandas' in info['env_specs']['sampleproj']['packages']
+
+
+class TestPublicationInfoLocked:
+    def test_locked_false_when_no_lockfile(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                sampleproj = { features = ["sampleproj"] }
+            """))
+            info = publication_info(td)
+            assert info['env_specs']['sampleproj']['locked'] is False
+
+    def test_locked_true_when_env_in_pixi_lock(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                sampleproj = { features = ["sampleproj"] }
+                test = { features = ["test"] }
+            """))
+            with open(os.path.join(td, 'pixi.lock'), 'w') as f:
+                f.write(textwrap.dedent("""\
+                    version: 6
+                    environments:
+                      sampleproj:
+                        channels:
+                        - url: https://example/
+                        packages: {}
+                """))
+            info = publication_info(td)
+            # sampleproj is in the lock — locked. test is not — unlocked.
+            assert info['env_specs']['sampleproj']['locked'] is True
+            assert info['env_specs']['test']['locked'] is False
+
+    def test_malformed_lockfile_falls_back_to_unlocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                sampleproj = { features = ["sampleproj"] }
+            """))
+            with open(os.path.join(td, 'pixi.lock'), 'w') as f:
+                # Not valid YAML — should silently fall back, not raise.
+                f.write('this is not: { valid yaml: at all\n')
+            info = publication_info(td)
+            assert info['env_specs']['sampleproj']['locked'] is False
 
 
 class TestPublicationInfoFeatures:

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -292,6 +292,134 @@ class TestPublicationInfoTasks:
             assert info['commands']['serve']['env_spec'] == 'prod'
 
 
+class TestPublicationInfoEnvResolution:
+    """env_spec should always name an env that supports the task — never
+    a placeholder like 'default' when the project's only env has another
+    name, and never the bare feature name when a real env carries it."""
+
+    def test_top_level_task_resolves_to_first_env_when_no_default(self):
+        # Single declared env named 'sampleproj'. Top-level [tasks.X] runs
+        # in the resolved default env, which is the first declared.
+        # `default` is also surfaced unconditionally because pixi
+        # materializes it at runtime regardless.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                sampleproj = { features = ["sampleproj"] }
+
+                [tasks.run]
+                cmd = "echo hi"
+            """))
+            info = publication_info(td)
+            assert info['commands']['run']['env_spec'] == 'sampleproj'
+            assert set(info['env_specs']) == {'default', 'sampleproj'}
+
+    def test_top_level_task_keeps_default_when_explicitly_declared(self):
+        # When the user *does* declare `default` in [environments], use
+        # that name verbatim — don't promote a sibling env.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                default = { features = [] }
+                ml = { features = ["ml"] }
+
+                [tasks.run]
+                cmd = "echo hi"
+            """))
+            info = publication_info(td)
+            assert info['commands']['run']['env_spec'] == 'default'
+            assert 'default' in info['env_specs']
+            assert 'ml' in info['env_specs']
+
+    def test_feature_task_resolves_to_env_carrying_feature(self):
+        # [feature.ml.tasks.train] should report env_spec='ml' because
+        # the env named `ml` includes feature `ml`. The exporter's
+        # convention (feature name == env name) makes this trivial, but
+        # the resolution logic doesn't assume that — it walks
+        # [environments] entries to find which envs include the feature.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                ml = { features = ["ml"] }
+
+                [feature.ml.tasks.train]
+                cmd = "python train.py"
+            """))
+            info = publication_info(td)
+            assert info['commands']['train']['env_spec'] == 'ml'
+
+    def test_feature_task_picks_default_env_when_multiple_match(self):
+        # If the same feature is included in multiple envs, the resolved
+        # default wins (so `pixi run task` matches the env publication
+        # picks).
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                primary = { features = ["common"] }
+                secondary = { features = ["common"] }
+
+                [feature.common.tasks.run]
+                cmd = "echo hi"
+            """))
+            info = publication_info(td)
+            # primary is first declared → resolved default → wins.
+            assert info['commands']['run']['env_spec'] == 'primary'
+
+    def test_default_env_always_surfaced_alongside_named_envs(self):
+        # Pixi always materializes a `default` env at runtime, so
+        # publication_info surfaces it unconditionally. Default-feature
+        # packages flow into the `default` env_spec; feature-specific
+        # deps flow into the named env. Each env carries the right
+        # packages (no cross-pollination).
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [dependencies]
+                python = "*"
+
+                [feature.sampleproj.dependencies]
+                pandas = "*"
+
+                [environments]
+                sampleproj = { features = ["sampleproj"] }
+            """))
+            info = publication_info(td)
+            assert set(info['env_specs']) == {'default', 'sampleproj'}
+            # `default` carries only the default-feature packages.
+            assert info['env_specs']['default']['packages'] == ['python']
+            # `sampleproj` inherits the default feature plus its own.
+            sample = info['env_specs']['sampleproj']['packages']
+            assert 'python' in sample
+            assert 'pandas' in sample
+            # Both default-feature and sampleproj-feature packages roll up.
+            assert 'python' in info['env_specs']['sampleproj']['packages']
+            assert 'pandas' in info['env_specs']['sampleproj']['packages']
+
+
 class TestPublicationInfoFeatures:
     def test_feature_tasks_included(self):
         with tempfile.TemporaryDirectory() as td:

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -747,6 +747,99 @@ class TestProjectTypeKey:
             assert publication_info(td)[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
 
 
+class TestEnvPaths:
+    """`env_paths=True` populates `info['env_specs'][name]['path']`. The
+    anaconda-project branch derives paths from each EnvSpec; the pixi branch
+    shells out to `pixi info --json`."""
+
+    def test_default_does_not_include_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert 'path' not in info['env_specs']['default']
+
+    def test_pixi_env_paths_via_subprocess(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            fake_json = (
+                '{"environments_info": ['
+                '{"name": "default", "prefix": "/fake/path/.pixi/envs/default"}'
+                ']}'
+            ).encode('utf-8')
+
+            def fake_check_output(cmd, stderr=None):
+                assert cmd[0] == 'pixi'
+                assert '--json' in cmd
+                return fake_json
+
+            import subprocess
+            monkeypatch.setattr(subprocess, 'check_output', fake_check_output)
+            info = publication_info(td, env_paths=True)
+            assert info['env_specs']['default']['path'] == '/fake/path/.pixi/envs/default'
+
+    def test_pixi_env_paths_subprocess_failure_raises(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+
+            import subprocess
+
+            def fake_check_output(cmd, stderr=None):
+                raise subprocess.CalledProcessError(1, cmd, stderr=b'pixi: bad manifest')
+
+            monkeypatch.setattr(subprocess, 'check_output', fake_check_output)
+            with pytest.raises(RuntimeError) as exc:
+                publication_info(td, env_paths=True)
+            assert 'pixi info' in str(exc.value)
+
+    def test_pixi_env_paths_pixi_missing_raises(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            import subprocess
+
+            def fake_check_output(cmd, stderr=None):
+                raise OSError(2, 'No such file or directory: pixi')
+
+            monkeypatch.setattr(subprocess, 'check_output', fake_check_output)
+            with pytest.raises(RuntimeError) as exc:
+                publication_info(td, env_paths=True)
+            assert 'pixi info' in str(exc.value)
+
+    def test_pixi_env_paths_invalid_json_raises(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            import subprocess
+
+            monkeypatch.setattr(subprocess, 'check_output',
+                                lambda cmd, stderr=None: b'not actually json')
+            with pytest.raises(RuntimeError) as exc:
+                publication_info(td, env_paths=True)
+            assert 'parse' in str(exc.value)
+
+    def test_anaconda_project_env_paths(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, textwrap.dedent("""\
+                name: sample
+                env_specs:
+                  default:
+                    channels: [defaults]
+                    packages: [python=3.12]
+                  alt:
+                    channels: [defaults]
+                    packages: [python=3.12, flask]
+            """))
+            info = publication_info(td, env_paths=True)
+            for name in ('default', 'alt'):
+                path = info['env_specs'][name]['path']
+                assert path.endswith(os.path.join('envs', name))
+                assert os.path.isabs(path)
+
+
 class TestExplicitProjectType:
     """Caller-supplied `project_type` overrides the pixi-wins-by-default
     detection. Asking for a format whose manifest is absent is an error."""

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -64,13 +64,27 @@ class TestFormatDep:
 
 
 class TestInferNotebook:
-    def test_notebook_detected(self):
+    def test_jupyter_notebook_detected(self):
         assert _infer_notebook('jupyter notebook analysis.ipynb') == 'analysis.ipynb'
 
-    def test_notebook_with_path(self):
-        assert _infer_notebook('voila notebooks/demo.ipynb') == 'notebooks/demo.ipynb'
+    def test_jupyter_lab_detected(self):
+        assert _infer_notebook('jupyter lab notebooks/demo.ipynb') == 'notebooks/demo.ipynb'
 
-    def test_no_notebook(self):
+    def test_jupyter_notebook_dash_form(self):
+        assert _infer_notebook('jupyter-notebook foo.ipynb') == 'foo.ipynb'
+
+    def test_panel_serve_ipynb_is_not_a_notebook(self):
+        # panel serve consumes the .ipynb but renders a web app, not a
+        # notebook view. Only commands that explicitly launch Jupyter
+        # should be classified as notebooks.
+        assert _infer_notebook('panel serve glaciers.ipynb') is None
+
+    def test_voila_ipynb_is_not_a_notebook(self):
+        # voila publishes notebooks as web apps. Same rule: not a
+        # notebook command in the publication-info sense.
+        assert _infer_notebook('voila notebooks/demo.ipynb') is None
+
+    def test_python_script_not_a_notebook(self):
         assert _infer_notebook('python app.py') is None
 
     def test_ipynb_substring_not_matched(self):
@@ -211,15 +225,32 @@ class TestPublicationInfoTasks:
             assert info['commands']['first']['default'] is True
             assert info['commands']['second']['default'] is False
 
-    def test_notebook_inference(self):
+    def test_notebook_inference_jupyter(self):
+        # Direct conversions of `notebook:` commands become
+        # `jupyter notebook ...`; those are what publication_info should
+        # report as a notebook.
         with tempfile.TemporaryDirectory() as td:
             _write_pixi_toml(
                 td,
-                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks]\nnb = "voila report.ipynb"\n',
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks]\nnb = "jupyter notebook report.ipynb"\n',
             )
             info = publication_info(td)
             assert info['commands']['nb']['notebook'] == 'report.ipynb'
             assert info['commands']['nb']['supports_http_options'] is True
+
+    def test_app_serving_ipynb_is_not_a_notebook(self):
+        # `panel serve foo.ipynb` happens to consume an .ipynb but is a
+        # web app, not a notebook view. The publication info should
+        # reflect that — supports_http_options stays True (it IS an HTTP
+        # service), but `notebook` must be None.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks]\ndashboard = "panel serve glaciers.ipynb"\n',
+            )
+            info = publication_info(td)
+            assert info['commands']['dashboard']['notebook'] is None
+            assert info['commands']['dashboard']['supports_http_options'] is True
 
     def test_task_with_environment(self):
         with tempfile.TemporaryDirectory() as td:

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -745,3 +745,51 @@ class TestProjectTypeKey:
         with tempfile.TemporaryDirectory() as td:
             _write_pixi_toml(td, '[workspace]\nname = "t"\n')
             assert publication_info(td)[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
+
+
+class TestExplicitProjectType:
+    """Caller-supplied `project_type` overrides the pixi-wins-by-default
+    detection. Asking for a format whose manifest is absent is an error."""
+
+    def test_force_anaconda_project_when_both_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "from-pixi"\n')
+            _write_anaconda_project(td, textwrap.dedent("""\
+                name: from-yml
+                env_specs:
+                  default:
+                    channels: [defaults]
+                    packages: [python=3.12]
+            """))
+            info = publication_info(td, project_type=PROJECT_TYPE_ANACONDA_PROJECT)
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_ANACONDA_PROJECT
+            assert info['name'] == 'from-yml'
+
+    def test_force_pixi_when_both_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "from-pixi"\n')
+            _write_anaconda_project(td, 'name: from-yml\n')
+            info = publication_info(td, project_type=PROJECT_TYPE_PIXI)
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
+            assert info['name'] == 'from-pixi'
+
+    def test_force_pixi_without_pixi_toml_raises(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, 'name: t\n')
+            with pytest.raises(FileNotFoundError) as exc:
+                publication_info(td, project_type=PROJECT_TYPE_PIXI)
+            assert 'pixi.toml' in str(exc.value)
+
+    def test_force_anaconda_project_without_yml_raises(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            with pytest.raises(FileNotFoundError) as exc:
+                publication_info(td, project_type=PROJECT_TYPE_ANACONDA_PROJECT)
+            assert 'anaconda-project.yml' in str(exc.value)
+
+    def test_unknown_project_type_raises(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            with pytest.raises(ValueError) as exc:
+                publication_info(td, project_type='conda-workspaces')
+            assert 'conda-workspaces' in str(exc.value)

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -53,8 +53,25 @@ class TestFormatDep:
     def test_bare_version_number(self):
         assert _format_dep('flask', '3.0.*') == 'flask=3.0.*'
 
-    def test_dict_spec(self):
-        assert _format_dep('torch', {'version': '>=2.0'}) == 'torch'
+    def test_dict_spec_with_operator(self):
+        assert _format_dep('torch', {'version': '>=2.0'}) == 'torch>=2.0'
+
+    def test_dict_spec_bare_version(self):
+        assert _format_dep('numpy', {'version': '1.20.*'}) == 'numpy=1.20.*'
+
+    def test_dict_spec_wildcard(self):
+        assert _format_dep('pandas', {'version': '*'}) == 'pandas'
+
+    def test_dict_spec_no_version(self):
+        # channel-only specs have no version constraint to express;
+        # fall back to a bare name rather than emitting bogus syntax.
+        assert _format_dep('jax', {'channel': 'conda-forge'}) == 'jax'
+
+    def test_dict_spec_extra_keys_ignored(self):
+        # build, channel, and other inline-table keys don't fit the
+        # conda spec string form, so we keep just the version.
+        assert _format_dep('scipy', {'version': '1.11.*', 'build': 'py311_0',
+                                     'channel': 'conda-forge'}) == 'scipy=1.11.*'
 
     def test_none_spec(self):
         assert _format_dep('requests', None) == 'requests'

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -768,7 +768,7 @@ class TestEnvPaths:
                 '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
             )
             fake_json = (
-                '{"environments_info": ['
+                '{"platform": "osx-arm64", "environments_info": ['
                 '{"name": "default", "prefix": "/fake/path/.pixi/envs/default"}'
                 ']}'
             ).encode('utf-8')
@@ -782,6 +782,19 @@ class TestEnvPaths:
             monkeypatch.setattr(subprocess, 'check_output', fake_check_output)
             info = publication_info(td, env_paths=True)
             assert info['env_specs']['default']['path'] == '/fake/path/.pixi/envs/default'
+            # Full pixi info --json output is stashed under `_pixi`.
+            assert info['_pixi']['platform'] == 'osx-arm64'
+            assert info['_pixi']['environments_info'][0]['prefix'] == \
+                '/fake/path/.pixi/envs/default'
+
+    def test_pixi_env_paths_no_pixi_field_when_not_requested(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert '_pixi' not in info
 
     def test_pixi_env_paths_subprocess_failure_raises(self, monkeypatch):
         with tempfile.TemporaryDirectory() as td:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,9 +1,11 @@
 name: anaconda-project-docs
 dependencies:
 - sphinx
-- pydata-sphinx-theme=0.14.4
+- pydata-sphinx-theme
 - sphinx-copybutton
 - sphinx-notfound-page
 channels:
-- defaults
+# `defaults` is intentionally omitted: Read the Docs build images
+# can't accept the Anaconda ToS gate that channel now requires, and
+# every package listed above is available on conda-forge.
 - conda-forge

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,4 +8,10 @@ channels:
 # `defaults` is intentionally omitted: Read the Docs build images
 # can't accept the Anaconda ToS gate that channel now requires, and
 # every package listed above is available on conda-forge.
+#
+# This applies only to the docs build environment. Projects exported
+# via `anaconda-project export-pixi` still resolve against the user's
+# configured `default_channels` (typically `pkgs/main` + `pkgs/r`);
+# the conda-forge-only choice here is a build-tooling decision, not
+# a project-level default.
 - conda-forge

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,8 +13,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import os
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -126,10 +124,12 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    html_theme = 'pydata_sphinx_theme'
+# Always set the theme. The previous `if not on_rtd:` guard skipped this
+# when building on Read the Docs (where READTHEDOCS=True), back when RTD
+# injected its own theme. RTD no longer does that — without the explicit
+# assignment sphinx falls back to alabaster, which doesn't understand the
+# pydata-specific options below and fails to render.
+html_theme = 'pydata_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further. The documentation for the current theme is found at

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,7 +56,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Anaconda Project'
-copyright = '2022, Anaconda, Inc'
+copyright = '2026, Anaconda, Inc'
 author = 'Anaconda'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -11,7 +11,7 @@ After completing this guide, you will be able to:
 * Run the project with a single command.
 * Package and share the project.
 
-If you have not yet installed and started Project,
+If you have not yet installed and started anaconda-project,
 follow the :doc:`Installation instructions <install>`.
 
 
@@ -113,9 +113,9 @@ To share this project with a colleague:
 
 For more information, see :doc:`user-guide/tasks/share-project`.
 
-Anyone with Project can run your project by unzipping the
-project archive file and then running a single command, without
-having to do any setup::
+Anyone with anaconda-project installed can run your project by
+unzipping the project archive file and then running a single command,
+without having to do any setup::
 
      $ anaconda-project unarchive interactive.zip
      $ cd demo_app
@@ -125,14 +125,14 @@ having to do any setup::
    using your project will need to specify which command to run.
    For more information, see :doc:`user-guide/tasks/run-project`.
 
-Project downloads the data, installs the necessary packages and
+anaconda-project downloads the data, installs the necessary packages and
 runs the command.
 
 
 Next steps
 ==========
 
-* Learn more about :doc:`what you can do in Project
+* Learn more about :doc:`what you can do with anaconda-project
   <user-guide/tasks/index>`, including how to :doc:`download data
   <user-guide/tasks/download-data>` with your project and how to
   :doc:`configure your project with environment variables

--- a/docs/source/help-support.rst
+++ b/docs/source/help-support.rst
@@ -25,13 +25,3 @@ For new project work, we encourage users to evaluate
 `conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_,
 or `uv <https://docs.astral.sh/uv/>`_ directly.
 
-Send feedback
-=============
-
-Suggestions for documentation or code fixes belong in the
-`Github Issue Tracker`_. Anaconda, Inc.\ |reg| (formerly Continuum
-Analytics) no longer monitors the legacy ``documentation@continuum.io``
-address; please use GitHub issues so the discussion stays attached to
-the codebase.
-
-.. |reg|    unicode:: U+000AE .. REGISTERED SIGN

--- a/docs/source/help-support.rst
+++ b/docs/source/help-support.rst
@@ -2,24 +2,36 @@
 Help and support
 ================
 
-To ask questions or submit bug reports, use the 
+To ask questions or submit bug reports, use the
 `Github Issue Tracker`_.
 
 .. _`Github Issue Tracker`: https://github.com/Anaconda-Platform/anaconda-project/issues
 
+Project scope
+=============
 
-Paid support 
-============
+Anaconda Project is in maintenance mode. The repository's active
+development focus is limited to:
 
-Anaconda Project is an open source project that originated at 
-`Anaconda, Inc. <https://www.anaconda.com/>`_
-Continuum offers paid `training 
-<https://www.continuum.io/training>`_ and `support 
-<https://www.continuum.io/support>`_.
+* Critical bug fixes against the existing ``anaconda-project``
+  command-line tool and library.
+* The conversion tooling described in :doc:`pixi-support`, which
+  helps users move existing projects onto
+  `pixi <https://pixi.sh/>`_ or
+  `conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_.
 
+For new project work, we encourage users to evaluate
+`pixi <https://pixi.sh/>`_,
+`conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_,
+or `uv <https://docs.astral.sh/uv/>`_ directly.
 
 Send feedback
 =============
 
-Help us make this documentation better. Send feedback about the 
-Project documentation to documentation@continuum.io.
+Suggestions for documentation or code fixes belong in the
+`Github Issue Tracker`_. Anaconda, Inc.\ |reg| (formerly Continuum
+Analytics) no longer monitors the legacy ``documentation@continuum.io``
+address; please use GitHub issues so the discussion stays attached to
+the codebase.
+
+.. |reg|    unicode:: U+000AE .. REGISTERED SIGN

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,23 +4,23 @@ Anaconda Project
 
 :emphasis:`Reproducible and executable project directories`
 
-Anaconda Project encapsulates data science projects and makes 
-them easily portable. Project automates setup steps such as 
-installing the right packages, downloading files, setting 
+Anaconda Project encapsulates data science projects and makes
+them easily portable. anaconda-project automates setup steps such as
+installing the right packages, downloading files, setting
 environment variables and running commands.
 
-Project makes it easy to reproduce your work, share projects with 
-others and run them on different platforms. It also simplifies 
-deployment to servers. Anaconda projects run the same way on your 
+anaconda-project makes it easy to reproduce your work, share projects with
+others and run them on different platforms. It also simplifies
+deployment to servers. Anaconda projects run the same way on your
 machine, on another user's machine or when deployed to a server.
 
-Traditional build scripts such as ``setup.py`` automate building 
-the project---going from source code to something 
-runnable---while Project automates running the project---taking 
-build artifacts and doing any necessary setup before executing 
+Traditional build scripts such as ``setup.py`` automate building
+the project---going from source code to something
+runnable---while anaconda-project automates running the project---taking
+build artifacts and doing any necessary setup before executing
 them.
 
-You can use Project on Windows, macOS and Linux.
+You can use anaconda-project on Windows, macOS and Linux.
 
 Project is supported and offered by Anaconda, Inc\ |reg|
 and contributors under a 3-clause BSD license.
@@ -49,65 +49,54 @@ Quick Start
 
 Check out the :ref:`Getting Started` guide
 
-Benefits of Project
-====================
+Benefits of anaconda-project
+============================
 
- * A ``README`` file that contains setup steps can become 
-   outdated, or users might not read it and then you have to help 
-   them diagnose problems. Project automates the setup steps so 
-   that the ``README`` file need only say "Type 
+ * A ``README`` file that contains setup steps can become
+   outdated, or users might not read it and then you have to help
+   them diagnose problems. anaconda-project automates the setup steps so
+   that the ``README`` file need only say "Type
    ``anaconda-project run``."
 
- * Project facilitates collaboration by ensuring that all users
-   working on a project have the same dependencies in their Conda 
-   environments. Project automates environment creation and 
+ * anaconda-project facilitates collaboration by ensuring that all users
+   working on a project have the same dependencies in their Conda
+   environments. anaconda-project automates environment creation and
    verifies that environments have the right versions of packages.
 
- * You can run ``os.getenv("DB_PASSWORD")`` and configure Project 
-   to prompt the user for any missing credentials. This allows 
-   you to avoid including your personal passwords or secret keys 
+ * You can run ``os.getenv("DB_PASSWORD")`` and configure anaconda-project
+   to prompt the user for any missing credentials. This allows
+   you to avoid including your personal passwords or secret keys
    in your code.
 
- * Project improves reproducibility. Someone who wants to 
-   reproduce your analysis can ensure that they have the same 
+ * anaconda-project improves reproducibility. Someone who wants to
+   reproduce your analysis can ensure that they have the same
    setup that you have on your machine.
 
- * Project simplifies deployment of your analysis as a web 
-   application. The configuration in ``anaconda-project.yml`` 
-   tells hosting providers how to run your project, so no special 
-   setup is needed when you move from your local machine to the 
+ * anaconda-project simplifies deployment of your analysis as a web
+   application. The configuration in ``anaconda-project.yml``
+   tells hosting providers how to run your project, so no special
+   setup is needed when you move from your local machine to the
    web.
 
 
-How Project works
-=================
+How anaconda-project works
+==========================
 
-By adding an ``anaconda-project.yml`` configuration file to your 
-project directory, a single ``anaconda-project run`` command can 
-set up all dependencies and then launch the project. Running an 
-Anaconda project executes a command specified in the 
-``anaconda-project.yml`` file, where you can also configure any 
-arbitrary commands. 
+By adding an ``anaconda-project.yml`` configuration file to your
+project directory, a single ``anaconda-project run`` command can
+set up all dependencies and then launch the project. Running an
+Anaconda project executes a command specified in the
+``anaconda-project.yml`` file, where you can also configure any
+arbitrary commands.
 
-Project automates project setup by establishing all prerequisite 
-conditions for the project's commands to execute successfully. 
+anaconda-project automates project setup by establishing all prerequisite
+conditions for the project's commands to execute successfully.
 These conditions could include:
 
 * Creating a Conda environment that includes certain packages.
 * Prompting the user for passwords or other configuration.
 * Downloading data files.
 * Starting extra processes such as a database server.
-
-
-Stability
-=========
-
-Currently, the Project API and command-line syntax are subject to 
-change in future releases. A project created with the current 
-beta version of Project may always need to be run with that 
-version of Project and not Project 1.0. When we think things are 
-solid, we will switch from beta to version 1.0, and you will be 
-able to rely on long-term interface stability.
 
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,8 +22,27 @@ them.
 
 You can use Project on Windows, macOS and Linux.
 
-Project is supported and offered by Anaconda, Inc\ |reg| 
+Project is supported and offered by Anaconda, Inc\ |reg|
 and contributors under a 3-clause BSD license.
+
+Project status
+==============
+
+Anaconda Project has not been actively developed in some time and has
+largely been superseded by newer alternatives.
+`conda-project <https://conda-incubator.github.io/conda-project/>`_
+was the first follow-on effort; today,
+`pixi <https://pixi.sh/>`_ and
+`uv <https://docs.astral.sh/uv/>`_ represent the first truly successful
+successors.
+`conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_
+is a promising pixi-compatible alternative for users who prefer to
+stay closer to the conda ecosystem.
+
+For that reason, recent work on this repository has been (and will
+remain) focused on critical bug fixes and on the ability to convert
+existing Anaconda Project projects into the pixi and conda-workspaces
+formats. See :doc:`pixi-support` for details on the conversion tooling.
 
 Quick Start
 ===========
@@ -107,6 +126,13 @@ able to rely on long-term interface stability.
    user-guide/concepts
    user-guide/tasks/index
    user-guide/reference
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: Pixi support
+
+   pixi-support
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -2,88 +2,26 @@
 Installation
 ============
 
-:doc:`Anaconda Project <index>` is included in Anaconda\ |reg| versions 4.3.1 and later.
-
-To check that you have ``anaconda-project``:
-
-1. Open a terminal window.
-
-   * (Windows) Open your start menu, type in "cmd", and click the Command Prompt application.
-   * (macOS) Open Launchpad and click the Terminal application.
-   * (Linux) Search for a Terminal in your Activities or Applications or (in most systems) enter Ctrl-Alt-T.
-
-2. Enter ``conda list``. Your terminal window should looks something like the following:
-
-  .. code-block:: shell
-
-    (base) ~ conda list
-    # packages in environment at /Users/jdoe/opt/anaconda3:
-    #
-    # Name                    Version                   Build  Channel
-    _ipyw_jlab_nb_ext_conf    0.1.0            py39hecd8cb5_0
-    anaconda                  2021.11                  py39_0
-    anaconda-client           1.9.0            py39hecd8cb5_0
-    anaconda-navigator        2.1.1                    py39_0
-    anaconda-project          0.10.1             pyhd3eb1b0_0
-    ...
-
-3. If for some reason your package list doesn't contain ``anaconda-project``, see the section below for instructions on
-   how to install it manually.
-
-Installing Anaconda Project Manually
-------------------------------------
-
-If you don't have access to conda yet, `installing Miniconda
-<https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_ is the simplest way
-to obtain it.
-
-You can install Anaconda Project manually using the ``install`` command in your terminal window.
-
-.. code-block:: shell
-  
-  (base) ~ conda install anaconda-project
-  Collecting package metadata (current_repodata.json): done
-  Solving environment: done
-
-  ## Package Plan ##
-
-    environment location: /Users/jdoe/opt/anaconda3
-
-    added / updated specs:
-      - anaconda-project
-
-
-  The following packages will be downloaded:
-
-      package                    |            build
-      ---------------------------|-----------------
-      anaconda-project-0.10.2    |     pyhd3eb1b0_0         218 KB
-      ------------------------------------------------------------
-                                             Total:         218 KB
-
-  The following NEW packages will be INSTALLED:
-
-    anaconda-project   pkgs/main/noarch::anaconda-project-0.10.2-pyhd3eb1b0_0
-    conda-pack         pkgs/main/noarch::conda-pack-0.6.0-pyhd3eb1b0_0
-
-
-  Proceed ([y]/n)? 
-
-Enter 'y' to proceed.
+:doc:`Anaconda Project <index>` is available on the ``defaults`` channel
+and on `conda-forge <https://conda-forge.org/>`_. Install it into the
+conda environment of your choice:
 
 .. code-block:: shell
 
-  Downloading and Extracting Packages
-  anaconda-project-0.1 | 218 KB    | ##################################### | 100%
-  Preparing transaction: done
-  Verifying transaction: done
-  Executing transaction: done
+  conda install anaconda-project
 
-Test your installation by running ``anaconda-project`` with the ``version``
-option::
+Or, equivalently, from conda-forge:
+
+.. code-block:: shell
+
+  conda install -c conda-forge anaconda-project
+
+Verify the install:
+
+.. code-block:: shell
 
   anaconda-project --version
 
-A successful installation reports the version number.
-
-.. |reg|	unicode:: U+000AE .. REGISTERED SIGN
+If you do not yet have conda available, `Miniconda
+<https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_
+is the simplest way to obtain it.

--- a/docs/source/pixi-support.rst
+++ b/docs/source/pixi-support.rst
@@ -1,0 +1,197 @@
+============
+Pixi support
+============
+
+Anaconda Project ships two pieces of tooling aimed at converting
+existing ``anaconda-project.yml`` projects into a form that can be
+managed by `pixi <https://pixi.sh/>`_ (and, by extension,
+`conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_,
+which consumes the same ``pixi.toml`` format).
+
+These are the focus of recent maintenance on this repository:
+
+* The ``anaconda-project export-pixi`` command, which writes a
+  ``pixi.toml`` (and a sibling ``ap_download.py`` helper when needed)
+  alongside an existing ``anaconda-project.yml``.
+* A ``publication_info`` function in
+  ``anaconda_project.project_info`` that can read either
+  ``anaconda-project.yml`` or ``pixi.toml`` and return a uniform
+  dictionary describing the project's commands, environments, and
+  variables. Downstream deployment tooling that ingests both formats
+  uses this as its single integration point.
+
+The rest of this page documents the conventions the conversion uses
+to preserve as much of the original project's behavior as possible.
+
+Export goals
+============
+
+The conversion is best-effort but tries to satisfy three contracts:
+
+* The resulting ``pixi.toml`` should be installable and runnable
+  without further manual editing for the common project shapes
+  (``unix:`` commands, ``notebook:``, ``bokeh_app:``, ``downloads:``,
+  ``variables:``, single or multi-environment).
+* Tasks invoked under pixi should mirror the runtime behavior of
+  ``anaconda-project run`` as closely as the underlying tools allow,
+  including HTTP options, environment selection, and download fetching.
+* The converted manifest should be readable for a maintainer who
+  inspects it later — comments mark anything that couldn't be
+  translated faithfully, and warnings appear at the top of the file
+  when a downstream consumer needs to act.
+
+Environment layout
+==================
+
+* When the source yml has a single ``env_specs:`` entry with a
+  non-default name (for example ``sampleproj:``), packages live in
+  the top-level ``[dependencies]`` table (pixi's default feature) and
+  the named env inherits via ``features = ["sampleproj"]``. Pixi's
+  mandatory implicit ``default`` env carries the same packages, so
+  ``pixi install`` (without ``-e``) still does something useful.
+* Multi-environment projects emit each ``env_specs:`` entry under
+  ``[environments]`` in source order. The first uncommented entry is
+  the project's intended default; downstream tools can extract it with
+  one line of ``awk``.
+* If one of multiple env_specs is literally named ``default``, its
+  ``[environments]`` slot is rendered as a comment
+  (``# default  (pixi creates this implicitly...)``) and its packages
+  are folded into top-level ``[dependencies]``. Pixi auto-creates
+  ``default`` from the default feature, so redeclaring it would be
+  redundant.
+* ``solve-group`` is intentionally not emitted. Anaconda Project does
+  not assume environments solve together, and pixi shouldn't be told
+  otherwise on import.
+
+Channel handling
+================
+
+Pixi has no ``defaults`` meta-channel and no equivalent of conda's
+``default_channels`` configuration. Two cases are handled explicitly:
+
+* If the source yml lists no channels at all, the converted manifest
+  is populated from ``conda config --show default_channels`` rather
+  than a hard-coded ``conda-forge`` fallback. This preserves
+  enterprise users' ``.condarc``-configured mirrors.
+* If the source yml includes ``defaults`` alongside other channels,
+  only the ``defaults`` entry is expanded; the rest are preserved in
+  source order with duplicate URLs removed.
+
+If ``conda`` is not on PATH (or fails to invoke) and ``defaults``
+expansion is required, the conversion fails fast — no partial output
+is written.
+
+Tasks and command translation
+=============================
+
+* ``unix:`` command lines are translated to a form compatible with
+  pixi's ``deno_task_shell`` task runner. ``${VAR}`` and ``%VAR%``
+  references are normalized to ``$VAR``; ``${PROJECT_DIR}`` becomes
+  ``$PIXI_PROJECT_ROOT``.
+* When both ``unix:`` and ``windows:`` command lines are present, the
+  converter normalizes the windows form (path separators, env vars)
+  and compares to the unix form. Matching forms collapse to a single
+  task; divergent forms emit the unix variant plus a comment noting
+  what the windows form would have rendered.
+* ``${CONDA_PREFIX}/bin/<name>``, ``${CONDA_PREFIX}/Scripts/<name>``,
+  and similar prefix-rooted paths are stripped to the bare command
+  name. Pixi's task activation already prepends the env's executable
+  directories to ``PATH``, so explicit prefix paths are redundant and
+  hurt cross-platform portability.
+
+The ``prepare`` task
+====================
+
+Every converted project gets a ``prepare`` task. It does double duty:
+
+* When the source yml declared ``downloads:``, ``prepare`` runs a
+  helper script (``ap_download.py``, written next to ``pixi.toml``)
+  once per download. The helper is pure stdlib and uses ``python3``,
+  so it works whether or not the env declares its own python.
+* Even when there are no downloads, ``prepare`` is emitted as a no-op
+  ``echo``. Its presence serves two purposes:
+
+  - Acts as a marker that downstream deployment tooling can use to
+    detect that this ``pixi.toml`` was converted from
+    ``anaconda-project.yml``.
+  - When scoped to a non-default env's feature (e.g.
+    ``[feature.sampleproj.tasks.prepare]``), forces
+    ``pixi run prepare`` to resolve to that env automatically — useful
+    when the project's default env_spec is named something other than
+    ``default``.
+
+If a download-needing env doesn't declare ``python``, the converted
+``pixi.toml`` carries a ``# WARNING:`` comment block at the top
+listing the affected envs, and the same warning is printed to stderr
+at conversion time. The conversion does not silently mutate the
+user's package list.
+
+HTTP options
+============
+
+Anaconda Project's ``supports_http_options: true`` (implicit on
+``notebook:`` and ``bokeh_app:`` commands) tells the underlying tool
+to expect ``--anaconda-project-X`` flags for host, port, address,
+url-prefix, iframe-hosts, no-browser, and use-xheaders. The exporter
+translates this contract into pixi ``args`` and templated ``cmd``
+strings, dispatching by command type:
+
+* ``notebook:`` commands become ``jupyter notebook <file>`` plus
+  Jupyter-native flags (``--port``, ``--ip``,
+  ``--NotebookApp.base_url=...``,
+  ``--NotebookApp.tornado_settings={...}`` for iframe hosts,
+  ``--no-browser``, ``--NotebookApp.trust_xheaders=True``). ``host``
+  is dropped because Jupyter has no host-restrict equivalent.
+* ``bokeh_app:`` commands become ``bokeh serve <app>`` plus bokeh's
+  bare flags (``--host``, ``--port``, ``--address``, ``--prefix``,
+  ``--use-xheaders``). ``--show`` is rendered as the *inverse* of
+  ``--no-browser``. ``iframe_hosts`` is dropped because bokeh has no
+  Content-Security-Policy equivalent.
+* Plain ``unix:`` commands with ``supports_http_options: true`` keep
+  their ``--anaconda-project-X`` flags verbatim. Generic tools that
+  opt in are expected to recognize the canonical names themselves
+  (``panel serve`` does).
+* ``unix:`` commands with ``supports_http_options: false`` are
+  scanned for HTTP Jinja vars (``{{ port }}``, ``{{ host }}``, etc.)
+  in their templates; pixi ``args`` are declared only for the vars
+  the cmd actually references.
+
+Each flag is wrapped in a Jinja conditional, so a blank pixi arg
+omits the flag entirely (rather than passing an empty value the
+underlying tool might reject).
+
+publication_info
+================
+
+``anaconda_project.project_info.publication_info(project_dir)``
+returns a uniform dictionary regardless of whether the project is
+managed by ``anaconda-project.yml`` or by a converted
+``pixi.toml``. The shape mirrors ``Project.publication_info()`` from
+the anaconda-project side; relevant additions for the pixi side:
+
+* ``commands[name]['args']`` — ordered list of pixi arg names
+  declared for the task. Empty for tasks without args. Lets
+  downstream tooling drive ``pixi run <task> *args`` to supply
+  positional values.
+* ``commands[name]['env_spec']`` — resolves to the name of an env
+  that supports the task. Top-level tasks resolve to the project's
+  default env (literal ``default`` if declared, otherwise the first
+  declared env). Feature-scoped tasks resolve to whichever env
+  actually includes the feature.
+* ``env_specs[name]['locked']`` — ``True`` when ``pixi.lock`` has an
+  ``environments[<name>]`` entry. Best-effort: any read or parse
+  failure silently falls back to ``False``.
+
+Limitations
+===========
+
+A few aspects of ``anaconda-project.yml`` cannot be translated
+faithfully. The exporter surfaces them as comments rather than
+silently dropping them:
+
+* ``services:`` (e.g. Redis) — pixi has no equivalent service-launch
+  primitive. The converted manifest carries a comment listing the
+  required services so a maintainer can wire them up out of band.
+* Variables without defaults — anaconda-project would prompt; pixi
+  cannot. The converted manifest emits a comment listing variables
+  that must be set in the environment before running.

--- a/docs/source/pixi-support.rst
+++ b/docs/source/pixi-support.rst
@@ -222,6 +222,16 @@ Each flag is wrapped in a Jinja conditional, so a blank pixi arg
 omits the flag entirely (rather than passing an empty value the
 underlying tool might reject).
 
+The ``{% if var %}...{% endif %}`` and ``{{ var }}`` template syntax
+inside task ``cmd`` strings is intentional, not accidental — pixi
+renders task commands through MiniJinja against the positional values
+passed to ``pixi run <task> <values...>`` (with ``args`` defaults
+filling in the rest), and only then hands the rendered command to
+``deno_task_shell`` for execution. The syntax is supported but not
+prominently documented in pixi's own docs; the converted ``pixi.toml``
+is exercising a real pixi feature, and editing the gates by hand is
+fine.
+
 The ``info`` command
 ====================
 

--- a/docs/source/pixi-support.rst
+++ b/docs/source/pixi-support.rst
@@ -19,6 +19,9 @@ These are the focus of recent maintenance on this repository:
   dictionary describing the project's commands, environments, and
   variables. Downstream deployment tooling that ingests both formats
   uses this as its single integration point.
+* The ``anaconda-project info`` command, a human-readable view of the
+  same data — modeled on ``pixi info`` — that works on either
+  manifest format.
 
 The rest of this page documents the conventions the conversion uses
 to preserve as much of the original project's behavior as possible.
@@ -160,6 +163,50 @@ Each flag is wrapped in a Jinja conditional, so a blank pixi arg
 omits the flag entirely (rather than passing an empty value the
 underlying tool might reject).
 
+The ``info`` command
+====================
+
+``anaconda-project info`` prints a human-readable summary of the
+project, modeled on ``pixi info``::
+
+    $ anaconda-project info --directory .
+    Project
+    ------------
+                  Type: pixi
+                  Name: Attractors
+           Description: A panel dashboard using datashader ...
+             Directory: /path/to/project
+
+    Commands
+    ------------
+               Command: dashboard  [default, http]
+                      : env_spec: sampleproj
+                      : cmd: panel serve attractors.ipynb {% if host %}...
+                      : args: host, port, address, url_prefix, ...
+
+    Environments
+    ------------
+           Environment: default
+              Channels: https://repo.anaconda.com/pkgs/main, ...
+      Dependency count: 12
+          Dependencies: colorcet, datashader, fiona, geoviews, ...
+                Locked: yes
+
+The command works on either manifest format — ``pixi.toml`` is
+preferred when both are present.
+
+Flags:
+
+* ``--json`` emits the underlying ``publication_info`` dict as
+  indented JSON, mirroring ``pixi info --json``.
+* ``--env-paths`` includes the on-disk prefix path for each
+  environment. For pixi projects this shells out to
+  ``pixi info --json``; the full pixi payload is also stashed
+  under an ``_pixi`` key in ``--json`` mode so callers don't have
+  to repeat the subprocess.
+* ``--project-type {pixi,anaconda-project}`` forces a manifest
+  format when both are present in the directory (e.g. mid-conversion).
+
 publication_info
 ================
 
@@ -181,6 +228,21 @@ the anaconda-project side; relevant additions for the pixi side:
 * ``env_specs[name]['locked']`` — ``True`` when ``pixi.lock`` has an
   ``environments[<name>]`` entry. Best-effort: any read or parse
   failure silently falls back to ``False``.
+
+Optional arguments:
+
+* ``project_type='pixi' | 'anaconda-project'`` forces a specific
+  manifest format. Default behavior is auto-detect, with ``pixi.toml``
+  winning when both are present. It is an error to ask for a format
+  whose manifest is not in the directory.
+* ``env_paths=True`` populates ``env_specs[name]['path']`` with the
+  on-disk prefix for each declared environment. For anaconda-project
+  this is derived from each ``EnvSpec``; for pixi it requires a
+  ``pixi info --json`` subprocess (so it is opt-in). Failure to
+  invoke pixi or parse its output raises ``RuntimeError``. When the
+  source is pixi, the full ``pixi info --json`` payload is also
+  stored under the top-level ``_pixi`` key so callers that want
+  richer pixi-specific data don't pay for a second subprocess.
 
 Limitations
 ===========

--- a/docs/source/pixi-support.rst
+++ b/docs/source/pixi-support.rst
@@ -66,6 +66,65 @@ Environment layout
   not assume environments solve together, and pixi shouldn't be told
   otherwise on import.
 
+The ``--use-default`` flag
+--------------------------
+
+Projects that have no env_spec literally named ``default`` route every
+dependency, task, and prepare body through ``[feature.{name}.*]``
+indirection — clean for projects that need explicit fan-out, but verbose
+for the common case of a single env (or a default command bound to one
+specific env in a multi-env project). Passing ``--use-default`` to
+``export-pixi`` collapses that:
+
+* The exporter picks one env_spec to promote to ``default``: the env_spec
+  attached to the project's default command (the one a bare
+  ``anaconda-project run`` would invoke), or — if there are no commands —
+  the first ``env_specs:`` entry declared.
+* That env_spec's packages, tasks, and prepare body land in top-level
+  ``[dependencies]`` / ``[tasks.X]`` / ``[tasks.prepare]`` instead of
+  inside ``[feature.{name}.*]`` blocks. Other env_specs (in a multi-env
+  project) keep their ``[feature.{name}.*]`` scoping unchanged.
+* The flag is a no-op when an env_spec literally named ``default``
+  already exists — there's nothing to rename.
+* Under ``--use-default`` the no-op ``prepare`` task is dropped. When
+  there are no ``downloads:`` to fetch, the unflagged export emits an
+  ``echo`` placeholder in ``[feature.{name}.tasks.prepare]`` so
+  ``pixi run prepare`` resolves to the project's intended env even
+  when that env's name isn't ``default``. Under ``--use-default`` the
+  promoted env *is* the implicit default, so the placeholder loses
+  its purpose; ``prepare`` is only emitted when there's real work to
+  do.
+
+When the user runs ``export-pixi`` without the flag and the project would
+benefit, the CLI prints a recommendation naming the env that would be
+promoted. With the flag on, the CLI confirms which env was renamed.
+The renaming applies only to the exported ``pixi.toml``; the source
+``anaconda-project.yml`` is not modified.
+
+The ``--add-current-platform`` flag
+-----------------------------------
+
+Pixi rejects an env that doesn't list the host platform; anaconda-project
+is more forgiving, so it's common to find a ported project with a
+``platforms:`` list that worked under conda but breaks at pixi install
+time on the developer's machine. Passing ``--add-current-platform`` to
+``export-pixi`` widens the converted manifest's ``platforms`` list to
+include the host's conda subdir (e.g. ``osx-arm64``) when it isn't
+already declared.
+
+Behavior mirrors ``--use-default``:
+
+* Off by default. The exporter does not silently mutate the user's
+  platforms list — the user explicitly chose what to support.
+* When omitted, the CLI prints a recommendation if the host platform
+  is missing.
+* When passed, the CLI prints a confirmation listing the platform
+  that was added — or stays quiet when the platform was already
+  present.
+
+The change applies only to the exported ``pixi.toml``; the source
+``anaconda-project.yml`` is not modified.
+
 Channel handling
 ================
 
@@ -243,6 +302,54 @@ Optional arguments:
   source is pixi, the full ``pixi info --json`` payload is also
   stored under the top-level ``_pixi`` key so callers that want
   richer pixi-specific data don't pay for a second subprocess.
+
+Programmatic export API
+=======================
+
+For tools that wrap the conversion (launchers, IDE plugins, custom CLIs),
+the export pipeline is exposed so downstream code never has to scrape
+generated TOML or re-implement the conversion rules.
+
+* ``project_ops.export_pixi(project, filename, use_default=False,
+  add_current_platform=False)`` writes ``pixi.toml`` to disk and returns
+  a ``PixiExportStatus``. On success the status carries:
+
+  - ``default_rename_from`` — the env_spec promoted to ``default`` by
+    ``use_default``, or ``None`` when the flag was off, no-op'd
+    (because ``default`` already existed), or the export failed.
+  - ``current_platform_added`` — the platform string added to the
+    ``platforms`` list by ``add_current_platform``, or ``None`` when
+    the flag was off, no-op'd (the platform was already declared), or
+    the export failed.
+
+  Callers use these to surface "Renamed env X → default" or "Added
+  platform Y" in their success notification without re-querying the
+  project.
+* ``project_ops.preview_pixi_export(project, use_default=False,
+  add_current_platform=False)`` runs the conversion in memory and
+  returns a dict
+  ``{pixi_toml, default_rename_from, current_platform_addition_target,
+  warnings}``. The ``pixi_toml`` entry is the would-be file content;
+  the rename / platform-addition fields report the *candidates*
+  (whether or not their flag was passed), so a confirmation dialog
+  can offer "re-render with --use-default" or "re-render with
+  --add-current-platform" as actions; ``warnings`` is the leading
+  ``# WARNING:`` block already extracted from the rendered TOML, so
+  callers don't have to grep for it themselves. Raises
+  ``CondaNotAvailableError`` if the conversion needs ``conda config
+  --show default_channels`` and conda isn't reachable.
+* ``anaconda_project.internal.pixi_export.default_rename_target(project)``
+  returns the env_spec name that ``--use-default`` would promote, or
+  ``None`` when promotion is a no-op (project already has a
+  ``default`` env_spec, or has no env_specs at all). Stable contract;
+  the underlying selection rule (default-command's env, else first
+  declared env_spec) lives in this one function.
+* ``anaconda_project.internal.pixi_export.current_platform_addition_target(project)``
+  returns the host's conda subdir if it would be added by
+  ``--add-current-platform``, or ``None`` when it's already in the
+  union of declared platforms. Same shape as
+  ``default_rename_target`` so callers can decide both flags
+  symmetrically.
 
 Limitations
 ===========

--- a/docs/source/user-guide/concepts.rst
+++ b/docs/source/user-guide/concepts.rst
@@ -57,7 +57,7 @@ Projects are affected by 3 configuration files:
   ``anaconda-project.yml``. For more information on
   ``anaconda-project-lock.yml``, see :doc:`reference`.
 
-To modify these files, use Project commands, Anaconda Navigator,
+To modify these files, use anaconda-project commands, Anaconda Navigator,
 or any text editor.
 
 
@@ -75,7 +75,7 @@ file that specifies 2 variables::
     - AMAZON_EC2_USERNAME
     - AMAZON_EC2_PASSWORD
 
-When a user runs your project, Project asks them for values to
+When a user runs your project, anaconda-project asks them for values to
 assign to these variables.
 
 In your script, you can use ``os.getenv()`` to obtain these
@@ -83,12 +83,12 @@ variables. This is a much better option than hardcoding passwords
 into your script, which can be a security risk.
 
 
-Comparing Project to conda env and environment.yml
-==================================================
+Comparing anaconda-project to conda env and environment.yml
+===========================================================
 
-Project has similar functionality to the ``conda env`` command
+anaconda-project has similar functionality to the ``conda env`` command
 and the ``environment.yml`` file, but it may be more convenient.
-The advantage of Project for environment handling is that it
+The advantage of anaconda-project for environment handling is that it
 performs conda operations and records them in a configuration
 file for reproducibility, all in one step.
 
@@ -103,7 +103,7 @@ The effect is comparable to adding the environment spec to
 environment and your configuration to be shared with others will
 not get out of sync.
 
-Project also automatically sets up environments for other users
+anaconda-project also automatically sets up environments for other users
 when they type ``anaconda-project run`` on their machines. They
 do not have to separately create, update or activate environments
 before they run the code. This may be especially useful when you
@@ -112,6 +112,6 @@ forget to rerun it and update their packages, while
 ``anaconda-project run`` automatically adds missing packages
 every time.
 
-In addition to creating environments, Project can perform other
+In addition to creating environments, anaconda-project can perform other
 kinds of setup, such as adding data files and running a database
 server. In that sense, it is a superset of ``conda env``.

--- a/docs/source/user-guide/tasks/clean-project.rst
+++ b/docs/source/user-guide/tasks/clean-project.rst
@@ -13,7 +13,7 @@ Run the following command from within the project directory::
 
   anaconda-project clean
 
-Project removes automatically created files and downloaded data.
+anaconda-project removes automatically created files and downloaded data.
 
 To restore these files:
 

--- a/docs/source/user-guide/tasks/create-project-archive.rst
+++ b/docs/source/user-guide/tasks/create-project-archive.rst
@@ -12,7 +12,7 @@ Excluding files from the archive
 ================================
 
 The ``anaconda-project archive`` command automatically omits the
-files that Project can reproduce automatically, which includes
+files that anaconda-project can reproduce automatically, which includes
 the ``envs/`` directory and any downloaded data files defined in the
 :ref:`downloads <downloads>` section of the ``anaconda-project.yml`` file.
 
@@ -49,7 +49,7 @@ EXAMPLE: To create a zip archive called "iris"::
 
   anaconda-project archive iris.zip
 
-Project creates the archive file.
+anaconda-project creates the archive file.
 
 If you list the files in the archive, you will see that
 automatically generated files are not listed.

--- a/docs/source/user-guide/tasks/work-with-commands.rst
+++ b/docs/source/user-guide/tasks/work-with-commands.rst
@@ -22,7 +22,7 @@ You could run your Python code with the command::
 
 NOTE: Replace ``file`` with the name of your file.
 
-However, to gain the benefits of Anaconda Project, use Project
+However, to gain the benefits of Anaconda Project, use anaconda-project
 to add code files to your project:
 
 #. Put the code file, application file, or notebook file into
@@ -98,11 +98,11 @@ dependencies. Add these environment specs with
 Using commands to automatically start processes
 ===============================================
 
-Project can automatically start processes that your commands
+anaconda-project can automatically start processes that your commands
 depend on. Currently it only supports starting Redis, for
 demonstration purposes.
 
-To see Project automatically start the Redis process::
+To see anaconda-project automatically start the Redis process::
 
   anaconda-project add-service redis
 


### PR DESCRIPTION
## Summary

Several iterations on the `export-pixi` command, driven by real-world testing against converted projects (Glaciers, NYC Taxi). The PR started as a single-bug fix for env_spec naming but grew into a coherent set of conventions for what a converted pixi.toml should look like and how the runtime behavior should mirror `anaconda-project`.

## What changed

### Environment layout

* **Single non-default env_spec** (e.g. `sampleproj:`): packages live in top-level `[dependencies]` (the default feature) and the named env inherits via `features = ["sampleproj"]`. Pixi's mandatory implicit `default` env carries the same packages, so `pixi install` works without `-e`.
* **`default` mixed into multi-env**: comment-out its slot in `[environments]` (`# default  (pixi creates this implicitly...)`) and fold its packages into top-level `[dependencies]`. Avoids redeclaring an env pixi auto-creates anyway.
* **env_specs emit in source order**, not alphabetical. The first uncommented entry in `[environments]` is the user's intended default — extractable with one line of `awk` for downstream tooling.
* **`solve-group` removed**. anaconda-project doesn't assume environments solve together; the converted manifest shouldn't either.

### `prepare` task convention

* Every converted project gets a `prepare` task, scoped to the default env_spec's feature (or top-level when the manifest has no `[environments]` table). The task does double duty: it carries the download logic when there are downloads, and it serves as a converted-project marker plus env-selection entry point in every case.
* The default env is whatever `project.default_env_spec_name` resolves to — typically the first declared env_spec. A literal `default` env_spec wins, since pixi's implicit `default` env materializes from the default feature anyway.
* Other env_specs do **not** get a prepare task. anaconda-project's global `downloads:` apply to every env, but we only need to fetch them once. Keeping `prepare` scoped to a single feature also sidesteps pixi's "task is defined in multiple environments" prompt entirely.
* When the source declares `downloads:`, prepare invokes a sibling helper `ap_download.py` (one line per download) instead of inlining urllib. Helper is written next to `pixi.toml` at conversion time and uses fixed positional args: `<url> <filename> [<description>]`.
* When there are no downloads, prepare is a no-op `echo` — small footprint, but its presence is what makes `pixi run prepare` resolve to a non-default-named env (e.g. `sampleproj`) automatically.
* Description field omitted from prepare tasks — pixi appends it to the banner as clutter. Run with `pixi run -q prepare` for clean output.

### `python` for downloads

* Helper invoked as `python3 ap_download.py ...` so it works with system `python3` when the env doesn't declare its own python.
* If a download-needing env lacks `python`, a `# WARNING:` block at the top of `pixi.toml` lists the affected envs. Same warning is also printed to stderr at conversion time.
* No silent mutation of the user's dep list.

## Files

* `anaconda_project/internal/pixi_export.py` — exporter logic.
* `anaconda_project/internal/ap_download.py` — sibling helper script.
* `anaconda_project/project_ops.py` — copies the helper next to pixi.toml; surfaces warnings.

## Test plan

* [x] 52 unit tests in `test_pixi_export.py` pass.
* [x] Manual verification against Glaciers (`sampleproj` env, no downloads).
* [x] Manual verification against NYC Taxi (`sampleproj` env, one download with description).
* [ ] `pixi install -e sampleproj` builds the env.
* [ ] `pixi run prepare` fetches the download.
* [ ] `pixi run dashboard` (or equivalent named task) auto-resolves to the named env without `-e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

