### PR TITLE
feat(export-pixi): http options + publication_info improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,11 @@ Thumbs.db
 # Project-specific
 anaconda-project-local.yml
 anaconda-project-prs/
+
+# Local AI tooling settings
+.claude/
+
+# Test artifacts produced by the local test runner
+cov.xml
+fake_project/
+fake_project.zip

--- a/anaconda_project/archiver.py
+++ b/anaconda_project/archiver.py
@@ -20,8 +20,12 @@ import tempfile
 import uuid
 import zipfile
 from io import BytesIO
-from conda_pack._progress import progressbar
-from tqdm import tqdm
+
+# `conda_pack` and `tqdm` are deferred to the call sites below
+# (`_archive_project_dir`, `_extract_files`). Importing them eagerly
+# adds tens of milliseconds to every `import anaconda_project.project`,
+# which `publication_info` and other lightweight consumers pay for no
+# reason — neither package is touched on the read path.
 
 from anaconda_project.frontend import NullFrontend, _new_error_recorder
 from anaconda_project.internal import logged_subprocess
@@ -259,6 +263,7 @@ def _leaf_infos(infos):
 
 
 def _write_tar(archive_root_name, infos, filename, compression, packed_envs, frontend):
+    from conda_pack._progress import progressbar
     if compression is None:
         compression = ""
     else:
@@ -294,6 +299,7 @@ def _write_tar(archive_root_name, infos, filename, compression, packed_envs, fro
 
 
 def _write_zip(archive_root_name, infos, filename, packed_envs, frontend):
+    from conda_pack._progress import progressbar
     with zipfile.ZipFile(filename, 'w') as zf:
         for info in _leaf_infos(infos):
             arcname = os.path.join(archive_root_name, info.relative_path)
@@ -446,6 +452,7 @@ def _extractall_chmod(zf, destination):
 
 
 def _extract_files_zip(zip_path, src_and_dest, frontend):
+    from tqdm import tqdm
     # the zipfile API has no way to extract to a filename of
     # our choice, so we have to unpack to a temporary location,
     # then copy those files over.
@@ -472,6 +479,7 @@ def _extract_files_zip(zip_path, src_and_dest, frontend):
 
 
 def _extract_files_tar(tar_path, src_and_dest, frontend):
+    from tqdm import tqdm
     with tarfile.open(tar_path, mode='r') as tf:
         if isinstance(frontend.underlying, NullFrontend):
             src_and_dest = tqdm(src_and_dest, desc='Extract ')

--- a/anaconda_project/internal/cli/info.py
+++ b/anaconda_project/internal/cli/info.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2026, Anaconda, Inc. All rights reserved.
+#
+# Licensed under the terms of the BSD 3-Clause License.
+# The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+"""`anaconda-project info` — human-readable summary of publication_info."""
+from __future__ import absolute_import, print_function
+
+import json
+import sys
+
+from anaconda_project.project_info import (
+    PROJECT_TYPE_PIXI,
+    PROJECT_TYPE_KEY,
+    publication_info,
+)
+
+
+def _format_section(title):
+    return '{}\n{}'.format(title, '-' * 12)
+
+
+def _format_label_value(label, value, width=18):
+    return '{:>{w}}: {}'.format(label, value, w=width)
+
+
+def _format_label_continuation(value, width=18):
+    return '{:>{w}}: {}'.format('', value, w=width)
+
+
+def _format_list(label, items, width=18):
+    """Format a label with a list of values, one per line, joined by ', '
+    on overflow. Mirrors `pixi info`'s layout for `Dependencies:`."""
+    if not items:
+        return _format_label_value(label, '', width=width)
+    return _format_label_value(label, ', '.join(items), width=width)
+
+
+def _print_text(info, project_dir):
+    """Render info as text, modeled on `pixi info`."""
+    project_type = info.get(PROJECT_TYPE_KEY, '<unknown>')
+    print(_format_section('Project'))
+    print(_format_label_value('Type', project_type))
+    print(_format_label_value('Name', info.get('name', '')))
+    if info.get('description'):
+        print(_format_label_value('Description', info['description']))
+    print(_format_label_value('Directory', project_dir))
+    print()
+
+    commands = info.get('commands') or {}
+    if commands:
+        print(_format_section('Commands'))
+        for name, cmd in commands.items():
+            tags = []
+            if cmd.get('default'):
+                tags.append('default')
+            if cmd.get('notebook'):
+                tags.append('notebook')
+            elif cmd.get('bokeh_app'):
+                tags.append('bokeh_app')
+            if cmd.get('supports_http_options'):
+                tags.append('http')
+            header = name
+            if tags:
+                header = '{}  [{}]'.format(name, ', '.join(tags))
+            print(_format_label_value('Command', header))
+            if cmd.get('env_spec'):
+                print(_format_label_continuation('env_spec: {}'.format(cmd['env_spec'])))
+            run_line = cmd.get('unix') or cmd.get('windows') or cmd.get('notebook') or cmd.get('bokeh_app') or ''
+            if run_line:
+                print(_format_label_continuation('cmd: {}'.format(run_line)))
+            if cmd.get('args'):
+                print(_format_label_continuation('args: {}'.format(', '.join(cmd['args']))))
+            if cmd.get('description') and cmd['description'] != run_line:
+                print(_format_label_continuation('desc: {}'.format(cmd['description'])))
+            print()
+
+    env_specs = info.get('env_specs') or {}
+    if env_specs:
+        print(_format_section('Environments'))
+        for name, env in env_specs.items():
+            print(_format_label_value('Environment', name))
+            channels = env.get('channels') or []
+            print(_format_list('Channels', channels))
+            packages = env.get('packages') or []
+            print(_format_label_value('Dependency count', len(packages)))
+            if packages:
+                print(_format_list('Dependencies', packages))
+            platforms = env.get('platforms')
+            if platforms:
+                print(_format_list('Target platforms', platforms))
+            print(_format_label_value('Locked', 'yes' if env.get('locked') else 'no'))
+            if 'path' in env:
+                print(_format_label_value('Prefix location', env['path']))
+            print()
+
+    variables = info.get('variables') or {}
+    if variables:
+        print(_format_section('Variables'))
+        for name, value in variables.items():
+            if isinstance(value, dict):
+                # anaconda-project shape: {title, description, encrypted, default}
+                rendered = value.get('default', '')
+            else:
+                rendered = value
+            print(_format_label_value(name, rendered))
+        print()
+
+
+def info_main(project_dir, as_json, env_paths, project_type):
+    """Show a human-readable view of `publication_info(project_dir)`.
+
+    With ``as_json``, emit the indented JSON instead.
+    """
+    try:
+        info = publication_info(
+            project_dir,
+            project_type=project_type,
+            env_paths=env_paths,
+        )
+    except (FileNotFoundError, ValueError, RuntimeError) as e:
+        print('{}'.format(e), file=sys.stderr)
+        return 1
+
+    if as_json:
+        # Match `pixi info --json`: indented, sorted-keys-off so order
+        # reflects insertion order (env_specs in declared order, etc).
+        print(json.dumps(info, indent=2, default=str))
+        return 0
+
+    _print_text(info, project_dir)
+    return 0
+
+
+def main(args):
+    """Argparse entry point for `anaconda-project info`."""
+    return info_main(
+        project_dir=args.directory,
+        as_json=args.json,
+        env_paths=args.env_paths,
+        project_type=args.project_type,
+    )

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -39,6 +39,7 @@ import anaconda_project.internal.cli.service_commands as service_commands
 import anaconda_project.internal.cli.environment_commands as environment_commands
 import anaconda_project.internal.cli.command_commands as command_commands
 import anaconda_project.internal.cli.pixi_commands as pixi_commands
+import anaconda_project.internal.cli.info as info_cli
 
 
 def _parse_args_and_run_subcommand(argv):
@@ -406,6 +407,30 @@ def _parse_args_and_run_subcommand(argv):
     add_directory_arg(preset)
     preset.add_argument('filename', metavar='PIXI_TOML_FILE', nargs='?', default='pixi.toml')
     preset.set_defaults(main=pixi_commands.main_export_pixi)
+
+    preset = subparsers.add_parser(
+        'info',
+        help=("Show a summary of the project: name, environments, commands, "
+              "variables. Reads pixi.toml when present (and an "
+              "anaconda-project.yml otherwise) and can also surface env "
+              "prefix locations."))
+    add_directory_arg(preset)
+    preset.add_argument('--json',
+                        action='store_true',
+                        default=False,
+                        help="Emit the publication_info dict as indented JSON instead of formatted text")
+    preset.add_argument('--env-paths',
+                        action='store_true',
+                        default=False,
+                        help=("Include filesystem prefix paths for each environment. "
+                              "For pixi projects this shells out to `pixi info --json` "
+                              "and stashes its full output under `_pixi` in --json mode."))
+    preset.add_argument('--project-type',
+                        choices=('pixi', 'anaconda-project'),
+                        default=None,
+                        help=("Force a manifest format. The default behavior reads "
+                              "pixi.toml if present, otherwise anaconda-project.yml."))
+    preset.set_defaults(main=info_cli.main)
 
     # argparse doesn't do this for us for whatever reason
     if len(argv) < 2:

--- a/anaconda_project/internal/cli/test/test_info.py
+++ b/anaconda_project/internal/cli/test/test_info.py
@@ -1,0 +1,193 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2026, Anaconda, Inc. All rights reserved.
+#
+# Licensed under the terms of the BSD 3-Clause License.
+# The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Tests for `anaconda-project info`."""
+from __future__ import absolute_import, print_function
+
+import json
+import os
+import tempfile
+import textwrap
+
+from anaconda_project.internal.cli.main import _parse_args_and_run_subcommand
+
+
+def _write_pixi_toml(d, content):
+    path = os.path.join(d, 'pixi.toml')
+    with open(path, 'w') as f:
+        f.write(content)
+
+
+def _write_anaconda_project(d, content):
+    path = os.path.join(d, 'anaconda-project.yml')
+    with open(path, 'w') as f:
+        f.write(content)
+
+
+_PIXI_TOML = textwrap.dedent("""\
+    [workspace]
+    name = "demo"
+    description = "A demo project"
+    channels = ["conda-forge"]
+    platforms = ["linux-64", "osx-arm64"]
+
+    [dependencies]
+    python = ">=3.12"
+    flask = "*"
+
+    [tasks]
+    serve = "flask run"
+""")
+
+
+class TestInfoText:
+    def test_pixi_text_output(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, _PIXI_TOML)
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td])
+            assert code == 0
+            out, err = capsys.readouterr()
+            assert err == ''
+            # Section headers and a few key fields are present.
+            assert 'Project' in out
+            assert 'Type: pixi' in out
+            assert 'Name: demo' in out
+            assert 'Description: A demo project' in out
+            assert 'Commands' in out
+            assert 'Command: serve' in out
+            assert 'Environments' in out
+            assert 'Environment: default' in out
+            assert 'flask' in out
+            # No JSON braces leak through.
+            assert '{' not in out
+
+    def test_anaconda_project_text_output(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, textwrap.dedent("""\
+                name: yml-project
+                description: An anaconda-project sample
+                env_specs:
+                  default:
+                    channels: [defaults]
+                    packages: [python=3.12, requests]
+            """))
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td])
+            assert code == 0
+            out, _ = capsys.readouterr()
+            assert 'Type: anaconda-project' in out
+            assert 'Name: yml-project' in out
+            assert 'requests' in out
+
+    def test_missing_manifest_returns_1(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td])
+            assert code == 1
+            _, err = capsys.readouterr()
+            assert 'pixi.toml' in err or 'anaconda-project.yml' in err
+
+
+class TestInfoJson:
+    def test_pixi_json_output(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, _PIXI_TOML)
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td, '--json'])
+            assert code == 0
+            out, _ = capsys.readouterr()
+            data = json.loads(out)
+            assert data['name'] == 'demo'
+            assert data['project_type'] == 'pixi'
+            assert 'serve' in data['commands']
+            assert '_pixi' not in data  # only with --env-paths
+
+    def test_json_is_indented(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, _PIXI_TOML)
+            _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td, '--json'])
+            out, _ = capsys.readouterr()
+            # Indented output has at least one '\n  ' (two-space indent).
+            assert '\n  ' in out
+
+
+class TestInfoProjectType:
+    def test_force_anaconda_project_when_both_present(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "from-pixi"\n')
+            _write_anaconda_project(td, 'name: from-yml\n')
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td,
+                 '--project-type', 'anaconda-project', '--json'])
+            assert code == 0
+            data = json.loads(capsys.readouterr().out)
+            assert data['project_type'] == 'anaconda-project'
+            assert data['name'] == 'from-yml'
+
+    def test_force_pixi_without_pixi_toml(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, 'name: t\n')
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td,
+                 '--project-type', 'pixi'])
+            assert code == 1
+            _, err = capsys.readouterr()
+            assert 'pixi.toml' in err
+
+
+class TestInfoEnvPaths:
+    def test_anaconda_project_env_paths_text(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, textwrap.dedent("""\
+                name: t
+                env_specs:
+                  default:
+                    channels: [defaults]
+                    packages: [python=3.12]
+            """))
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td, '--env-paths'])
+            assert code == 0
+            out, _ = capsys.readouterr()
+            assert 'Prefix location' in out
+
+    def test_pixi_env_paths_includes_pixi_field(self, capsys, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, _PIXI_TOML)
+            fake_json = json.dumps({
+                'platform': 'osx-arm64',
+                'environments_info': [
+                    {'name': 'default', 'prefix': os.path.join(td, '.pixi/envs/default')},
+                ],
+            }).encode('utf-8')
+            import subprocess
+            monkeypatch.setattr(subprocess, 'check_output',
+                                lambda cmd, stderr=None: fake_json)
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td,
+                 '--env-paths', '--json'])
+            assert code == 0
+            data = json.loads(capsys.readouterr().out)
+            assert data['env_specs']['default']['path'].endswith('.pixi/envs/default')
+            assert data['_pixi']['platform'] == 'osx-arm64'
+
+    def test_pixi_env_paths_subprocess_failure_returns_1(self, capsys, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, _PIXI_TOML)
+            import subprocess
+
+            def boom(cmd, stderr=None):
+                raise subprocess.CalledProcessError(1, cmd, stderr=b'pixi: bad manifest')
+
+            monkeypatch.setattr(subprocess, 'check_output', boom)
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td, '--env-paths'])
+            assert code == 1
+            _, err = capsys.readouterr()
+            assert 'pixi info' in err

--- a/anaconda_project/internal/cli/test/test_main.py
+++ b/anaconda_project/internal/cli/test/test_main.py
@@ -23,7 +23,7 @@ all_subcommands = ('init', 'run', 'prepare', 'clean', 'activate', 'archive', 'un
                    'list-services', 'add-env-spec', 'remove-env-spec', 'list-env-specs', 'export-env-spec', 'lock',
                    'unlock', 'update', 'add-packages', 'remove-packages', 'list-packages', 'add-platforms',
                    'remove-platforms', 'list-platforms', 'add-command', 'remove-command', 'list-default-command',
-                   'list-commands', 'export-pixi')
+                   'list-commands', 'export-pixi', 'info')
 all_subcommands_in_curlies = "{" + ",".join(all_subcommands) + "}"
 all_subcommands_comma_space = ", ".join(["'" + s + "'" for s in all_subcommands])
 
@@ -134,6 +134,10 @@ expected_usage_msg_format = (  # noqa
     '                        List only the default command on the project\n'
     '    list-commands       List the commands on the project\n'
     '    export-pixi         Export the project as a pixi.toml file\n'
+    '    info                Show a summary of the project: name, environments,\n'
+    '                        commands, variables. Reads pixi.toml when present (and\n'
+    '                        an anaconda-project.yml otherwise) and can also\n'
+    '                        surface env prefix locations.\n'
     '\n'
     'optional arguments:\n'
     '  -h, --help            show this help message and exit\n'

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -14,6 +14,7 @@ import os
 import platform
 import re
 import shutil
+import struct
 import sys
 import tempfile
 import yaml
@@ -584,9 +585,11 @@ def environ_set_prefix(environ, prefix, varname=conda_prefix_variable()):
         environ['CONDA_DEFAULT_ENV'] = name
 
 
-# This isn't all (e.g. leaves out arm, power).  it's sort of "all
-# that people typically publish for"
-default_platforms = ('linux-64', 'osx-64', 'win-64')
+# Platforms a project is assumed to target by default if the manifest
+# doesn't list any. Covers the four subdirs that account for the
+# overwhelming majority of conda traffic in 2026 (x86_64 Linux/Windows,
+# aarch64 Linux, Apple Silicon macOS).
+default_platforms = ('linux-64', 'linux-aarch64', 'osx-arm64', 'win-64')
 assert tuple(sorted(default_platforms)) == default_platforms
 
 # osx-32 isn't in here since it isn't much used
@@ -599,8 +602,9 @@ _non_x86_osx_machines = {'arm64'}
 # this list will get outdated, unfortunately.
 _known_platforms = tuple(
     sorted(
-        list(default_platforms_plus_32_bit) + ['osx-32'] + [("linux-%s" % m) for m in _non_x86_linux_machines] +
-        [("osx-%s" % m) for m in _non_x86_osx_machines]))
+        set(list(default_platforms_plus_32_bit) + list(default_platforms) + ['osx-32'] +
+            [("linux-%s" % m) for m in _non_x86_linux_machines] +
+            [("osx-%s" % m) for m in _non_x86_osx_machines])))
 
 known_platform_names = ('linux', 'osx', 'win')
 assert tuple(sorted(known_platform_names)) == known_platform_names
@@ -642,16 +646,47 @@ _known_platform_groups_keys = ('all', 'unix') + known_platform_names
 assert set(_known_platform_groups_keys) == set(_known_platform_groups.keys())
 
 
+# Mirrors conda.base.context._platform_map / non_x86_machines so we can
+# compute the current subdir without spawning `conda info`. The original
+# implementation invoked the conda subprocess at module-import time,
+# which made `import anaconda_project` ~1s slower than necessary for
+# every consumer (publication_info, project_info, CLI tools).
+_PLATFORM_MAP = {
+    'linux': 'linux',
+    'linux2': 'linux',
+    'darwin': 'osx',
+    'win32': 'win',
+    'zos': 'zos',
+}
+_NON_X86_MACHINES = frozenset({
+    'armv6l', 'armv7l', 'aarch64', 'arm64', 'ppc64', 'ppc64le', 'riscv64', 's390x',
+})
+
+
 def current_platform():
-    conda_info = info()
-    return conda_info.get('platform')
+    """Return the conda subdir for the current interpreter (e.g. ``'osx-arm64'``).
 
-
-_default_platforms_with_current = tuple(sorted(list(set(default_platforms + (current_platform(), )))))
+    Honors ``CONDA_SUBDIR`` if set, matching conda's own precedence.
+    Otherwise derives the value from :data:`sys.platform`,
+    :func:`platform.machine`, and the pointer size — a reimplementation
+    of conda's :py:meth:`Context._native_subdir` so we don't have to
+    shell out to ``conda info``.
+    """
+    override = os.environ.get('CONDA_SUBDIR')
+    if override:
+        return override
+    plat = _PLATFORM_MAP.get(sys.platform, 'unknown')
+    if plat == 'zos':
+        return 'zos-z'
+    machine = platform.machine().lower()
+    if machine in _NON_X86_MACHINES:
+        return '{}-{}'.format(plat, machine)
+    bits = 8 * struct.calcsize('P')
+    return '{}-{}'.format(plat, bits)
 
 
 def default_platforms_with_current():
-    return _default_platforms_with_current
+    return tuple(sorted(set(default_platforms + (current_platform(), ))))
 
 
 def parse_platform(platform):

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -438,6 +438,7 @@ _HTTP_GENERIC = (
     ('host',         'pos', '--anaconda-project-host {{ host }}'),
     ('port',         'pos', '--anaconda-project-port {{ port }}'),
     ('address',      'pos', '--anaconda-project-address {{ address }}'),
+    ('url_prefix',   'pos', '--anaconda-project-url-prefix {{ url_prefix }}'),
     ('iframe_hosts', 'pos', '--anaconda-project-iframe-hosts {{ iframe_hosts }}'),
     ('no_browser',   'pos', '--anaconda-project-no-browser'),
     ('use_xheaders', 'pos', '--anaconda-project-use-xheaders'),
@@ -447,6 +448,8 @@ _HTTP_BOKEH = (
     ('host',         'pos', '--host {{ host }}'),
     ('port',         'pos', '--port {{ port }}'),
     ('address',      'pos', '--address {{ address }}'),
+    # bokeh renames --anaconda-project-url-prefix to --prefix.
+    ('url_prefix',   'pos', '--prefix {{ url_prefix }}'),
     # iframe_hosts: bokeh has no equivalent; the original transformer
     # drops it silently, so we omit it from the args declaration too.
     # `--show` is bokeh's "open browser" flag — the inverse of
@@ -468,6 +471,11 @@ _HTTP_NOTEBOOK = (
     # host: jupyter has no host-restrict equivalent; original drops it.
     ('port',         'pos', '--port {{ port }}'),
     ('address',      'pos', '--ip {{ address }}'),
+    # url_prefix renames to --NotebookApp.base_url. The original
+    # transformer comments that the two-arg (space-separated) form is
+    # rejected here — only the `--key=value` form works — so we render
+    # it that way.
+    ('url_prefix',   'pos', '--NotebookApp.base_url={{ url_prefix }}'),
     ('iframe_hosts', 'pos', _NOTEBOOK_IFRAME_BODY),
     ('no_browser',   'pos', '--no-browser'),
     ('use_xheaders', 'pos', '--NotebookApp.trust_xheaders=True'),

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -111,6 +111,31 @@ def _toml_multiline_string(value):
     return '"""\n{}\n"""'.format(escaped)
 
 
+def _toml_wrapped_string(parts, separator=' '):
+    """Format a long single-line string as a TOML triple-quoted block where
+    every line is joined with ``separator`` at parse time.
+
+    Uses TOML's ``\\`` line-continuation: a backslash at the end of a line
+    inside a multi-line basic string strips the line terminator and any
+    leading whitespace on the next line. We separate the chunks with
+    ``\\<newline><spaces><continuation>`` so a TOML parser reconstructs
+    the original ``separator``-joined string while a human sees one chunk
+    per line in the source.
+    """
+    if not parts:
+        return _toml_string('')
+    # Each chunk is escaped just like _toml_string would, but we keep
+    # newlines intact (they're explicit \\<newline>s in our output, not
+    # data). Triple-quoted strings interpret backslash escapes the same
+    # way basic strings do.
+    escaped_parts = [
+        p.replace('\\', '\\\\').replace('"""', '\\"\\"\\"')
+        for p in parts
+    ]
+    body = '{sep}\\\n'.format(sep=separator).join(escaped_parts)
+    return '"""\\\n{body}\\\n"""'.format(body=body)
+
+
 def _toml_inline_array(items):
     return '[{}]'.format(', '.join(_toml_string(i) for i in items))
 
@@ -396,6 +421,151 @@ def _build_prepare_command(downloads):
     return '\n'.join(lines)
 
 
+# Per-mode HTTP option tables. Each entry is (jinja_var, gate, body):
+#   * jinja_var: variable name declared in pixi `args` and referenced by
+#     {% if %} gates and {{ }} substitutions in the body.
+#   * gate: 'pos' renders body when the var is truthy ({% if var %}),
+#     'neg' renders body when the var is falsy ({% if not var %}). The
+#     latter is for bokeh's --show flag, which is the *inverse* of the
+#     anaconda-project --no-browser semantics.
+#   * body: the rendered chunk; may contain {{ var }} for value
+#     substitution. Templated and gated by _wrap_gate at emit time.
+#
+# Each table is curated to match the per-tool transforms in
+# anaconda_project/project_commands.py (_BokehArgsTransformer and
+# _NotebookArgsTransformer); see HTTP_SPECS there for the source list.
+_HTTP_GENERIC = (
+    ('host',         'pos', '--anaconda-project-host {{ host }}'),
+    ('port',         'pos', '--anaconda-project-port {{ port }}'),
+    ('address',      'pos', '--anaconda-project-address {{ address }}'),
+    ('iframe_hosts', 'pos', '--anaconda-project-iframe-hosts {{ iframe_hosts }}'),
+    ('no_browser',   'pos', '--anaconda-project-no-browser'),
+    ('use_xheaders', 'pos', '--anaconda-project-use-xheaders'),
+)
+
+_HTTP_BOKEH = (
+    ('host',         'pos', '--host {{ host }}'),
+    ('port',         'pos', '--port {{ port }}'),
+    ('address',      'pos', '--address {{ address }}'),
+    # iframe_hosts: bokeh has no equivalent; the original transformer
+    # drops it silently, so we omit it from the args declaration too.
+    # `--show` is bokeh's "open browser" flag — the inverse of
+    # anaconda-project's --no-browser, hence the negative gate.
+    ('no_browser',   'neg', '--show'),
+    ('use_xheaders', 'pos', '--use-xheaders'),
+)
+
+# Notebook iframe_hosts requires a Python dict literal embedded as a
+# tornado_settings value carrying a Content-Security-Policy header. The
+# original transformer prepends 'self' to the host list; we mirror that.
+_NOTEBOOK_IFRAME_BODY = (
+    "--NotebookApp.tornado_settings="
+    "{ 'headers': { 'Content-Security-Policy': "
+    "\"frame-ancestors 'self' {{ iframe_hosts }}\" } }"
+)
+
+_HTTP_NOTEBOOK = (
+    # host: jupyter has no host-restrict equivalent; original drops it.
+    ('port',         'pos', '--port {{ port }}'),
+    ('address',      'pos', '--ip {{ address }}'),
+    ('iframe_hosts', 'pos', _NOTEBOOK_IFRAME_BODY),
+    ('no_browser',   'pos', '--no-browser'),
+    ('use_xheaders', 'pos', '--NotebookApp.trust_xheaders=True'),
+)
+
+
+def _wrap_gate(gate, var, body):
+    """Wrap a chunk body in the appropriate Jinja conditional."""
+    if gate == 'pos':
+        return '{{% if {var} %}}{body}{{% endif %}}'.format(var=var, body=body)
+    if gate == 'neg':
+        return '{{% if not {var} %}}{body}{{% endif %}}'.format(var=var, body=body)
+    return body
+
+
+def _notebook_default_url_chunk(notebook_path):
+    """Build the unconditional --NotebookApp.default_url=... prefix that
+    anaconda-project's _NotebookArgsTransformer prepends to every jupyter
+    invocation. URL-quoted basename, matching the original behavior."""
+    from urllib.parse import quote
+    basename = os.path.basename(notebook_path)
+    return '--NotebookApp.default_url=/notebooks/{}'.format(quote(basename))
+
+# Match `{{ name }}` / `{{name}}` Jinja variable references. Used when
+# supports_http_options is false to discover which HTTP vars the user's
+# templated unix line actually consumes; we only declare pixi args for
+# those, not the full set.
+_JINJA_VAR_RE = re.compile(r'\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}')
+
+
+def _http_args_for_command(command):
+    """Return the list of jinja var names to emit as pixi ``args``,
+    plus a list of cmd chunks to append.
+
+    Three dispatch paths, mirroring anaconda-project's per-tool
+    transformers in ``project_commands.py``:
+
+    * ``command.notebook is not None`` → the command was a converted
+      ``notebook:`` shorthand (now ``jupyter notebook <file>``). Use
+      the Jupyter-specific flag mapping (``--ip`` for address,
+      ``--NotebookApp.*`` for prefix/iframe/xheaders, drop host).
+    * ``command.bokeh_app is not None`` → converted ``bokeh_app:``
+      shorthand (now ``bokeh serve <app>``). Use bokeh's bare flags
+      (``--host``, ``--port``, ``--address``, ``--show`` as the
+      *inverse* of ``--no-browser``, ``--use-xheaders``).
+    * Otherwise (``supports_http_options: true`` on a plain
+      ``unix:`` command) → pass ``--anaconda-project-X`` through
+      verbatim so the underlying tool can pick up what it understands.
+
+    For ``supports_http_options: false``, scan the user's templated
+    unix line for HTTP Jinja vars and declare pixi args only for those;
+    the cmd template is left unchanged.
+    """
+    if command.supports_http_options:
+        if command.notebook is not None:
+            table = _HTTP_NOTEBOOK
+            preamble = [_notebook_default_url_chunk(command.notebook)]
+        elif command.bokeh_app is not None:
+            table = _HTTP_BOKEH
+            preamble = []
+        else:
+            table = _HTTP_GENERIC
+            preamble = []
+
+        chunks = list(preamble)
+        for var, gate, body in table:
+            chunks.append(_wrap_gate(gate, var, body))
+        args = [var for var, _, _ in table]
+        return args, chunks
+
+    # supports_http_options is false — only declare pixi args for vars
+    # the templated unix line actually references.
+    cmd = command.unix_shell_commandline or ''
+    # The full superset of HTTP-related Jinja var names a user might
+    # reference. Drawn from every per-tool table.
+    all_http_vars = {var for var, _, _ in _HTTP_GENERIC}
+    referenced = []
+    seen = set()
+    for match in _JINJA_VAR_RE.finditer(cmd):
+        name = match.group(1)
+        if name in seen or name not in all_http_vars:
+            continue
+        seen.add(name)
+        referenced.append(name)
+    return referenced, []
+
+
+def _format_args_block(args):
+    """Render a pixi ``args = [...]`` line. Defaults are always empty —
+    the cmd template uses ``{% if var %}`` gating, so an empty value means
+    the flag is omitted at run time. ``pixi run task value-for-port`` (or
+    similar positional override) sets the var."""
+    if not args:
+        return None
+    parts = ['{{ arg = "{}", default = "" }}'.format(var) for var in args]
+    return 'args = [{}]'.format(', '.join(parts))
+
+
 def _command_to_task(command, declared_vars):
     """Convert a ProjectCommand to a pixi task string or None.
 
@@ -406,10 +576,11 @@ def _command_to_task(command, declared_vars):
     keep the unix form (the deno_task_shell-native one) and surface the
     divergence in a comment so a maintainer can review.
 
-    Returns ``(task_cmd_string, raw_cmd_string, comments)``. ``raw_cmd_string``
-    is the pre-translation form, useful for comparing against
-    ``command.description`` (which anaconda-project synthesizes from the raw
-    command when the user hasn't supplied one).
+    Returns ``(task_cmd_string, raw_cmd_string, comments, args_line)``.
+    ``raw_cmd_string`` is the pre-translation form, useful for comparing
+    against ``command.description``. ``args_line`` is the formatted
+    pixi ``args = [...]`` declaration (or None if the command needs no
+    pixi args).
     """
     comments = []
     # raw_forms holds every string that anaconda-project might use as the
@@ -434,10 +605,26 @@ def _command_to_task(command, declared_vars):
         raw_forms.append(raw_cmd)
         comments.append('translated from windows-only command')
     else:
-        return None, None, comments
+        return None, None, comments, None
 
     translated, unresolved = _translate_command_env_vars(raw_cmd, declared_vars)
     translated = _strip_conda_prefix_paths(translated)
+
+    # Compose http-options support: append --anaconda-project-* flags
+    # (gated by Jinja conditionals) when supports_http_options is true,
+    # or just declare pixi args for whatever {{vars}} the user already
+    # referenced when it's false. Append-chunks render as a wrapped
+    # multi-line TOML string so the file stays readable, but parse to a
+    # single shell command at run time.
+    http_arg_vars, http_chunks = _http_args_for_command(command)
+    if http_chunks:
+        cmd_rendered = _toml_wrapped_string([translated, *http_chunks])
+        # For windows-divergence comparison and any other plain-text use,
+        # keep `translated` as the already-joined single-line form.
+        translated = ' '.join([translated, *http_chunks])
+    else:
+        cmd_rendered = _toml_string(translated)
+    args_line = _format_args_block(http_arg_vars)
 
     # If both forms exist, check that the windows line doesn't say something
     # the unix line doesn't — pixi can't run two variants of the same task,
@@ -458,7 +645,7 @@ def _command_to_task(command, declared_vars):
         comments.append(
             'unresolved env var(s): {} — set them via [activation.env] or '
             'before running pixi'.format(', '.join(unresolved)))
-    return translated, raw_forms, comments
+    return cmd_rendered, raw_forms, comments, args_line
 
 
 def export_pixi_toml(project):
@@ -697,26 +884,30 @@ def export_pixi_toml(project):
             else:
                 global_tasks.append((cmd_name, command))
 
-        if global_tasks:
-            lines.append('[tasks]')
-            for cmd_name, command in global_tasks:
-                task_cmd, raw_forms, comments = _command_to_task(command, declared_vars)
-                if task_cmd is None:
-                    lines.append('# {} — could not convert (no unix command)'.format(cmd_name))
-                    continue
-                desc = command.description
-                has_desc = desc and desc != cmd_name and desc not in (raw_forms or [])
-                for comment in comments:
-                    lines.append('# {}'.format(comment))
-                if has_desc:
-                    lines.append('{} = {{ cmd = {}, description = {} }}'.format(
-                        cmd_name, _toml_string(task_cmd), _toml_string(desc)))
-                else:
-                    lines.append('{} = {}'.format(cmd_name, _toml_string(task_cmd)))
+        for cmd_name, command in global_tasks:
+            task_cmd, raw_forms, comments, args_line = _command_to_task(
+                command, declared_vars)
+            if task_cmd is None:
+                lines.append('# {} — could not convert (no unix command)'.format(cmd_name))
+                continue
+            desc = command.description
+            has_desc = desc and desc != cmd_name and desc not in (raw_forms or [])
+            for comment in comments:
+                lines.append('# {}'.format(comment))
+            # Always use the explicit [tasks.X] form. The shorthand
+            # `name = "cmd"` doesn't allow args, and consistency reads
+            # better than mixing two forms.
+            lines.append('[tasks.{}]'.format(cmd_name))
+            lines.append('cmd = {}'.format(task_cmd))
+            if has_desc:
+                lines.append('description = {}'.format(_toml_string(desc)))
+            if args_line:
+                lines.append(args_line)
             lines.append('')
 
         for cmd_name, command in feature_tasks:
-            task_cmd, raw_forms, comments = _command_to_task(command, declared_vars)
+            task_cmd, raw_forms, comments, args_line = _command_to_task(
+                command, declared_vars)
             if task_cmd is None:
                 lines.append('# {} — could not convert (no unix command)'.format(cmd_name))
                 continue
@@ -726,9 +917,11 @@ def export_pixi_toml(project):
             has_desc = desc and desc != cmd_name and desc not in (raw_forms or [])
             section = 'feature.{}.tasks.{}'.format(pixi_env_name, cmd_name)
             lines.append('[{}]'.format(section))
-            lines.append('cmd = {}'.format(_toml_string(task_cmd)))
+            lines.append('cmd = {}'.format(task_cmd))
             if has_desc:
                 lines.append('description = {}'.format(_toml_string(desc)))
+            if args_line:
+                lines.append(args_line)
             for comment in comments:
                 lines.append('# {}'.format(comment))
             lines.append('')

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -354,6 +354,12 @@ def _windows_to_deno_shell(command_str):
     return ''.join(out)
 
 
+# Body for the no-op prepare task. Doubles as the
+# converted-from-anaconda-project marker (downstream tooling looks for
+# the `prepare` task name to detect a converted project) and gives the
+# task something visible to print when there are no downloads to fetch.
+_PREPARE_MARKER_ECHO = 'echo "Running migrated anaconda-project prepare task..."'
+
 # Helper script written next to pixi.toml during conversion; see
 # anaconda_project/internal/ap_download.py for the source. Prepare tasks
 # invoke it via `python ap_download.py <url> <filename> [<description>]`
@@ -933,12 +939,18 @@ def export_pixi_toml(project):
             lines.append('')
 
     # -- `prepare` task
-    # Mirror anaconda-project's prepare semantics for the default env:
-    # fetch any declared downloads. Emit only when there's real work to
-    # do — downstream tooling that runs `pixi run prepare` after install
-    # checks for the task's existence and skips when absent. A no-op
-    # marker would force every consumer to detect-and-skip when running
-    # against non-converted projects, which is more code for no benefit.
+    # Always emit a `prepare` task on a converted project. Two reasons:
+    #   1. Mirror anaconda-project's `prepare` semantics for the default
+    #      env: fetch any declared downloads.
+    #   2. When the default env_spec has a non-default name (e.g.
+    #      `sampleproj`), pixi has no native way to bind a default
+    #      task to that env. Scoping `prepare` to the env's feature
+    #      forces `pixi run prepare` to resolve to that env, which
+    #      makes it a useful "select the right env" entry point even
+    #      when there are no downloads to fetch.
+    # The task name itself doubles as a marker — downstream tooling can
+    # detect "this pixi.toml was converted from anaconda-project.yml"
+    # by looking for the `prepare` task.
     if 'default' in env_specs:
         default_source = 'default'
     elif project.default_env_spec_name in env_specs:
@@ -951,17 +963,23 @@ def export_pixi_toml(project):
     if default_source in downloads_per_env:
         prepare_body = _toml_multiline_string(
             _build_prepare_command(downloads_per_env[default_source]))
-        # Multi-env: scope to the default env's feature so
-        # `pixi run prepare` auto-resolves to that env. When the default
-        # is the literal `default`, fold to the global default feature —
-        # pixi's implicit default env picks it up.
-        if has_multiple_envs and default_source != 'default':
-            pixi_env_name = _sanitize_env_name(default_source)
-            lines.append('[feature.{}.tasks.prepare]'.format(pixi_env_name))
-        else:
-            lines.append('[tasks.prepare]')
-        lines.append('cmd = {}'.format(prepare_body))
-        lines.append('')
+    else:
+        # No downloads — the task is a no-op echo. Acts as the
+        # converted-project marker and (when scoped to a feature) as
+        # the env-selection entry point.
+        prepare_body = _toml_string(_PREPARE_MARKER_ECHO)
+
+    # Multi-env: scope to the default env's feature so `pixi run prepare`
+    # auto-resolves to that env. When the default is the literal
+    # `default`, fold to the global default feature — pixi's implicit
+    # default env picks it up.
+    if has_multiple_envs and default_source and default_source != 'default':
+        pixi_env_name = _sanitize_env_name(default_source)
+        lines.append('[feature.{}.tasks.prepare]'.format(pixi_env_name))
+    else:
+        lines.append('[tasks.prepare]')
+    lines.append('cmd = {}'.format(prepare_body))
+    lines.append('')
 
     # -- Services as comments
     services = {}

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -354,8 +354,6 @@ def _windows_to_deno_shell(command_str):
     return ''.join(out)
 
 
-_PREPARE_MARKER_ECHO = 'echo "Running migrated anaconda-project prepare task..."'
-
 # Helper script written next to pixi.toml during conversion; see
 # anaconda_project/internal/ap_download.py for the source. Prepare tasks
 # invoke it via `python ap_download.py <url> <filename> [<description>]`
@@ -936,15 +934,11 @@ def export_pixi_toml(project):
 
     # -- `prepare` task
     # Mirror anaconda-project's prepare semantics for the default env:
-    # fetch any declared downloads. Emit exactly one `prepare` task,
-    # scoped to the default env_spec's feature when there is one (so it
-    # only resolves under that env), or at the top level when the manifest
-    # has no [environments] table.
-    #
-    # The presence of `prepare` is itself the canonical signal that this
-    # pixi.toml was converted from anaconda-project.yml. Other env_specs
-    # don't get a prepare task — keeps the manifest small and avoids
-    # pixi's env-selection prompt entirely.
+    # fetch any declared downloads. Emit only when there's real work to
+    # do — downstream tooling that runs `pixi run prepare` after install
+    # checks for the task's existence and skips when absent. A no-op
+    # marker would force every consumer to detect-and-skip when running
+    # against non-converted projects, which is more code for no benefit.
     if 'default' in env_specs:
         default_source = 'default'
     elif project.default_env_spec_name in env_specs:
@@ -957,20 +951,17 @@ def export_pixi_toml(project):
     if default_source in downloads_per_env:
         prepare_body = _toml_multiline_string(
             _build_prepare_command(downloads_per_env[default_source]))
-    else:
-        prepare_body = _toml_string(_PREPARE_MARKER_ECHO)
-
-    # Multi-env: scope to the default env's feature so `pixi run prepare`
-    # auto-resolves to that env. (When the default is the literal
-    # `default`, fold to the global default feature — pixi's implicit
-    # default env picks it up.)
-    if has_multiple_envs and default_source and default_source != 'default':
-        pixi_env_name = _sanitize_env_name(default_source)
-        lines.append('[feature.{}.tasks.prepare]'.format(pixi_env_name))
-    else:
-        lines.append('[tasks.prepare]')
-    lines.append('cmd = {}'.format(prepare_body))
-    lines.append('')
+        # Multi-env: scope to the default env's feature so
+        # `pixi run prepare` auto-resolves to that env. When the default
+        # is the literal `default`, fold to the global default feature —
+        # pixi's implicit default env picks it up.
+        if has_multiple_envs and default_source != 'default':
+            pixi_env_name = _sanitize_env_name(default_source)
+            lines.append('[feature.{}.tasks.prepare]'.format(pixi_env_name))
+        else:
+            lines.append('[tasks.prepare]')
+        lines.append('cmd = {}'.format(prepare_body))
+        lines.append('')
 
     # -- Services as comments
     services = {}

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -720,6 +720,50 @@ commands:
         # Generic --anaconda-project-* flags shouldn't appear.
         assert '--anaconda-project-' not in result
 
+    def test_url_prefix_renamed_per_tool(self):
+        # --anaconda-project-url-prefix maps differently in each tool:
+        #   generic  -> --anaconda-project-url-prefix VALUE  (passthrough)
+        #   bokeh    -> --prefix VALUE
+        #   notebook -> --NotebookApp.base_url=VALUE  (single-arg form,
+        #               original transformer notes the two-arg form is
+        #               rejected by jupyter)
+        # Mirror those mappings here so converted commands carry the
+        # right flag for the tool that will receive them.
+        for label, yml, expected_flag in [
+            ('generic',
+             """name: t
+packages: [python]
+platforms: [linux-64]
+commands:
+  serve:
+    unix: panel serve foo.ipynb
+    supports_http_options: true
+""",
+             '--anaconda-project-url-prefix {{ url_prefix }}'),
+            ('bokeh',
+             """name: t
+packages: [python, bokeh]
+platforms: [linux-64]
+commands:
+  app:
+    bokeh_app: myapp
+""",
+             '--prefix {{ url_prefix }}'),
+            ('notebook',
+             """name: t
+packages: [python]
+platforms: [linux-64]
+commands:
+  nb:
+    notebook: report.ipynb
+""",
+             '--NotebookApp.base_url={{ url_prefix }}'),
+        ]:
+            project = self._make_project(yml)
+            result = export_pixi_toml(project)
+            assert expected_flag in result, '{}: missing {!r}'.format(label, expected_flag)
+            assert 'arg = "url_prefix"' in result, '{}: arg not declared'.format(label)
+
     def test_bokeh_app_uses_bokeh_flags(self):
         # bokeh_app: commands translate to bokeh's flag names: bare
         # --host/--port/--address, and --show as the *inverse* of

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -150,7 +150,7 @@ commands:
         assert 'https://example.test/main' in result
         assert 'https://example.test/r' in result
         assert '"linux-64"' in result
-        assert 'run = "python main.py"' in result
+        assert 'cmd = "python main.py"' in result
 
     def test_pip_packages(self):
         project = self._make_project("""
@@ -596,7 +596,7 @@ commands:
     windows: python %PROJECT_DIR%\\hello.py
 """)
         result = export_pixi_toml(project)
-        assert 'run = "python $PIXI_PROJECT_ROOT/hello.py"' in result
+        assert 'cmd = "python $PIXI_PROJECT_ROOT/hello.py"' in result
         assert 'windows command differs' not in result
 
     def test_diverging_unix_and_windows_flags_comment(self):
@@ -611,7 +611,7 @@ commands:
     windows: python %PROJECT_DIR%\\hello_win.py
 """)
         result = export_pixi_toml(project)
-        assert 'run = "python $PIXI_PROJECT_ROOT/hello.py"' in result
+        assert 'cmd = "python $PIXI_PROJECT_ROOT/hello.py"' in result
         assert 'windows command differs from unix' in result
         assert 'hello_win.py' in result
 
@@ -626,7 +626,7 @@ commands:
     windows: python %PROJECT_DIR%\\hello.py
 """)
         result = export_pixi_toml(project)
-        assert 'run = "python $PIXI_PROJECT_ROOT/hello.py"' in result
+        assert 'cmd = "python $PIXI_PROJECT_ROOT/hello.py"' in result
         assert 'translated from windows-only command' in result
 
 
@@ -659,6 +659,137 @@ class TestStripCondaPrefixPaths:
         assert _strip_conda_prefix_paths('exec ${CONDA_PREFIX}/bin/python') == 'exec python'
 
 
+class TestHttpOptions:
+    def _make_project(self, yml_content):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, 'anaconda-project.yml'), 'w') as f:
+            f.write(yml_content)
+        return Project(tmpdir)
+
+    def test_supports_http_options_appends_all_flags(self):
+        # supports_http_options=true → cmd gets all six --anaconda-project-X
+        # flags appended (gated by Jinja so empty args drop the flag), and
+        # pixi args declared with empty defaults.
+        project = self._make_project("""
+name: Http
+packages:
+  - python
+platforms:
+  - linux-64
+commands:
+  serve:
+    unix: panel serve foo.ipynb
+    supports_http_options: true
+""")
+        result = export_pixi_toml(project)
+        # All six flags appear in the cmd, gated.
+        for flag in ('--anaconda-project-host', '--anaconda-project-port',
+                     '--anaconda-project-address', '--anaconda-project-iframe-hosts',
+                     '--anaconda-project-no-browser', '--anaconda-project-use-xheaders'):
+            assert flag in result, "missing %s" % flag
+        # Each is gated by an `{% if var %}` so empty args don't render.
+        assert '{% if port %}' in result
+        assert '{% if no_browser %}' in result
+        # Pixi args block declares all six with empty defaults.
+        assert 'arg = "port", default = ""' in result
+        assert 'arg = "no_browser", default = ""' in result
+
+    def test_notebook_command_uses_jupyter_flags(self):
+        # notebook: commands have supports_http_options=true by default,
+        # and translate to Jupyter's specific flag names — `--port` (not
+        # `--anaconda-project-port`), `--ip` for address, etc., plus the
+        # unconditional --NotebookApp.default_url prefix that
+        # anaconda-project's _NotebookArgsTransformer emits.
+        project = self._make_project("""
+name: NbHttp
+packages:
+  - python
+platforms:
+  - linux-64
+commands:
+  nb:
+    notebook: report.ipynb
+""")
+        result = export_pixi_toml(project)
+        assert '--NotebookApp.default_url=/notebooks/report.ipynb' in result
+        assert '--port {{ port }}' in result
+        assert '--ip {{ address }}' in result
+        assert 'arg = "port"' in result
+        # Notebook drops host entirely (jupyter has no equivalent).
+        assert 'arg = "host"' not in result
+        # Generic --anaconda-project-* flags shouldn't appear.
+        assert '--anaconda-project-' not in result
+
+    def test_bokeh_app_uses_bokeh_flags(self):
+        # bokeh_app: commands translate to bokeh's flag names: bare
+        # --host/--port/--address, and --show as the *inverse* of
+        # --no-browser. iframe_hosts is dropped (bokeh has no equivalent).
+        project = self._make_project("""
+name: BokehHttp
+packages:
+  - python
+  - bokeh
+platforms:
+  - linux-64
+commands:
+  app:
+    bokeh_app: myapp
+""")
+        result = export_pixi_toml(project)
+        assert '--host {{ host }}' in result
+        assert '--port {{ port }}' in result
+        assert '--address {{ address }}' in result
+        # --show is gated by `not no_browser` (negative gate).
+        assert '{% if not no_browser %}--show{% endif %}' in result
+        assert '--use-xheaders' in result
+        # iframe_hosts is not declared as an arg or referenced.
+        assert 'arg = "iframe_hosts"' not in result
+        assert '--anaconda-project-' not in result
+
+    def test_supports_http_options_false_no_jinja_no_args(self):
+        # supports_http_options=false and the unix line has no {{var}}
+        # references → no http args at all, cmd unchanged.
+        project = self._make_project("""
+name: Plain
+packages:
+  - python
+platforms:
+  - linux-64
+commands:
+  run:
+    unix: python app.py
+""")
+        result = export_pixi_toml(project)
+        assert '--anaconda-project-' not in result
+        assert 'args = [' not in result
+
+    def test_supports_http_options_false_picks_up_referenced_jinja(self):
+        # User wrote a templated unix: command with {{port}} and {{host}}.
+        # We declare pixi args only for those, leave the cmd alone.
+        project = self._make_project("""
+name: Tmpl
+packages:
+  - python
+platforms:
+  - linux-64
+commands:
+  run:
+    unix: "myserver --port={{ port }} --host={{ host }}"
+""")
+        result = export_pixi_toml(project)
+        # Cmd preserved verbatim (env-var translation doesn't touch
+        # Jinja vars).
+        assert '--port={{ port }}' in result
+        assert '--host={{ host }}' in result
+        # Only port and host declared; not the other four http vars.
+        assert 'arg = "port"' in result
+        assert 'arg = "host"' in result
+        assert 'arg = "address"' not in result
+        assert 'arg = "iframe_hosts"' not in result
+        # No --anaconda-project-X flags appended.
+        assert '--anaconda-project-' not in result
+
+
 class TestEndToEndCondaPrefixUnification:
     def _make_project(self, yml_content):
         tmpdir = tempfile.mkdtemp()
@@ -681,5 +812,5 @@ commands:
     windows: '%CONDA_PREFIX%\\python.exe %PROJECT_DIR%\\hello.py'
 """)
         result = export_pixi_toml(project)
-        assert 'run = "python $PIXI_PROJECT_ROOT/hello.py"' in result
+        assert 'cmd = "python $PIXI_PROJECT_ROOT/hello.py"' in result
         assert 'windows command differs' not in result

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -274,12 +274,16 @@ downloads:
         # Old comment-only path is gone.
         assert '# Downloads from anaconda-project.yml' not in result
 
-    def test_no_prepare_task_when_no_downloads(self):
-        # If there's no real work for prepare to do, omit it entirely.
-        # Downstream tooling looks for `prepare` and runs it when
-        # present; an absent task is the same signal as "nothing to
-        # prepare for this project," and skipping it costs no logic on
-        # the consumer side.
+    def test_marker_prepare_when_no_downloads(self):
+        # Even without downloads, every converted project gets a
+        # `prepare` task. It does double duty:
+        #   * Marks the file as converted from anaconda-project.yml,
+        #     for downstream tooling that detects converted projects
+        #     by task name.
+        #   * When scoped to a non-default env's feature, gives
+        #     `pixi run prepare` an entry point that auto-resolves to
+        #     that env — useful when the default env_spec is named
+        #     something other than `default`.
         project = self._make_project("""
 name: NoDl
 packages:
@@ -288,7 +292,10 @@ platforms:
   - linux-64
 """)
         result = export_pixi_toml(project)
-        assert 'prepare' not in result
+        assert '[tasks.prepare]' in result
+        assert 'Running migrated anaconda-project prepare task' in result
+        # No downloads, so no helper invocation.
+        assert 'ap_download.py' not in result
 
     def test_only_default_env_gets_prepare(self):
         # anaconda-project's top-level downloads: apply to every env, but
@@ -357,20 +364,24 @@ env_specs:
         # No prepare-all either — single prepare keeps things simple.
         assert 'prepare-all' not in result
 
-    def test_no_prepare_when_yml_has_no_downloads(self):
-        # Mirror of test_no_prepare_task_when_no_downloads but at this
-        # level of the suite — keeping coverage close to the related
-        # single-named-env test below.
+    def test_prepare_scoped_to_named_default_env(self):
+        # When the default env_spec has a non-default name (sampleproj),
+        # the prepare task is scoped to that feature so `pixi run prepare`
+        # auto-resolves to the right env. This is the second job of the
+        # always-emit-prepare convention: it's an env-selection entry
+        # point even when there's nothing to download.
         project = self._make_project("""
 name: Plain
 packages:
   - python
 platforms:
   - linux-64
+env_specs:
+  sampleproj: {}
 """)
         result = export_pixi_toml(project)
-        assert 'prepare' not in result
-        # And no helper invocation either, of course.
+        assert '[feature.sampleproj.tasks.prepare]' in result
+        # No downloads → no helper invocation.
         assert 'ap_download.py' not in result
 
     def test_project_dir_translated(self):

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -274,10 +274,12 @@ downloads:
         # Old comment-only path is gone.
         assert '# Downloads from anaconda-project.yml' not in result
 
-    def test_marker_echo_only_when_no_downloads(self):
-        # The no-op prepare body still uses the marker echo so the task
-        # has *something* to print and so anyone reading the manifest
-        # immediately sees what it came from.
+    def test_no_prepare_task_when_no_downloads(self):
+        # If there's no real work for prepare to do, omit it entirely.
+        # Downstream tooling looks for `prepare` and runs it when
+        # present; an absent task is the same signal as "nothing to
+        # prepare for this project," and skipping it costs no logic on
+        # the consumer side.
         project = self._make_project("""
 name: NoDl
 packages:
@@ -286,7 +288,7 @@ platforms:
   - linux-64
 """)
         result = export_pixi_toml(project)
-        assert 'Running migrated anaconda-project prepare task' in result
+        assert 'prepare' not in result
 
     def test_only_default_env_gets_prepare(self):
         # anaconda-project's top-level downloads: apply to every env, but
@@ -355,10 +357,10 @@ env_specs:
         # No prepare-all either — single prepare keeps things simple.
         assert 'prepare-all' not in result
 
-    def test_marker_prepare_when_no_downloads(self):
-        # Every converted project gets a prepare task — even when there are
-        # no downloads to fetch. Detection of "is this a converted project?"
-        # relies on the presence of `prepare`.
+    def test_no_prepare_when_yml_has_no_downloads(self):
+        # Mirror of test_no_prepare_task_when_no_downloads but at this
+        # level of the suite — keeping coverage close to the related
+        # single-named-env test below.
         project = self._make_project("""
 name: Plain
 packages:
@@ -367,10 +369,9 @@ platforms:
   - linux-64
 """)
         result = export_pixi_toml(project)
-        assert '[tasks.prepare]' in result
-        assert 'Running migrated anaconda-project prepare task' in result
-        # No downloads, so no urllib invocation.
-        assert 'urllib.request' not in result
+        assert 'prepare' not in result
+        # And no helper invocation either, of course.
+        assert 'ap_download.py' not in result
 
     def test_project_dir_translated(self):
         project = self._make_project("""

--- a/anaconda_project/project_commands.py
+++ b/anaconda_project/project_commands.py
@@ -14,7 +14,11 @@ from collections import namedtuple
 import os
 import platform
 import sys
-from jinja2 import Template
+
+# `jinja2.Template` is only used inside `_TemplateArgsTransformer.parse_and_template`
+# at command-execution time. Importing it eagerly costs ~20 ms on every
+# `import anaconda_project.project`, which `publication_info` and other
+# read-only consumers don't need to pay for.
 
 from anaconda_project.verbose import _verbose_logger
 from anaconda_project.internal import (conda_api, logged_subprocess, py2_compat)
@@ -155,6 +159,7 @@ class _TemplateArgsTransformer(_ArgsTransformer):
         items.update(replacements)
         items.update(environ)
 
+        from jinja2 import Template
         normalized = {self.arg_to_identifier(k): v for k, v in items.items()}
         templated_command = Template(command).render(normalized)
         return [_append_extra_args_to_command_line(templated_command, extra_args)]

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -86,6 +86,29 @@ def _anaconda_project_publication_info(project_dir):
     return Project(project_dir).publication_info()
 
 
+def _read_pixi_lock_envs(project_dir):
+    """Return the set of environment names that appear in pixi.lock, or
+    empty if the lockfile is missing, malformed, or can't be loaded.
+
+    Failure is silent by design: lock detection is informational; the
+    rest of publication_info should never break because of a corrupt
+    lockfile.
+    """
+    lock_path = os.path.join(project_dir, 'pixi.lock')
+    try:
+        import yaml
+        with open(lock_path, 'r') as f:
+            lock = yaml.safe_load(f)
+    except Exception:
+        return set()
+    if not isinstance(lock, dict):
+        return set()
+    envs = lock.get('environments')
+    if not isinstance(envs, dict):
+        return set()
+    return set(envs.keys())
+
+
 def _pixi_publication_info(project_dir):
     pixi_path = os.path.join(project_dir, PIXI_MANIFEST)
     try:
@@ -93,6 +116,8 @@ def _pixi_publication_info(project_dir):
             data = tomllib.load(f)
     except (OSError, tomllib.TOMLDecodeError) as e:
         raise ValueError('Failed to parse {}: {}'.format(pixi_path, e)) from e
+
+    locked_envs = _read_pixi_lock_envs(project_dir)
 
     workspace = data.get('workspace', {})
     project_meta = data.get('project', {})
@@ -182,6 +207,7 @@ def _pixi_publication_info(project_dir):
         'default': {
             'packages': _packages_for_env(declared_envs.get('default')),
             'channels': channels,
+            'locked': default_env_name in locked_envs,
         },
     }
     for env_name, env_def in declared_envs.items():
@@ -190,6 +216,7 @@ def _pixi_publication_info(project_dir):
         env_specs[env_name] = {
             'packages': _packages_for_env(env_def),
             'channels': channels,
+            'locked': env_name in locked_envs,
         }
 
     variables = dict(data.get('activation', {}).get('env', {}))

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -102,11 +102,45 @@ def _pixi_publication_info(project_dir):
 
     tool_commands = data.get('tool', {}).get('anaconda', {}).get('commands', {})
 
+    # Resolve the name of pixi's implicit `default` environment to the
+    # user-meaningful env_spec it actually represents. Pixi always
+    # materializes a `default` env from the default feature; the
+    # exporter (and anaconda-project's own publication_info) report the
+    # resolved name, not the placeholder. Logic mirrors the exporter:
+    # a literal `default` in [environments] wins; otherwise fall back
+    # to the first declared environment.
+    declared_envs = data.get('environments', {})
+    if 'default' in declared_envs:
+        default_env_name = 'default'
+    elif declared_envs:
+        default_env_name = next(iter(declared_envs))
+    else:
+        default_env_name = 'default'
+
+    # For tasks defined under [feature.X.tasks.Y], pixi runs them in any
+    # env that includes feature X. publication_info should report a
+    # specific env that "supports this task": prefer the resolved
+    # default if it includes the feature, else the first declared env
+    # that does, else fall back to the feature name itself (which is
+    # what our own exporter uses — feature name matches env name in the
+    # converted manifests).
+    def _env_for_feature(feat_name):
+        candidate_envs = []
+        for env_name, env_def in declared_envs.items():
+            features = env_def if isinstance(env_def, list) else env_def.get('features', [])
+            if feat_name in features:
+                candidate_envs.append(env_name)
+        if not candidate_envs:
+            return feat_name
+        if default_env_name in candidate_envs:
+            return default_env_name
+        return candidate_envs[0]
+
     commands = {}
     state = {'first': True}
 
     for task_name, task_def in data.get('tasks', {}).items():
-        cmd = _build_command(task_name, task_def, 'default', tool_commands, state)
+        cmd = _build_command(task_name, task_def, default_env_name, tool_commands, state)
         if cmd is not None:
             commands[task_name] = cmd
 
@@ -114,7 +148,9 @@ def _pixi_publication_info(project_dir):
         for task_name, task_def in feat_def.get('tasks', {}).items():
             if task_name in commands:
                 continue
-            cmd = _build_command(task_name, task_def, feat_name, tool_commands, state)
+            cmd = _build_command(task_name, task_def,
+                                 _env_for_feature(feat_name),
+                                 tool_commands, state)
             if cmd is not None:
                 commands[task_name] = cmd
 
@@ -139,10 +175,9 @@ def _pixi_publication_info(project_dir):
             pkgs.extend(_format_dep(n, s) for n, s in feat_deps.items())
         return pkgs
 
-    # Pixi always materializes a `default` env, even when not declared in
-    # [environments]. Surface it unconditionally; honor the user's
+    # Pixi always materializes a `default` env, even when [environments]
+    # only declares others. Surface it unconditionally; honor the user's
     # declaration if one exists.
-    declared_envs = data.get('environments', {})
     env_specs = {
         'default': {
             'packages': _packages_for_env(declared_envs.get('default')),

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -171,12 +171,29 @@ def _pixi_publication_info(project_dir):
 def _build_command(task_name, task_def, env_spec, tool_commands, state):
     if isinstance(task_def, str):
         cmd_str = task_def
+        raw_args = []
     elif isinstance(task_def, dict):
         cmd_str = task_def.get('cmd', '')
         if task_def.get('environment'):
             env_spec = task_def['environment']
+        raw_args = task_def.get('args') or []
     else:
         return None
+
+    # Pixi `args` entries are inline tables like { arg = "port", default = "" }
+    # or bare strings like "name". Pull just the names, in declaration order;
+    # downstream tooling uses this to know which positional values to supply
+    # to `pixi run <task>`.
+    args = []
+    for entry in raw_args:
+        if isinstance(entry, dict):
+            name = entry.get('arg')
+        elif isinstance(entry, str):
+            name = entry
+        else:
+            name = None
+        if name:
+            args.append(name)
 
     tool_meta = tool_commands.get(task_name, {})
 
@@ -203,6 +220,7 @@ def _build_command(task_name, task_def, env_spec, tool_commands, state):
         'notebook': notebook,
         'default': is_default,
         'description': description,
+        'args': args,
     }
 
 

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -54,29 +54,52 @@ def detect_project_type(project_dir):
     return None
 
 
-def publication_info(project_dir):
+def publication_info(project_dir, project_type=None):
     """Return a publication-info dict for the project at *project_dir*.
 
-    If ``pixi.toml`` is present, the pixi manifest is parsed directly. Otherwise
-    ``anaconda-project.yml`` is loaded through :class:`Project`. The returned
-    dict always includes a ``project_type`` key identifying which manifest
-    format was used.
+    With *project_type* unset (the default), ``pixi.toml`` is preferred when
+    present and ``anaconda-project.yml`` is loaded through :class:`Project`
+    otherwise. Pass ``project_type='pixi'`` or ``'anaconda-project'`` to force
+    a specific manifest format; it is an error to ask for a format whose
+    manifest is not present in *project_dir*. The returned dict always
+    includes a ``project_type`` key identifying which manifest format was
+    used.
 
     Raises:
-        ValueError: the pixi manifest cannot be parsed.
-        FileNotFoundError: neither manifest is present.
+        ValueError: *project_type* is not a recognized value, or the pixi
+            manifest cannot be parsed.
+        FileNotFoundError: the requested manifest (or, with no
+            *project_type*, neither manifest) is not present.
     """
-    project_type = detect_project_type(project_dir)
-    if project_type == PROJECT_TYPE_PIXI:
-        info = _pixi_publication_info(project_dir)
+    if project_type is None:
+        project_type = detect_project_type(project_dir)
+        if project_type is None:
+            raise FileNotFoundError(
+                'No {} or {} found in {}'.format(
+                    PIXI_MANIFEST, ANACONDA_PROJECT_MANIFEST, project_dir
+                )
+            )
+    elif project_type == PROJECT_TYPE_PIXI:
+        if not os.path.isfile(os.path.join(project_dir, PIXI_MANIFEST)):
+            raise FileNotFoundError(
+                'No {} found in {}'.format(PIXI_MANIFEST, project_dir)
+            )
     elif project_type == PROJECT_TYPE_ANACONDA_PROJECT:
-        info = _anaconda_project_publication_info(project_dir)
+        if not os.path.isfile(os.path.join(project_dir, ANACONDA_PROJECT_MANIFEST)):
+            raise FileNotFoundError(
+                'No {} found in {}'.format(ANACONDA_PROJECT_MANIFEST, project_dir)
+            )
     else:
-        raise FileNotFoundError(
-            'No {} or {} found in {}'.format(
-                PIXI_MANIFEST, ANACONDA_PROJECT_MANIFEST, project_dir
+        raise ValueError(
+            'Unknown project_type {!r}; expected {!r} or {!r}'.format(
+                project_type, PROJECT_TYPE_PIXI, PROJECT_TYPE_ANACONDA_PROJECT
             )
         )
+
+    if project_type == PROJECT_TYPE_PIXI:
+        info = _pixi_publication_info(project_dir)
+    else:
+        info = _anaconda_project_publication_info(project_dir)
     info[PROJECT_TYPE_KEY] = project_type
     return info
 

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -54,7 +54,7 @@ def detect_project_type(project_dir):
     return None
 
 
-def publication_info(project_dir, project_type=None):
+def publication_info(project_dir, project_type=None, env_paths=False):
     """Return a publication-info dict for the project at *project_dir*.
 
     With *project_type* unset (the default), ``pixi.toml`` is preferred when
@@ -65,11 +65,19 @@ def publication_info(project_dir, project_type=None):
     includes a ``project_type`` key identifying which manifest format was
     used.
 
+    Pass ``env_paths=True`` to populate ``info['env_specs'][name]['path']``
+    with the filesystem prefix for each declared environment. For
+    anaconda-project this is computed from each :class:`EnvSpec` and is
+    free; for pixi we shell out to ``pixi info --json`` (so it costs a
+    subprocess) and surface any error from that call.
+
     Raises:
         ValueError: *project_type* is not a recognized value, or the pixi
             manifest cannot be parsed.
         FileNotFoundError: the requested manifest (or, with no
             *project_type*, neither manifest) is not present.
+        RuntimeError: ``env_paths=True`` was requested for a pixi project
+            and ``pixi info --json`` failed.
     """
     if project_type is None:
         project_type = detect_project_type(project_dir)
@@ -98,15 +106,52 @@ def publication_info(project_dir, project_type=None):
 
     if project_type == PROJECT_TYPE_PIXI:
         info = _pixi_publication_info(project_dir)
+        if env_paths:
+            _attach_pixi_env_paths(info, project_dir)
     else:
-        info = _anaconda_project_publication_info(project_dir)
+        info = _anaconda_project_publication_info(project_dir, env_paths=env_paths)
     info[PROJECT_TYPE_KEY] = project_type
     return info
 
 
-def _anaconda_project_publication_info(project_dir):
+def _anaconda_project_publication_info(project_dir, env_paths=False):
     from anaconda_project.project import Project
-    return Project(project_dir).publication_info()
+    project = Project(project_dir)
+    info = project.publication_info()
+    if env_paths:
+        for name, env in project.env_specs.items():
+            if name in info['env_specs']:
+                info['env_specs'][name]['path'] = env.path(project_dir)
+    return info
+
+
+def _attach_pixi_env_paths(info, project_dir):
+    """Fill in ``info['env_specs'][name]['path']`` from ``pixi info --json``.
+
+    Pixi reports prefixes in ``environments_info[].prefix``. Any failure to
+    invoke pixi or parse its output raises :class:`RuntimeError` — callers
+    only ask for env paths explicitly via ``env_paths=True``, so silent
+    fallback would hide bugs.
+    """
+    import json
+    import subprocess
+    pixi_path = os.path.join(project_dir, PIXI_MANIFEST)
+    try:
+        out = subprocess.check_output(
+            ['pixi', 'info', '--json', '--manifest-path', pixi_path],
+            stderr=subprocess.PIPE,
+        )
+    except (OSError, subprocess.CalledProcessError) as e:
+        raise RuntimeError('Failed to run `pixi info --json`: {}'.format(e)) from e
+    try:
+        data = json.loads(out)
+    except ValueError as e:
+        raise RuntimeError('Could not parse `pixi info --json` output: {}'.format(e)) from e
+    for env in data.get('environments_info', []):
+        name = env.get('name')
+        prefix = env.get('prefix')
+        if name in info['env_specs'] and prefix:
+            info['env_specs'][name]['path'] = prefix
 
 
 def _read_pixi_lock_envs(project_dir):

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -126,7 +126,8 @@ def _anaconda_project_publication_info(project_dir, env_paths=False):
 
 
 def _attach_pixi_env_paths(info, project_dir):
-    """Fill in ``info['env_specs'][name]['path']`` from ``pixi info --json``.
+    """Fill in ``info['env_specs'][name]['path']`` and stash the full
+    ``pixi info --json`` payload at ``info['_pixi']``.
 
     Pixi reports prefixes in ``environments_info[].prefix``. Any failure to
     invoke pixi or parse its output raises :class:`RuntimeError` — callers
@@ -152,6 +153,7 @@ def _attach_pixi_env_paths(info, project_dir):
         prefix = env.get('prefix')
         if name in info['env_specs'] and prefix:
             info['env_specs'][name]['path'] = prefix
+    info['_pixi'] = data
 
 
 def _read_pixi_lock_envs(project_dir):

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -215,6 +215,36 @@ class TestPublicationInfoTasks:
             assert info['commands']['serve']['unix'] == 'flask run'
             assert info['commands']['serve']['supports_http_options'] is True
 
+    def test_args_extracted_from_pixi_task(self):
+        # The exporter emits `args = [{ arg = "host", default = "" }, ...]`
+        # for tasks that take http options. publication_info should
+        # surface those arg names (in declaration order) so callers can
+        # know what positional values `pixi run <task>` expects.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [tasks.serve]
+                cmd = "panel serve foo.ipynb {% if port %}--port {{ port }}{% endif %}"
+                args = [{ arg = "host", default = "" }, { arg = "port", default = "" }]
+            """))
+            info = publication_info(td)
+            assert info['commands']['serve']['args'] == ['host', 'port']
+
+    def test_args_empty_for_string_task(self):
+        # A bare string task (no `args` key) gets an empty `args` list,
+        # not a missing key — keeps the schema uniform for callers.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n\n[tasks]\nrun = "echo hi"\n',
+            )
+            info = publication_info(td)
+            assert info['commands']['run']['args'] == []
+
     def test_first_task_is_default(self):
         with tempfile.TemporaryDirectory() as td:
             _write_pixi_toml(

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -131,7 +131,9 @@ class TestPublicationInfoBasic:
             assert info['name'] == 'test'
             assert info['description'] == ''
             assert info['commands'] == {}
-            assert info['env_specs'] == {'default': {'packages': [], 'channels': ['conda-forge']}}
+            assert info['env_specs'] == {
+                'default': {'packages': [], 'channels': ['conda-forge'], 'locked': False},
+            }
             assert info['variables'] == {}
             assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
 
@@ -418,6 +420,65 @@ class TestPublicationInfoEnvResolution:
             # Both default-feature and sampleproj-feature packages roll up.
             assert 'python' in info['env_specs']['sampleproj']['packages']
             assert 'pandas' in info['env_specs']['sampleproj']['packages']
+
+
+class TestPublicationInfoLocked:
+    def test_locked_false_when_no_lockfile(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                sampleproj = { features = ["sampleproj"] }
+            """))
+            info = publication_info(td)
+            assert info['env_specs']['sampleproj']['locked'] is False
+
+    def test_locked_true_when_env_in_pixi_lock(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                sampleproj = { features = ["sampleproj"] }
+                test = { features = ["test"] }
+            """))
+            with open(os.path.join(td, 'pixi.lock'), 'w') as f:
+                f.write(textwrap.dedent("""\
+                    version: 6
+                    environments:
+                      sampleproj:
+                        channels:
+                        - url: https://example/
+                        packages: {}
+                """))
+            info = publication_info(td)
+            # sampleproj is in the lock — locked. test is not — unlocked.
+            assert info['env_specs']['sampleproj']['locked'] is True
+            assert info['env_specs']['test']['locked'] is False
+
+    def test_malformed_lockfile_falls_back_to_unlocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                sampleproj = { features = ["sampleproj"] }
+            """))
+            with open(os.path.join(td, 'pixi.lock'), 'w') as f:
+                # Not valid YAML — should silently fall back, not raise.
+                f.write('this is not: { valid yaml: at all\n')
+            info = publication_info(td)
+            assert info['env_specs']['sampleproj']['locked'] is False
 
 
 class TestPublicationInfoFeatures:

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -292,6 +292,134 @@ class TestPublicationInfoTasks:
             assert info['commands']['serve']['env_spec'] == 'prod'
 
 
+class TestPublicationInfoEnvResolution:
+    """env_spec should always name an env that supports the task — never
+    a placeholder like 'default' when the project's only env has another
+    name, and never the bare feature name when a real env carries it."""
+
+    def test_top_level_task_resolves_to_first_env_when_no_default(self):
+        # Single declared env named 'sampleproj'. Top-level [tasks.X] runs
+        # in the resolved default env, which is the first declared.
+        # `default` is also surfaced unconditionally because pixi
+        # materializes it at runtime regardless.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                sampleproj = { features = ["sampleproj"] }
+
+                [tasks.run]
+                cmd = "echo hi"
+            """))
+            info = publication_info(td)
+            assert info['commands']['run']['env_spec'] == 'sampleproj'
+            assert set(info['env_specs']) == {'default', 'sampleproj'}
+
+    def test_top_level_task_keeps_default_when_explicitly_declared(self):
+        # When the user *does* declare `default` in [environments], use
+        # that name verbatim — don't promote a sibling env.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                default = { features = [] }
+                ml = { features = ["ml"] }
+
+                [tasks.run]
+                cmd = "echo hi"
+            """))
+            info = publication_info(td)
+            assert info['commands']['run']['env_spec'] == 'default'
+            assert 'default' in info['env_specs']
+            assert 'ml' in info['env_specs']
+
+    def test_feature_task_resolves_to_env_carrying_feature(self):
+        # [feature.ml.tasks.train] should report env_spec='ml' because
+        # the env named `ml` includes feature `ml`. The exporter's
+        # convention (feature name == env name) makes this trivial, but
+        # the resolution logic doesn't assume that — it walks
+        # [environments] entries to find which envs include the feature.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                ml = { features = ["ml"] }
+
+                [feature.ml.tasks.train]
+                cmd = "python train.py"
+            """))
+            info = publication_info(td)
+            assert info['commands']['train']['env_spec'] == 'ml'
+
+    def test_feature_task_picks_default_env_when_multiple_match(self):
+        # If the same feature is included in multiple envs, the resolved
+        # default wins (so `pixi run task` matches the env publication
+        # picks).
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                primary = { features = ["common"] }
+                secondary = { features = ["common"] }
+
+                [feature.common.tasks.run]
+                cmd = "echo hi"
+            """))
+            info = publication_info(td)
+            # primary is first declared → resolved default → wins.
+            assert info['commands']['run']['env_spec'] == 'primary'
+
+    def test_default_env_always_surfaced_alongside_named_envs(self):
+        # Pixi always materializes a `default` env at runtime, so
+        # publication_info surfaces it unconditionally. Default-feature
+        # packages flow into the `default` env_spec; feature-specific
+        # deps flow into the named env. Each env carries the right
+        # packages (no cross-pollination).
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [dependencies]
+                python = "*"
+
+                [feature.sampleproj.dependencies]
+                pandas = "*"
+
+                [environments]
+                sampleproj = { features = ["sampleproj"] }
+            """))
+            info = publication_info(td)
+            assert set(info['env_specs']) == {'default', 'sampleproj'}
+            # `default` carries only the default-feature packages.
+            assert info['env_specs']['default']['packages'] == ['python']
+            # `sampleproj` inherits the default feature plus its own.
+            sample = info['env_specs']['sampleproj']['packages']
+            assert 'python' in sample
+            assert 'pandas' in sample
+            # Both default-feature and sampleproj-feature packages roll up.
+            assert 'python' in info['env_specs']['sampleproj']['packages']
+            assert 'pandas' in info['env_specs']['sampleproj']['packages']
+
+
 class TestPublicationInfoFeatures:
     def test_feature_tasks_included(self):
         with tempfile.TemporaryDirectory() as td:

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -747,6 +747,99 @@ class TestProjectTypeKey:
             assert publication_info(td)[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
 
 
+class TestEnvPaths:
+    """`env_paths=True` populates `info['env_specs'][name]['path']`. The
+    anaconda-project branch derives paths from each EnvSpec; the pixi branch
+    shells out to `pixi info --json`."""
+
+    def test_default_does_not_include_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert 'path' not in info['env_specs']['default']
+
+    def test_pixi_env_paths_via_subprocess(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            fake_json = (
+                '{"environments_info": ['
+                '{"name": "default", "prefix": "/fake/path/.pixi/envs/default"}'
+                ']}'
+            ).encode('utf-8')
+
+            def fake_check_output(cmd, stderr=None):
+                assert cmd[0] == 'pixi'
+                assert '--json' in cmd
+                return fake_json
+
+            import subprocess
+            monkeypatch.setattr(subprocess, 'check_output', fake_check_output)
+            info = publication_info(td, env_paths=True)
+            assert info['env_specs']['default']['path'] == '/fake/path/.pixi/envs/default'
+
+    def test_pixi_env_paths_subprocess_failure_raises(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+
+            import subprocess
+
+            def fake_check_output(cmd, stderr=None):
+                raise subprocess.CalledProcessError(1, cmd, stderr=b'pixi: bad manifest')
+
+            monkeypatch.setattr(subprocess, 'check_output', fake_check_output)
+            with pytest.raises(RuntimeError) as exc:
+                publication_info(td, env_paths=True)
+            assert 'pixi info' in str(exc.value)
+
+    def test_pixi_env_paths_pixi_missing_raises(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            import subprocess
+
+            def fake_check_output(cmd, stderr=None):
+                raise OSError(2, 'No such file or directory: pixi')
+
+            monkeypatch.setattr(subprocess, 'check_output', fake_check_output)
+            with pytest.raises(RuntimeError) as exc:
+                publication_info(td, env_paths=True)
+            assert 'pixi info' in str(exc.value)
+
+    def test_pixi_env_paths_invalid_json_raises(self, monkeypatch):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            import subprocess
+
+            monkeypatch.setattr(subprocess, 'check_output',
+                                lambda cmd, stderr=None: b'not actually json')
+            with pytest.raises(RuntimeError) as exc:
+                publication_info(td, env_paths=True)
+            assert 'parse' in str(exc.value)
+
+    def test_anaconda_project_env_paths(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, textwrap.dedent("""\
+                name: sample
+                env_specs:
+                  default:
+                    channels: [defaults]
+                    packages: [python=3.12]
+                  alt:
+                    channels: [defaults]
+                    packages: [python=3.12, flask]
+            """))
+            info = publication_info(td, env_paths=True)
+            for name in ('default', 'alt'):
+                path = info['env_specs'][name]['path']
+                assert path.endswith(os.path.join('envs', name))
+                assert os.path.isabs(path)
+
+
 class TestExplicitProjectType:
     """Caller-supplied `project_type` overrides the pixi-wins-by-default
     detection. Asking for a format whose manifest is absent is an error."""

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -745,3 +745,51 @@ class TestProjectTypeKey:
         with tempfile.TemporaryDirectory() as td:
             _write_pixi_toml(td, '[workspace]\nname = "t"\n')
             assert publication_info(td)[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
+
+
+class TestExplicitProjectType:
+    """Caller-supplied `project_type` overrides the pixi-wins-by-default
+    detection. Asking for a format whose manifest is absent is an error."""
+
+    def test_force_anaconda_project_when_both_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "from-pixi"\n')
+            _write_anaconda_project(td, textwrap.dedent("""\
+                name: from-yml
+                env_specs:
+                  default:
+                    channels: [defaults]
+                    packages: [python=3.12]
+            """))
+            info = publication_info(td, project_type=PROJECT_TYPE_ANACONDA_PROJECT)
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_ANACONDA_PROJECT
+            assert info['name'] == 'from-yml'
+
+    def test_force_pixi_when_both_present(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "from-pixi"\n')
+            _write_anaconda_project(td, 'name: from-yml\n')
+            info = publication_info(td, project_type=PROJECT_TYPE_PIXI)
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
+            assert info['name'] == 'from-pixi'
+
+    def test_force_pixi_without_pixi_toml_raises(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, 'name: t\n')
+            with pytest.raises(FileNotFoundError) as exc:
+                publication_info(td, project_type=PROJECT_TYPE_PIXI)
+            assert 'pixi.toml' in str(exc.value)
+
+    def test_force_anaconda_project_without_yml_raises(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            with pytest.raises(FileNotFoundError) as exc:
+                publication_info(td, project_type=PROJECT_TYPE_ANACONDA_PROJECT)
+            assert 'anaconda-project.yml' in str(exc.value)
+
+    def test_unknown_project_type_raises(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            with pytest.raises(ValueError) as exc:
+                publication_info(td, project_type='conda-workspaces')
+            assert 'conda-workspaces' in str(exc.value)

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -768,7 +768,7 @@ class TestEnvPaths:
                 '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
             )
             fake_json = (
-                '{"environments_info": ['
+                '{"platform": "osx-arm64", "environments_info": ['
                 '{"name": "default", "prefix": "/fake/path/.pixi/envs/default"}'
                 ']}'
             ).encode('utf-8')
@@ -782,6 +782,19 @@ class TestEnvPaths:
             monkeypatch.setattr(subprocess, 'check_output', fake_check_output)
             info = publication_info(td, env_paths=True)
             assert info['env_specs']['default']['path'] == '/fake/path/.pixi/envs/default'
+            # Full pixi info --json output is stashed under `_pixi`.
+            assert info['_pixi']['platform'] == 'osx-arm64'
+            assert info['_pixi']['environments_info'][0]['prefix'] == \
+                '/fake/path/.pixi/envs/default'
+
+    def test_pixi_env_paths_no_pixi_field_when_not_requested(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(
+                td,
+                '[workspace]\nname = "t"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert '_pixi' not in info
 
     def test_pixi_env_paths_subprocess_failure_raises(self, monkeypatch):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary

Stacked on #429. HTTP-options support across all three command shapes, several `publication_info` fixes for downstream consumers, and a perf fix that cuts cold-start cost on the read path by ~80%.

## HTTP options translation in `pixi_export`

`supports_http_options: true` is implicit on `notebook:` and `bokeh_app:` commands. Translated per command type:

### `notebook:` commands

```toml
[tasks.nb]
cmd = """\
jupyter notebook report.ipynb \
--NotebookApp.default_url=/notebooks/report.ipynb \
{% if port %}--port {{ port }}{% endif %} \
{% if address %}--ip {{ address }}{% endif %} \
{% if url_prefix %}--NotebookApp.base_url={{ url_prefix }}{% endif %} \
{% if iframe_hosts %}--NotebookApp.tornado_settings={...}{% endif %} \
{% if no_browser %}--no-browser{% endif %} \
{% if use_xheaders %}--NotebookApp.trust_xheaders=True{% endif %}\
"""
args = [{ arg = "port", default = "" }, { arg = "address", default = "" }, ...]
```

### `bokeh_app:` commands

```toml
[tasks.app]
cmd = """\
bokeh serve myapp \
{% if host %}--host {{ host }}{% endif %} \
{% if port %}--port {{ port }}{% endif %} \
{% if address %}--address {{ address }}{% endif %} \
{% if url_prefix %}--prefix {{ url_prefix }}{% endif %} \
{% if not no_browser %}--show{% endif %} \
{% if use_xheaders %}--use-xheaders{% endif %}\
"""
args = [{ arg = "host", default = "" }, ...]
```

### Generic `unix:` with `supports_http_options: true`

```toml
[feature.sampleproj.tasks.dashboard]
cmd = """\
panel serve glaciers.ipynb \
{% if host %}--anaconda-project-host {{ host }}{% endif %} \
...
"""
args = [{ arg = "host", default = "" }, ...]
```

### `supports_http_options: false`

Scan the user's templated `unix:` line for HTTP Jinja vars (`{{ port }}`, `{{ host }}`, etc.) and declare pixi args only for the ones actually referenced. The cmd template is left verbatim.

### Per-tool arg counts

| shape | count | dropped |
|---|---|---|
| generic | 7 | — |
| `notebook:` | 6 | `host` (jupyter has no equivalent) |
| `bokeh_app:` | 6 | `iframe_hosts` (bokeh has no CSP) |

## `publication_info` improvements

* `info['commands'][name]['args']` — ordered list of pixi arg names. Empty for tasks without args. Lets downstream tooling drive `pixi run <task> *args` with positional values pulled from env vars or wherever.
* `info['commands'][name]['env_spec']` — resolves to an env that actually supports the task. Top-level tasks → resolved default env. Feature-scoped tasks → an env that includes the feature.
* `info['env_specs'][name]['locked']` — `True` if `pixi.lock` has an `environments[<name>]` entry. Silent `False` on any read/parse failure.
* `info['env_specs']` no longer surfaces a phantom `default` entry alongside user-declared envs.
* **Optional `project_type` argument** to force a specific manifest format. Default behavior (auto-detect, pixi-wins-when-both-present) is unchanged. Callers that need to read whichever they ask for explicitly — typically mid-conversion directories where both `pixi.toml` and `anaconda-project.yml` exist — can now pass `project_type='pixi'` or `project_type='anaconda-project'`. Asking for a format whose manifest is absent raises `FileNotFoundError`; an unrecognized value raises `ValueError`.
* **Optional `env_paths=True`** to populate `info['env_specs'][name]['path']` with the filesystem prefix for each declared environment. Off by default. For anaconda-project the path comes from each `EnvSpec.path()` — free. For pixi we shell out to `pixi info --json --manifest-path <pixi.toml>` and read `environments_info[].prefix`; failure to invoke pixi or parse its output raises `RuntimeError` since the caller explicitly opted in. When the source project is pixi *and* `env_paths=True`, the full `pixi info --json` payload is also stashed under an `_pixi` key in the result for callers that want richer pixi-specific data without making a second subprocess call.

## New `anaconda-project info` subcommand

Human-readable summary of `publication_info()` modeled on `pixi info`.

```
$ anaconda-project info --directory .
Project
------------
              Type: pixi
              Name: Attractors
       Description: A panel dashboard using datashader to interact with attractor equations.
         Directory: /Users/.../attractors

Commands
------------
           Command: dashboard  [default, http]
                  : env_spec: sampleproj
                  : cmd: panel serve attractors.ipynb {% if host %}...{% endif %} ...
                  : args: host, port, address, url_prefix, iframe_hosts, no_browser, use_xheaders

Environments
------------
       Environment: default
          Channels: https://repo.anaconda.com/pkgs/main, https://repo.anaconda.com/pkgs/r
  Dependency count: 12
      Dependencies: colorcet, datashader, fiona, geoviews, ipykernel, jupyter_bokeh, ...
            Locked: yes
```

Flags:

* `--json` — emit the `publication_info` dict as indented JSON, mirroring `pixi info --json`.
* `--env-paths` — include filesystem prefix paths for each environment. For pixi, this shells out to `pixi info --json` and (in `--json` mode) stashes the full pixi output under an `_pixi` key.
* `--project-type {pixi,anaconda-project}` — force a manifest format when both are present.

## prepare task convention (final)

Every converted project gets a `prepare` task. The body depends on context:

* **Source yml declared `downloads:`** → prepare invokes `ap_download.py` once per download.
* **No downloads** → prepare is a no-op `echo`. It still serves as the converted-project marker (downstream tooling detects converted projects by task name) and, when scoped to a non-default env's feature, as the env-selection entry point that makes `pixi run prepare` resolve to the right env.

## Cold-start perf fix

`publication_info()` was ~80x slower on `anaconda-project.yml` than on `pixi.toml` (~1150ms vs ~14ms on a small project). Profiling showed the gap was almost entirely module-import cost — paid once per process, but very visible in CLI tools and short-lived workers.

Three concurrent fixes in this PR:

1. **`current_platform()` reimplemented in pure Python** — mirrors `conda.base.context._native_subdir` (CONDA_SUBDIR override, sys.platform map, non-x86 machine table, pointer size). The previous implementation shelled out to `conda info --json` at *module-import time* (line `_default_platforms_with_current = ...`), accounting for ~1s on every `import anaconda_project`. Verified to match `conda info --json` on the dev machine; honors `CONDA_SUBDIR` so the existing parametrized non-x86 tests still pass.
2. **`default_platforms` updated** to `('linux-64', 'linux-aarch64', 'osx-arm64', 'win-64')` — the 2026 default set.
3. **Lazy imports** for heavy optional deps: `conda_pack._progress` and `tqdm` moved inside their call sites in `archiver.py`; `jinja2.Template` moved inside `_TemplateArgsTransformer.parse_and_template`. None of these are touched on the publication_info read path.

Result on a small attractors project (cold process):

| | before | after |
|---|---|---|
| anaconda-project | ~1149ms | ~180ms |
| pixi | ~14ms | ~9ms |
| anaconda-project (steady-state) | ~10ms | ~11ms |

The remaining ~140ms cold cost in dev checkouts is `_version.py` shelling out to `git describe` — versioneer writes a static `_version.py` at sdist/wheel build time, so installed distributions don't pay this cost.

## Test plan

* [x] 124 tests across `test_pixi_export.py` and `test_project_info.py` pass.
* [x] Glaciers (`panel serve` with `supports_http_options: true`): all 7 args declared; gated flags render correctly; `pixi run dashboard <host> <port> ...` works.
* [x] NYC Taxi (downloads): prepare task fetches the parquet; absent if downloads were also absent.
* [x] Multi-env with literal `default`: `default` slot commented in `[environments]`; default-feature packages folded; `env_spec` resolution names a real env.
* [x] `current_platform()` matches `conda info --json` on darwin/arm64.
* [ ] Convert a real notebook: project; verify `pixi run nb` accepts `--port` overrides correctly.
* [ ] Convert a real bokeh_app: project; verify `--show` (no-browser inverse) renders correctly.
