### PR TITLE
feat(export-pixi): channel defaults; project_info notebook + env_specs fixes

### DIFF
--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -10,11 +10,82 @@ from __future__ import absolute_import, print_function
 
 import os
 import re
+import shutil
+import subprocess
 
 from anaconda_project.requirements_registry.requirement import EnvVarRequirement
 from anaconda_project.requirements_registry.requirements.conda_env import CondaEnvRequirement
 from anaconda_project.requirements_registry.requirements.download import DownloadRequirement
 from anaconda_project.requirements_registry.requirements.service import ServiceRequirement
+
+
+class CondaNotAvailableError(Exception):
+    """Raised when the exporter needs `conda` for channel resolution but
+    can't find or invoke it. Wraps the underlying reason so the CLI can
+    surface a useful failure status."""
+
+
+def _resolve_default_channels():
+    """Return the list of URLs that `defaults` expands to, taken from the
+    user's local ``conda config --show default_channels``.
+
+    Pixi has no notion of a `defaults` meta-channel, so we have to rewrite
+    every occurrence to the URLs it would resolve to under conda. We avoid
+    `--json` because conda renders URL fields as nested urlparse dicts in
+    that mode; the plain YAML-ish output is easier to parse and is what
+    `conda config --show` emits by default.
+    """
+    if not shutil.which('conda'):
+        raise CondaNotAvailableError(
+            "`conda` not found on PATH; required to expand the `defaults` "
+            "channel into concrete URLs.")
+    try:
+        proc = subprocess.run(
+            ['conda', 'config', '--show', 'default_channels'],
+            check=True, capture_output=True, text=True)
+    except (OSError, subprocess.CalledProcessError) as e:
+        raise CondaNotAvailableError(
+            "Failed to invoke `conda config --show default_channels`: {}".format(e))
+
+    urls = []
+    in_block = False
+    for line in proc.stdout.splitlines():
+        if line.startswith('default_channels:'):
+            in_block = True
+            continue
+        if in_block:
+            stripped = line.strip()
+            if stripped.startswith('- '):
+                urls.append(stripped[2:].strip())
+            elif stripped == '':
+                continue
+            else:
+                # A non-list, non-blank line means we've fallen out of
+                # the default_channels block (a sibling key, etc.).
+                break
+    if not urls:
+        raise CondaNotAvailableError(
+            "`conda config --show default_channels` returned no entries.")
+    return urls
+
+
+def _expand_defaults_in_channels(channels, default_channels):
+    """Replace every `defaults` entry in ``channels`` with ``default_channels``.
+
+    Order is preserved; duplicates are removed (first wins).
+    """
+    out = []
+    seen = set()
+    for ch in channels:
+        if ch == 'defaults':
+            for d in default_channels:
+                if d not in seen:
+                    seen.add(d)
+                    out.append(d)
+        elif ch not in seen:
+            seen.add(ch)
+            out.append(ch)
+    return out
 
 
 def _sanitize_env_name(name):
@@ -402,7 +473,14 @@ def export_pixi_toml(project):
     lines = []
 
     # -- [workspace] metadata, channels, and platforms
-    # Collect channels from all env specs (union, preserving order)
+    # Collect channels from all env specs (union, preserving order). Pixi
+    # has no `defaults` meta-channel and no notion of channel aliases that
+    # match conda's, so we expand any `defaults` reference into the URLs
+    # that conda would resolve it to. When the project declares no
+    # channels at all, we fall back to those same default URLs rather
+    # than hard-coding conda-forge — that preserves whatever the user's
+    # conda environment treats as default (which may be an enterprise
+    # mirror configured via .condarc).
     all_channels = []
     seen_channels = set()
     for env in project.env_specs.values():
@@ -410,6 +488,13 @@ def export_pixi_toml(project):
             if ch not in seen_channels:
                 all_channels.append(ch)
                 seen_channels.add(ch)
+
+    needs_defaults = (not all_channels) or ('defaults' in all_channels)
+    default_channels = _resolve_default_channels() if needs_defaults else None
+    if not all_channels:
+        all_channels = list(default_channels)
+    elif 'defaults' in all_channels:
+        all_channels = _expand_defaults_in_channels(all_channels, default_channels)
 
     # Collect platforms (union)
     all_platforms = set()
@@ -431,10 +516,7 @@ def export_pixi_toml(project):
     lines.append('name = {}'.format(_toml_string(project.name)))
     if project.description:
         lines.append('description = {}'.format(_toml_string(project.description)))
-    if all_channels:
-        lines.append('channels = {}'.format(_toml_inline_array(all_channels)))
-    else:
-        lines.append('channels = ["conda-forge"]')
+    lines.append('channels = {}'.format(_toml_inline_array(all_channels)))
     lines.append('platforms = {}'.format(_toml_inline_array(sorted(all_platforms))))
     lines.append('')
 

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -12,14 +12,76 @@ import os
 import pytest
 import tempfile
 
+from anaconda_project.internal import pixi_export as pixi_export_module
 from anaconda_project.internal.pixi_export import (
+    CondaNotAvailableError,
     _conda_spec_to_pixi,
+    _expand_defaults_in_channels,
     _strip_conda_prefix_paths,
     _translate_command_env_vars,
     _windows_to_deno_shell,
     export_pixi_toml,
 )
 from anaconda_project.project import Project
+
+
+# Use a stable, fake `defaults` expansion across the suite so tests don't
+# depend on the developer's local `conda config` and don't shell out to
+# conda once per test.
+FAKE_DEFAULTS = ['https://example.test/main', 'https://example.test/r']
+
+
+@pytest.fixture(autouse=True)
+def _stub_default_channels(monkeypatch):
+    monkeypatch.setattr(
+        pixi_export_module, '_resolve_default_channels',
+        lambda: list(FAKE_DEFAULTS),
+    )
+
+
+class TestExpandDefaultsInChannels:
+    def test_no_defaults(self):
+        out = _expand_defaults_in_channels(['conda-forge', 'bioconda'], FAKE_DEFAULTS)
+        assert out == ['conda-forge', 'bioconda']
+
+    def test_defaults_expanded_in_place(self):
+        out = _expand_defaults_in_channels(['defaults', 'bioconda'], FAKE_DEFAULTS)
+        assert out == FAKE_DEFAULTS + ['bioconda']
+
+    def test_defaults_in_middle(self):
+        out = _expand_defaults_in_channels(
+            ['bioconda', 'defaults', 'conda-forge'], FAKE_DEFAULTS)
+        assert out == ['bioconda'] + FAKE_DEFAULTS + ['conda-forge']
+
+    def test_dedup_when_default_already_listed(self):
+        out = _expand_defaults_in_channels(
+            ['https://example.test/main', 'defaults'], FAKE_DEFAULTS)
+        # The pre-existing entry wins; defaults' duplicate is skipped.
+        assert out == ['https://example.test/main', 'https://example.test/r']
+
+    def test_multiple_defaults_collapse(self):
+        out = _expand_defaults_in_channels(['defaults', 'defaults'], FAKE_DEFAULTS)
+        assert out == FAKE_DEFAULTS
+
+
+class TestExportFailsWithoutConda:
+    def test_export_raises_when_conda_missing(self, monkeypatch, tmpdir):
+        # Override the autouse stub: simulate conda being unreachable.
+        def boom():
+            raise CondaNotAvailableError('conda not found')
+        monkeypatch.setattr(
+            pixi_export_module, '_resolve_default_channels', boom)
+
+        yml = tmpdir.join('anaconda-project.yml')
+        yml.write("""
+name: NeedsConda
+packages: []
+platforms:
+  - linux-64
+""")
+        project = Project(str(tmpdir))
+        with pytest.raises(CondaNotAvailableError):
+            export_pixi_toml(project)
 
 
 class TestCondaSpecToPixi:
@@ -81,7 +143,12 @@ commands:
         assert 'description = "A test project"' in result
         assert 'numpy = "*"' in result
         assert 'pandas = ">=2.0"' in result
-        assert '"defaults"' in result
+        # `defaults` from the yml is expanded into the URLs that conda
+        # would resolve it to. The literal "defaults" never appears in
+        # the converted manifest — pixi has no such meta-channel.
+        assert '"defaults"' not in result
+        assert 'https://example.test/main' in result
+        assert 'https://example.test/r' in result
         assert '"linux-64"' in result
         assert 'run = "python main.py"' in result
 
@@ -168,6 +235,10 @@ commands:
         assert '# converted from notebook' in result
 
     def test_default_channels_when_empty(self):
+        # When the yml declares no channels, fall back to the URLs that
+        # conda's default_channels resolves to (NOT a hard-coded
+        # conda-forge), since pixi has no `defaults` meta-channel and
+        # the user's local conda config is the source of truth.
         project = self._make_project("""
 name: NoChan
 packages: []
@@ -175,7 +246,9 @@ platforms:
   - linux-64
 """)
         result = export_pixi_toml(project)
-        assert 'channels = ["conda-forge"]' in result
+        assert 'channels = ["https://example.test/main", "https://example.test/r"]' in result
+        assert '"defaults"' not in result
+        assert '"conda-forge"' not in result
 
     def test_downloads_become_prepare_task(self):
         # Single env (default) — prepare emitted at top-level. Body

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -121,22 +121,39 @@ def _pixi_publication_info(project_dir):
     top_packages = [
         _format_dep(pkg, spec) for pkg, spec in data.get('dependencies', {}).items()
     ]
+
+    def _packages_for_env(env_def):
+        """Resolve effective package list for a declared env: top-level
+        [dependencies] (the default feature) plus each feature listed in
+        the env's `features = [...]`. An env declared with
+        `no-default-feature = true` does not inherit the default feature."""
+        if env_def is None:
+            return list(top_packages)
+        features = env_def if isinstance(env_def, list) else env_def.get('features', [])
+        no_default = (
+            isinstance(env_def, dict) and env_def.get('no-default-feature', False)
+        )
+        pkgs = [] if no_default else list(top_packages)
+        for feat in features:
+            feat_deps = data.get('feature', {}).get(feat, {}).get('dependencies', {})
+            pkgs.extend(_format_dep(n, s) for n, s in feat_deps.items())
+        return pkgs
+
+    # Pixi always materializes a `default` env, even when not declared in
+    # [environments]. Surface it unconditionally; honor the user's
+    # declaration if one exists.
+    declared_envs = data.get('environments', {})
     env_specs = {
         'default': {
-            'packages': top_packages,
+            'packages': _packages_for_env(declared_envs.get('default')),
             'channels': channels,
         },
     }
-    for env_name, env_def in data.get('environments', {}).items():
+    for env_name, env_def in declared_envs.items():
         if env_name == 'default':
             continue
-        features = env_def if isinstance(env_def, list) else env_def.get('features', [])
-        feature_pkgs = list(top_packages)
-        for feat in features:
-            feat_deps = data.get('feature', {}).get(feat, {}).get('dependencies', {})
-            feature_pkgs.extend(_format_dep(n, s) for n, s in feat_deps.items())
         env_specs[env_name] = {
-            'packages': feature_pkgs,
+            'packages': _packages_for_env(env_def),
             'channels': channels,
         }
 

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -197,7 +197,23 @@ def _format_dep(name, spec):
     return name
 
 
+# Commands we recognize as actual Jupyter notebook launchers. Anything
+# else that mentions an .ipynb file (e.g. `panel serve foo.ipynb`,
+# `voila foo.ipynb`, `streamlit run foo.ipynb`) is a different kind of
+# app — it happens to consume an .ipynb as its source but isn't
+# something a notebook viewer should render.
+_NOTEBOOK_LAUNCHERS = (
+    'jupyter notebook',
+    'jupyter lab',
+    'jupyter-lab',
+    'jupyter-notebook',
+)
+
+
 def _infer_notebook(cmd_str):
+    cmd_lower = cmd_str.lower()
+    if not any(launcher in cmd_lower for launcher in _NOTEBOOK_LAUNCHERS):
+        return None
     for token in cmd_str.split():
         if token.endswith('.ipynb'):
             return token

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -641,10 +641,17 @@ def export_pixi(project, filename):
     if failed is not None:
         return failed
 
-    from anaconda_project.internal.pixi_export import export_pixi_toml, DOWNLOAD_HELPER_FILENAME
+    from anaconda_project.internal.pixi_export import (
+        CondaNotAvailableError, DOWNLOAD_HELPER_FILENAME, export_pixi_toml,
+    )
     import sys
     try:
         content = export_pixi_toml(project)
+    except CondaNotAvailableError as e:
+        return SimpleStatus(
+            success=False,
+            description="Cannot export to pixi: {}".format(e))
+    try:
         with open(filename, 'w') as f:
             f.write(content)
         # If the converted manifest invokes ap_download.py, drop the helper

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -331,6 +331,86 @@ class TestPublicationInfoFeatures:
             assert 'pytorch' in info['env_specs']['gpu']['packages']
             assert 'python>=3.12' in info['env_specs']['gpu']['packages']
 
+    def test_no_default_feature_excludes_top_level_deps(self):
+        # An env declared with `no-default-feature = true` must not inherit
+        # the top-level [dependencies] (the default feature).
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [dependencies]
+                pandas = "*"
+                python = ">=3.12"
+
+                [feature.testenv.dependencies]
+                ipykernel = "*"
+                pandas = "*"
+
+                [environments]
+                sampleproj = { features = ["testenv"] }
+                testenv = { features = ["testenv"], no-default-feature = true }
+            """))
+            info = publication_info(td)
+            sample = info['env_specs']['sampleproj']['packages']
+            test = info['env_specs']['testenv']['packages']
+            # sampleproj inherits the default feature -> python is present
+            assert 'python>=3.12' in sample
+            assert 'pandas' in sample
+            assert 'ipykernel' in sample
+            # testenv opts out of the default feature -> python is absent
+            assert 'python>=3.12' not in test
+            assert 'ipykernel' in test
+            assert 'pandas' in test
+
+    def test_default_env_always_present(self):
+        # Pixi always materializes a `default` env. publication_info must
+        # surface it even when [environments] only declares other envs.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [dependencies]
+                python = ">=3.12"
+
+                [feature.alt.dependencies]
+                numpy = "*"
+
+                [environments]
+                alt = { features = ["alt"] }
+            """))
+            info = publication_info(td)
+            assert 'default' in info['env_specs']
+            assert 'python>=3.12' in info['env_specs']['default']['packages']
+
+    def test_default_env_honors_declaration(self):
+        # When the user explicitly declares `default = { features = [...] }`,
+        # the resulting default env_spec must include those feature deps.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [dependencies]
+                python = ">=3.12"
+
+                [feature.extras.dependencies]
+                requests = "*"
+
+                [environments]
+                default = { features = ["extras"] }
+            """))
+            info = publication_info(td)
+            assert 'requests' in info['env_specs']['default']['packages']
+            assert 'python>=3.12' in info['env_specs']['default']['packages']
+
 
 class TestPublicationInfoVariables:
     def test_activation_env(self):

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -64,13 +64,27 @@ class TestFormatDep:
 
 
 class TestInferNotebook:
-    def test_notebook_detected(self):
+    def test_jupyter_notebook_detected(self):
         assert _infer_notebook('jupyter notebook analysis.ipynb') == 'analysis.ipynb'
 
-    def test_notebook_with_path(self):
-        assert _infer_notebook('voila notebooks/demo.ipynb') == 'notebooks/demo.ipynb'
+    def test_jupyter_lab_detected(self):
+        assert _infer_notebook('jupyter lab notebooks/demo.ipynb') == 'notebooks/demo.ipynb'
 
-    def test_no_notebook(self):
+    def test_jupyter_notebook_dash_form(self):
+        assert _infer_notebook('jupyter-notebook foo.ipynb') == 'foo.ipynb'
+
+    def test_panel_serve_ipynb_is_not_a_notebook(self):
+        # panel serve consumes the .ipynb but renders a web app, not a
+        # notebook view. Only commands that explicitly launch Jupyter
+        # should be classified as notebooks.
+        assert _infer_notebook('panel serve glaciers.ipynb') is None
+
+    def test_voila_ipynb_is_not_a_notebook(self):
+        # voila publishes notebooks as web apps. Same rule: not a
+        # notebook command in the publication-info sense.
+        assert _infer_notebook('voila notebooks/demo.ipynb') is None
+
+    def test_python_script_not_a_notebook(self):
         assert _infer_notebook('python app.py') is None
 
     def test_ipynb_substring_not_matched(self):
@@ -211,15 +225,32 @@ class TestPublicationInfoTasks:
             assert info['commands']['first']['default'] is True
             assert info['commands']['second']['default'] is False
 
-    def test_notebook_inference(self):
+    def test_notebook_inference_jupyter(self):
+        # Direct conversions of `notebook:` commands become
+        # `jupyter notebook ...`; those are what publication_info should
+        # report as a notebook.
         with tempfile.TemporaryDirectory() as td:
             _write_pixi_toml(
                 td,
-                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks]\nnb = "voila report.ipynb"\n',
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks]\nnb = "jupyter notebook report.ipynb"\n',
             )
             info = publication_info(td)
             assert info['commands']['nb']['notebook'] == 'report.ipynb'
             assert info['commands']['nb']['supports_http_options'] is True
+
+    def test_app_serving_ipynb_is_not_a_notebook(self):
+        # `panel serve foo.ipynb` happens to consume an .ipynb but is a
+        # web app, not a notebook view. The publication info should
+        # reflect that — supports_http_options stays True (it IS an HTTP
+        # service), but `notebook` must be None.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks]\ndashboard = "panel serve glaciers.ipynb"\n',
+            )
+            info = publication_info(td)
+            assert info['commands']['dashboard']['notebook'] is None
+            assert info['commands']['dashboard']['supports_http_options'] is True
 
     def test_task_with_environment(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary

Stacked on #428. Three commits:

1. **Channel defaults expansion** (described below).
2. **Notebook-detection narrowing in project_info**: `_infer_notebook` previously flagged any command with a `.ipynb` token as a notebook, which mis-classified `panel serve foo.ipynb` and `voila foo.ipynb` as notebooks. Now only commands that explicitly launch Jupyter (`jupyter notebook|lab`) are classified that way — matching what anaconda-project's `notebook:` shorthand expands to. Other tools that consume an `.ipynb` are still picked up as HTTP services.
3. **Two env_specs fixes for pixi projects** in `publication_info`:
   * Envs declared with `no-default-feature = true` previously inherited the top-level `[dependencies]`. They now correctly start from an empty package list and only collect packages from the features they list. Surfaced by `workbench-sample-projects/projects/attractors/pixi.toml`, which has `testenv = { features = ["testenv"], no-default-feature = true }`.
   * Pixi always materializes a `default` env even when `[environments]` declares only other envs. `publication_info` now surfaces `default` unconditionally and honors a user-declared `default = { features = [...], ... }` instead of silently overwriting it with the top-level dependencies.

## Channel defaults expansion

* Pixi has no `defaults` meta-channel and no equivalent of conda's `default_channels` config.
* The previous exporter either passed `defaults` through verbatim (later breaking at install time) or hard-coded `"conda-forge"` when the yml declared no channels at all, ignoring the user's actual conda configuration.
* This PR resolves `defaults` by shelling out to `conda config --show default_channels` and substituting the result.

## Behavior

* **No channels in the yml** → populate from `conda config --show default_channels` (typically `https://repo.anaconda.com/pkgs/main` and `.../pkgs/r`, but enterprise users with custom `.condarc` get their own mirror URLs).
* **`defaults` mixed with other channels** → expand only that entry; preserve the rest in source order. Dedup so an explicit channel isn't re-added by the expansion.
* **No `defaults` reference at all** → no conda invocation; channels pass through.

## Why not `--json`?

`conda config --show --json` renders URL fields as nested urlparse dicts (`{"scheme": "https", "netloc": "...", ...}`) instead of the original strings. The plain text output is `key:` followed by `  - <value>` list entries — easy to parse and stable.

## Hard-error path

If `conda` isn't on PATH or fails to invoke, the exporter raises `CondaNotAvailableError` and `project_ops.export_pixi` returns a failure status. Nothing is written. Faithful conversion requires resolving `defaults`, so we don't fall back silently.

## Test plan

* [x] Unit tests for `_expand_defaults_in_channels` (no-defaults, in-place, mixed, dedup, repeat).
* [x] End-to-end test verifying `defaults` is expanded in the converted manifest.
* [x] End-to-end test verifying the no-channels case populates from conda's defaults.
* [x] Conda-missing test asserts `CondaNotAvailableError` is raised.
* [x] Notebook-classification tests cover the `panel serve foo.ipynb` / `voila foo.ipynb` cases.
* [x] `no-default-feature = true` test verifies the env's package list excludes top-level deps but includes the listed feature's deps.
* [x] `default`-always-present test verifies `default` is in `env_specs` even when `[environments]` only lists other envs, and honors a user-declared `default`.
* [x] All `test_project_info.py` and `test_pixi_export.py` tests pass.
* [ ] Verify the converted Glaciers / NYC Taxi pixi.toml installs cleanly when `defaults` is expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
