### PR TITLE
docs: project status, pixi support page, and modern feedback channels

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+# Read the Docs configuration. See:
+# https://docs.readthedocs.com/platform/stable/config-file/v2.html
+#
+# Read the Docs requires this file (in the repository root) to build
+# the docs. Sphinx config and dependencies live under docs/.
+
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    # miniforge3 supplies conda + the conda-forge channel by default,
+    # which matches the resolution we get locally with the env file.
+    python: "miniforge3-latest"
+
+conda:
+  environment: docs/environment.yml
+
+sphinx:
+  configuration: docs/source/conf.py

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,9 +1,11 @@
 name: anaconda-project-docs
 dependencies:
 - sphinx
-- pydata-sphinx-theme=0.14.4
+- pydata-sphinx-theme
 - sphinx-copybutton
 - sphinx-notfound-page
 channels:
-- defaults
+# `defaults` is intentionally omitted: Read the Docs build images
+# can't accept the Anaconda ToS gate that channel now requires, and
+# every package listed above is available on conda-forge.
 - conda-forge

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,4 +8,10 @@ channels:
 # `defaults` is intentionally omitted: Read the Docs build images
 # can't accept the Anaconda ToS gate that channel now requires, and
 # every package listed above is available on conda-forge.
+#
+# This applies only to the docs build environment. Projects exported
+# via `anaconda-project export-pixi` still resolve against the user's
+# configured `default_channels` (typically `pkgs/main` + `pkgs/r`);
+# the conda-forge-only choice here is a build-tooling decision, not
+# a project-level default.
 - conda-forge

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,8 +13,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import os
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -126,10 +124,12 @@ todo_include_todos = False
 # a list of builtin themes.
 #
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
-
-if not on_rtd:  # only import and set the theme if we're building docs locally
-    html_theme = 'pydata_sphinx_theme'
+# Always set the theme. The previous `if not on_rtd:` guard skipped this
+# when building on Read the Docs (where READTHEDOCS=True), back when RTD
+# injected its own theme. RTD no longer does that — without the explicit
+# assignment sphinx falls back to alabaster, which doesn't understand the
+# pydata-specific options below and fails to render.
+html_theme = 'pydata_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further. The documentation for the current theme is found at

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -56,7 +56,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Anaconda Project'
-copyright = '2022, Anaconda, Inc'
+copyright = '2026, Anaconda, Inc'
 author = 'Anaconda'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -11,7 +11,7 @@ After completing this guide, you will be able to:
 * Run the project with a single command.
 * Package and share the project.
 
-If you have not yet installed and started Project,
+If you have not yet installed and started anaconda-project,
 follow the :doc:`Installation instructions <install>`.
 
 
@@ -113,9 +113,9 @@ To share this project with a colleague:
 
 For more information, see :doc:`user-guide/tasks/share-project`.
 
-Anyone with Project can run your project by unzipping the
-project archive file and then running a single command, without
-having to do any setup::
+Anyone with anaconda-project installed can run your project by
+unzipping the project archive file and then running a single command,
+without having to do any setup::
 
      $ anaconda-project unarchive interactive.zip
      $ cd demo_app
@@ -125,14 +125,14 @@ having to do any setup::
    using your project will need to specify which command to run.
    For more information, see :doc:`user-guide/tasks/run-project`.
 
-Project downloads the data, installs the necessary packages and
+anaconda-project downloads the data, installs the necessary packages and
 runs the command.
 
 
 Next steps
 ==========
 
-* Learn more about :doc:`what you can do in Project
+* Learn more about :doc:`what you can do with anaconda-project
   <user-guide/tasks/index>`, including how to :doc:`download data
   <user-guide/tasks/download-data>` with your project and how to
   :doc:`configure your project with environment variables

--- a/docs/source/help-support.rst
+++ b/docs/source/help-support.rst
@@ -25,13 +25,3 @@ For new project work, we encourage users to evaluate
 `conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_,
 or `uv <https://docs.astral.sh/uv/>`_ directly.
 
-Send feedback
-=============
-
-Suggestions for documentation or code fixes belong in the
-`Github Issue Tracker`_. Anaconda, Inc.\ |reg| (formerly Continuum
-Analytics) no longer monitors the legacy ``documentation@continuum.io``
-address; please use GitHub issues so the discussion stays attached to
-the codebase.
-
-.. |reg|    unicode:: U+000AE .. REGISTERED SIGN

--- a/docs/source/help-support.rst
+++ b/docs/source/help-support.rst
@@ -2,24 +2,36 @@
 Help and support
 ================
 
-To ask questions or submit bug reports, use the 
+To ask questions or submit bug reports, use the
 `Github Issue Tracker`_.
 
 .. _`Github Issue Tracker`: https://github.com/Anaconda-Platform/anaconda-project/issues
 
+Project scope
+=============
 
-Paid support 
-============
+Anaconda Project is in maintenance mode. The repository's active
+development focus is limited to:
 
-Anaconda Project is an open source project that originated at 
-`Anaconda, Inc. <https://www.anaconda.com/>`_
-Continuum offers paid `training 
-<https://www.continuum.io/training>`_ and `support 
-<https://www.continuum.io/support>`_.
+* Critical bug fixes against the existing ``anaconda-project``
+  command-line tool and library.
+* The conversion tooling described in :doc:`pixi-support`, which
+  helps users move existing projects onto
+  `pixi <https://pixi.sh/>`_ or
+  `conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_.
 
+For new project work, we encourage users to evaluate
+`pixi <https://pixi.sh/>`_,
+`conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_,
+or `uv <https://docs.astral.sh/uv/>`_ directly.
 
 Send feedback
 =============
 
-Help us make this documentation better. Send feedback about the 
-Project documentation to documentation@continuum.io.
+Suggestions for documentation or code fixes belong in the
+`Github Issue Tracker`_. Anaconda, Inc.\ |reg| (formerly Continuum
+Analytics) no longer monitors the legacy ``documentation@continuum.io``
+address; please use GitHub issues so the discussion stays attached to
+the codebase.
+
+.. |reg|    unicode:: U+000AE .. REGISTERED SIGN

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,23 +4,23 @@ Anaconda Project
 
 :emphasis:`Reproducible and executable project directories`
 
-Anaconda Project encapsulates data science projects and makes 
-them easily portable. Project automates setup steps such as 
-installing the right packages, downloading files, setting 
+Anaconda Project encapsulates data science projects and makes
+them easily portable. anaconda-project automates setup steps such as
+installing the right packages, downloading files, setting
 environment variables and running commands.
 
-Project makes it easy to reproduce your work, share projects with 
-others and run them on different platforms. It also simplifies 
-deployment to servers. Anaconda projects run the same way on your 
+anaconda-project makes it easy to reproduce your work, share projects with
+others and run them on different platforms. It also simplifies
+deployment to servers. Anaconda projects run the same way on your
 machine, on another user's machine or when deployed to a server.
 
-Traditional build scripts such as ``setup.py`` automate building 
-the project---going from source code to something 
-runnable---while Project automates running the project---taking 
-build artifacts and doing any necessary setup before executing 
+Traditional build scripts such as ``setup.py`` automate building
+the project---going from source code to something
+runnable---while anaconda-project automates running the project---taking
+build artifacts and doing any necessary setup before executing
 them.
 
-You can use Project on Windows, macOS and Linux.
+You can use anaconda-project on Windows, macOS and Linux.
 
 Project is supported and offered by Anaconda, Inc\ |reg|
 and contributors under a 3-clause BSD license.
@@ -49,65 +49,54 @@ Quick Start
 
 Check out the :ref:`Getting Started` guide
 
-Benefits of Project
-====================
+Benefits of anaconda-project
+============================
 
- * A ``README`` file that contains setup steps can become 
-   outdated, or users might not read it and then you have to help 
-   them diagnose problems. Project automates the setup steps so 
-   that the ``README`` file need only say "Type 
+ * A ``README`` file that contains setup steps can become
+   outdated, or users might not read it and then you have to help
+   them diagnose problems. anaconda-project automates the setup steps so
+   that the ``README`` file need only say "Type
    ``anaconda-project run``."
 
- * Project facilitates collaboration by ensuring that all users
-   working on a project have the same dependencies in their Conda 
-   environments. Project automates environment creation and 
+ * anaconda-project facilitates collaboration by ensuring that all users
+   working on a project have the same dependencies in their Conda
+   environments. anaconda-project automates environment creation and
    verifies that environments have the right versions of packages.
 
- * You can run ``os.getenv("DB_PASSWORD")`` and configure Project 
-   to prompt the user for any missing credentials. This allows 
-   you to avoid including your personal passwords or secret keys 
+ * You can run ``os.getenv("DB_PASSWORD")`` and configure anaconda-project
+   to prompt the user for any missing credentials. This allows
+   you to avoid including your personal passwords or secret keys
    in your code.
 
- * Project improves reproducibility. Someone who wants to 
-   reproduce your analysis can ensure that they have the same 
+ * anaconda-project improves reproducibility. Someone who wants to
+   reproduce your analysis can ensure that they have the same
    setup that you have on your machine.
 
- * Project simplifies deployment of your analysis as a web 
-   application. The configuration in ``anaconda-project.yml`` 
-   tells hosting providers how to run your project, so no special 
-   setup is needed when you move from your local machine to the 
+ * anaconda-project simplifies deployment of your analysis as a web
+   application. The configuration in ``anaconda-project.yml``
+   tells hosting providers how to run your project, so no special
+   setup is needed when you move from your local machine to the
    web.
 
 
-How Project works
-=================
+How anaconda-project works
+==========================
 
-By adding an ``anaconda-project.yml`` configuration file to your 
-project directory, a single ``anaconda-project run`` command can 
-set up all dependencies and then launch the project. Running an 
-Anaconda project executes a command specified in the 
-``anaconda-project.yml`` file, where you can also configure any 
-arbitrary commands. 
+By adding an ``anaconda-project.yml`` configuration file to your
+project directory, a single ``anaconda-project run`` command can
+set up all dependencies and then launch the project. Running an
+Anaconda project executes a command specified in the
+``anaconda-project.yml`` file, where you can also configure any
+arbitrary commands.
 
-Project automates project setup by establishing all prerequisite 
-conditions for the project's commands to execute successfully. 
+anaconda-project automates project setup by establishing all prerequisite
+conditions for the project's commands to execute successfully.
 These conditions could include:
 
 * Creating a Conda environment that includes certain packages.
 * Prompting the user for passwords or other configuration.
 * Downloading data files.
 * Starting extra processes such as a database server.
-
-
-Stability
-=========
-
-Currently, the Project API and command-line syntax are subject to 
-change in future releases. A project created with the current 
-beta version of Project may always need to be run with that 
-version of Project and not Project 1.0. When we think things are 
-solid, we will switch from beta to version 1.0, and you will be 
-able to rely on long-term interface stability.
 
 
 .. toctree::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,8 +22,27 @@ them.
 
 You can use Project on Windows, macOS and Linux.
 
-Project is supported and offered by Anaconda, Inc\ |reg| 
+Project is supported and offered by Anaconda, Inc\ |reg|
 and contributors under a 3-clause BSD license.
+
+Project status
+==============
+
+Anaconda Project has not been actively developed in some time and has
+largely been superseded by newer alternatives.
+`conda-project <https://conda-incubator.github.io/conda-project/>`_
+was the first follow-on effort; today,
+`pixi <https://pixi.sh/>`_ and
+`uv <https://docs.astral.sh/uv/>`_ represent the first truly successful
+successors.
+`conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_
+is a promising pixi-compatible alternative for users who prefer to
+stay closer to the conda ecosystem.
+
+For that reason, recent work on this repository has been (and will
+remain) focused on critical bug fixes and on the ability to convert
+existing Anaconda Project projects into the pixi and conda-workspaces
+formats. See :doc:`pixi-support` for details on the conversion tooling.
 
 Quick Start
 ===========
@@ -107,6 +126,13 @@ able to rely on long-term interface stability.
    user-guide/concepts
    user-guide/tasks/index
    user-guide/reference
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: Pixi support
+
+   pixi-support
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -2,88 +2,26 @@
 Installation
 ============
 
-:doc:`Anaconda Project <index>` is included in Anaconda\ |reg| versions 4.3.1 and later.
-
-To check that you have ``anaconda-project``:
-
-1. Open a terminal window.
-
-   * (Windows) Open your start menu, type in "cmd", and click the Command Prompt application.
-   * (macOS) Open Launchpad and click the Terminal application.
-   * (Linux) Search for a Terminal in your Activities or Applications or (in most systems) enter Ctrl-Alt-T.
-
-2. Enter ``conda list``. Your terminal window should looks something like the following:
-
-  .. code-block:: shell
-
-    (base) ~ conda list
-    # packages in environment at /Users/jdoe/opt/anaconda3:
-    #
-    # Name                    Version                   Build  Channel
-    _ipyw_jlab_nb_ext_conf    0.1.0            py39hecd8cb5_0
-    anaconda                  2021.11                  py39_0
-    anaconda-client           1.9.0            py39hecd8cb5_0
-    anaconda-navigator        2.1.1                    py39_0
-    anaconda-project          0.10.1             pyhd3eb1b0_0
-    ...
-
-3. If for some reason your package list doesn't contain ``anaconda-project``, see the section below for instructions on
-   how to install it manually.
-
-Installing Anaconda Project Manually
-------------------------------------
-
-If you don't have access to conda yet, `installing Miniconda
-<https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_ is the simplest way
-to obtain it.
-
-You can install Anaconda Project manually using the ``install`` command in your terminal window.
-
-.. code-block:: shell
-  
-  (base) ~ conda install anaconda-project
-  Collecting package metadata (current_repodata.json): done
-  Solving environment: done
-
-  ## Package Plan ##
-
-    environment location: /Users/jdoe/opt/anaconda3
-
-    added / updated specs:
-      - anaconda-project
-
-
-  The following packages will be downloaded:
-
-      package                    |            build
-      ---------------------------|-----------------
-      anaconda-project-0.10.2    |     pyhd3eb1b0_0         218 KB
-      ------------------------------------------------------------
-                                             Total:         218 KB
-
-  The following NEW packages will be INSTALLED:
-
-    anaconda-project   pkgs/main/noarch::anaconda-project-0.10.2-pyhd3eb1b0_0
-    conda-pack         pkgs/main/noarch::conda-pack-0.6.0-pyhd3eb1b0_0
-
-
-  Proceed ([y]/n)? 
-
-Enter 'y' to proceed.
+:doc:`Anaconda Project <index>` is available on the ``defaults`` channel
+and on `conda-forge <https://conda-forge.org/>`_. Install it into the
+conda environment of your choice:
 
 .. code-block:: shell
 
-  Downloading and Extracting Packages
-  anaconda-project-0.1 | 218 KB    | ##################################### | 100%
-  Preparing transaction: done
-  Verifying transaction: done
-  Executing transaction: done
+  conda install anaconda-project
 
-Test your installation by running ``anaconda-project`` with the ``version``
-option::
+Or, equivalently, from conda-forge:
+
+.. code-block:: shell
+
+  conda install -c conda-forge anaconda-project
+
+Verify the install:
+
+.. code-block:: shell
 
   anaconda-project --version
 
-A successful installation reports the version number.
-
-.. |reg|	unicode:: U+000AE .. REGISTERED SIGN
+If you do not yet have conda available, `Miniconda
+<https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_
+is the simplest way to obtain it.

--- a/docs/source/pixi-support.rst
+++ b/docs/source/pixi-support.rst
@@ -1,0 +1,197 @@
+============
+Pixi support
+============
+
+Anaconda Project ships two pieces of tooling aimed at converting
+existing ``anaconda-project.yml`` projects into a form that can be
+managed by `pixi <https://pixi.sh/>`_ (and, by extension,
+`conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_,
+which consumes the same ``pixi.toml`` format).
+
+These are the focus of recent maintenance on this repository:
+
+* The ``anaconda-project export-pixi`` command, which writes a
+  ``pixi.toml`` (and a sibling ``ap_download.py`` helper when needed)
+  alongside an existing ``anaconda-project.yml``.
+* A ``publication_info`` function in
+  ``anaconda_project.project_info`` that can read either
+  ``anaconda-project.yml`` or ``pixi.toml`` and return a uniform
+  dictionary describing the project's commands, environments, and
+  variables. Downstream deployment tooling that ingests both formats
+  uses this as its single integration point.
+
+The rest of this page documents the conventions the conversion uses
+to preserve as much of the original project's behavior as possible.
+
+Export goals
+============
+
+The conversion is best-effort but tries to satisfy three contracts:
+
+* The resulting ``pixi.toml`` should be installable and runnable
+  without further manual editing for the common project shapes
+  (``unix:`` commands, ``notebook:``, ``bokeh_app:``, ``downloads:``,
+  ``variables:``, single or multi-environment).
+* Tasks invoked under pixi should mirror the runtime behavior of
+  ``anaconda-project run`` as closely as the underlying tools allow,
+  including HTTP options, environment selection, and download fetching.
+* The converted manifest should be readable for a maintainer who
+  inspects it later — comments mark anything that couldn't be
+  translated faithfully, and warnings appear at the top of the file
+  when a downstream consumer needs to act.
+
+Environment layout
+==================
+
+* When the source yml has a single ``env_specs:`` entry with a
+  non-default name (for example ``sampleproj:``), packages live in
+  the top-level ``[dependencies]`` table (pixi's default feature) and
+  the named env inherits via ``features = ["sampleproj"]``. Pixi's
+  mandatory implicit ``default`` env carries the same packages, so
+  ``pixi install`` (without ``-e``) still does something useful.
+* Multi-environment projects emit each ``env_specs:`` entry under
+  ``[environments]`` in source order. The first uncommented entry is
+  the project's intended default; downstream tools can extract it with
+  one line of ``awk``.
+* If one of multiple env_specs is literally named ``default``, its
+  ``[environments]`` slot is rendered as a comment
+  (``# default  (pixi creates this implicitly...)``) and its packages
+  are folded into top-level ``[dependencies]``. Pixi auto-creates
+  ``default`` from the default feature, so redeclaring it would be
+  redundant.
+* ``solve-group`` is intentionally not emitted. Anaconda Project does
+  not assume environments solve together, and pixi shouldn't be told
+  otherwise on import.
+
+Channel handling
+================
+
+Pixi has no ``defaults`` meta-channel and no equivalent of conda's
+``default_channels`` configuration. Two cases are handled explicitly:
+
+* If the source yml lists no channels at all, the converted manifest
+  is populated from ``conda config --show default_channels`` rather
+  than a hard-coded ``conda-forge`` fallback. This preserves
+  enterprise users' ``.condarc``-configured mirrors.
+* If the source yml includes ``defaults`` alongside other channels,
+  only the ``defaults`` entry is expanded; the rest are preserved in
+  source order with duplicate URLs removed.
+
+If ``conda`` is not on PATH (or fails to invoke) and ``defaults``
+expansion is required, the conversion fails fast — no partial output
+is written.
+
+Tasks and command translation
+=============================
+
+* ``unix:`` command lines are translated to a form compatible with
+  pixi's ``deno_task_shell`` task runner. ``${VAR}`` and ``%VAR%``
+  references are normalized to ``$VAR``; ``${PROJECT_DIR}`` becomes
+  ``$PIXI_PROJECT_ROOT``.
+* When both ``unix:`` and ``windows:`` command lines are present, the
+  converter normalizes the windows form (path separators, env vars)
+  and compares to the unix form. Matching forms collapse to a single
+  task; divergent forms emit the unix variant plus a comment noting
+  what the windows form would have rendered.
+* ``${CONDA_PREFIX}/bin/<name>``, ``${CONDA_PREFIX}/Scripts/<name>``,
+  and similar prefix-rooted paths are stripped to the bare command
+  name. Pixi's task activation already prepends the env's executable
+  directories to ``PATH``, so explicit prefix paths are redundant and
+  hurt cross-platform portability.
+
+The ``prepare`` task
+====================
+
+Every converted project gets a ``prepare`` task. It does double duty:
+
+* When the source yml declared ``downloads:``, ``prepare`` runs a
+  helper script (``ap_download.py``, written next to ``pixi.toml``)
+  once per download. The helper is pure stdlib and uses ``python3``,
+  so it works whether or not the env declares its own python.
+* Even when there are no downloads, ``prepare`` is emitted as a no-op
+  ``echo``. Its presence serves two purposes:
+
+  - Acts as a marker that downstream deployment tooling can use to
+    detect that this ``pixi.toml`` was converted from
+    ``anaconda-project.yml``.
+  - When scoped to a non-default env's feature (e.g.
+    ``[feature.sampleproj.tasks.prepare]``), forces
+    ``pixi run prepare`` to resolve to that env automatically — useful
+    when the project's default env_spec is named something other than
+    ``default``.
+
+If a download-needing env doesn't declare ``python``, the converted
+``pixi.toml`` carries a ``# WARNING:`` comment block at the top
+listing the affected envs, and the same warning is printed to stderr
+at conversion time. The conversion does not silently mutate the
+user's package list.
+
+HTTP options
+============
+
+Anaconda Project's ``supports_http_options: true`` (implicit on
+``notebook:`` and ``bokeh_app:`` commands) tells the underlying tool
+to expect ``--anaconda-project-X`` flags for host, port, address,
+url-prefix, iframe-hosts, no-browser, and use-xheaders. The exporter
+translates this contract into pixi ``args`` and templated ``cmd``
+strings, dispatching by command type:
+
+* ``notebook:`` commands become ``jupyter notebook <file>`` plus
+  Jupyter-native flags (``--port``, ``--ip``,
+  ``--NotebookApp.base_url=...``,
+  ``--NotebookApp.tornado_settings={...}`` for iframe hosts,
+  ``--no-browser``, ``--NotebookApp.trust_xheaders=True``). ``host``
+  is dropped because Jupyter has no host-restrict equivalent.
+* ``bokeh_app:`` commands become ``bokeh serve <app>`` plus bokeh's
+  bare flags (``--host``, ``--port``, ``--address``, ``--prefix``,
+  ``--use-xheaders``). ``--show`` is rendered as the *inverse* of
+  ``--no-browser``. ``iframe_hosts`` is dropped because bokeh has no
+  Content-Security-Policy equivalent.
+* Plain ``unix:`` commands with ``supports_http_options: true`` keep
+  their ``--anaconda-project-X`` flags verbatim. Generic tools that
+  opt in are expected to recognize the canonical names themselves
+  (``panel serve`` does).
+* ``unix:`` commands with ``supports_http_options: false`` are
+  scanned for HTTP Jinja vars (``{{ port }}``, ``{{ host }}``, etc.)
+  in their templates; pixi ``args`` are declared only for the vars
+  the cmd actually references.
+
+Each flag is wrapped in a Jinja conditional, so a blank pixi arg
+omits the flag entirely (rather than passing an empty value the
+underlying tool might reject).
+
+publication_info
+================
+
+``anaconda_project.project_info.publication_info(project_dir)``
+returns a uniform dictionary regardless of whether the project is
+managed by ``anaconda-project.yml`` or by a converted
+``pixi.toml``. The shape mirrors ``Project.publication_info()`` from
+the anaconda-project side; relevant additions for the pixi side:
+
+* ``commands[name]['args']`` — ordered list of pixi arg names
+  declared for the task. Empty for tasks without args. Lets
+  downstream tooling drive ``pixi run <task> *args`` to supply
+  positional values.
+* ``commands[name]['env_spec']`` — resolves to the name of an env
+  that supports the task. Top-level tasks resolve to the project's
+  default env (literal ``default`` if declared, otherwise the first
+  declared env). Feature-scoped tasks resolve to whichever env
+  actually includes the feature.
+* ``env_specs[name]['locked']`` — ``True`` when ``pixi.lock`` has an
+  ``environments[<name>]`` entry. Best-effort: any read or parse
+  failure silently falls back to ``False``.
+
+Limitations
+===========
+
+A few aspects of ``anaconda-project.yml`` cannot be translated
+faithfully. The exporter surfaces them as comments rather than
+silently dropping them:
+
+* ``services:`` (e.g. Redis) — pixi has no equivalent service-launch
+  primitive. The converted manifest carries a comment listing the
+  required services so a maintainer can wire them up out of band.
+* Variables without defaults — anaconda-project would prompt; pixi
+  cannot. The converted manifest emits a comment listing variables
+  that must be set in the environment before running.

--- a/docs/source/pixi-support.rst
+++ b/docs/source/pixi-support.rst
@@ -222,6 +222,16 @@ Each flag is wrapped in a Jinja conditional, so a blank pixi arg
 omits the flag entirely (rather than passing an empty value the
 underlying tool might reject).
 
+The ``{% if var %}...{% endif %}`` and ``{{ var }}`` template syntax
+inside task ``cmd`` strings is intentional, not accidental — pixi
+renders task commands through MiniJinja against the positional values
+passed to ``pixi run <task> <values...>`` (with ``args`` defaults
+filling in the rest), and only then hands the rendered command to
+``deno_task_shell`` for execution. The syntax is supported but not
+prominently documented in pixi's own docs; the converted ``pixi.toml``
+is exercising a real pixi feature, and editing the gates by hand is
+fine.
+
 The ``info`` command
 ====================
 

--- a/docs/source/pixi-support.rst
+++ b/docs/source/pixi-support.rst
@@ -19,6 +19,9 @@ These are the focus of recent maintenance on this repository:
   dictionary describing the project's commands, environments, and
   variables. Downstream deployment tooling that ingests both formats
   uses this as its single integration point.
+* The ``anaconda-project info`` command, a human-readable view of the
+  same data — modeled on ``pixi info`` — that works on either
+  manifest format.
 
 The rest of this page documents the conventions the conversion uses
 to preserve as much of the original project's behavior as possible.
@@ -160,6 +163,50 @@ Each flag is wrapped in a Jinja conditional, so a blank pixi arg
 omits the flag entirely (rather than passing an empty value the
 underlying tool might reject).
 
+The ``info`` command
+====================
+
+``anaconda-project info`` prints a human-readable summary of the
+project, modeled on ``pixi info``::
+
+    $ anaconda-project info --directory .
+    Project
+    ------------
+                  Type: pixi
+                  Name: Attractors
+           Description: A panel dashboard using datashader ...
+             Directory: /path/to/project
+
+    Commands
+    ------------
+               Command: dashboard  [default, http]
+                      : env_spec: sampleproj
+                      : cmd: panel serve attractors.ipynb {% if host %}...
+                      : args: host, port, address, url_prefix, ...
+
+    Environments
+    ------------
+           Environment: default
+              Channels: https://repo.anaconda.com/pkgs/main, ...
+      Dependency count: 12
+          Dependencies: colorcet, datashader, fiona, geoviews, ...
+                Locked: yes
+
+The command works on either manifest format — ``pixi.toml`` is
+preferred when both are present.
+
+Flags:
+
+* ``--json`` emits the underlying ``publication_info`` dict as
+  indented JSON, mirroring ``pixi info --json``.
+* ``--env-paths`` includes the on-disk prefix path for each
+  environment. For pixi projects this shells out to
+  ``pixi info --json``; the full pixi payload is also stashed
+  under an ``_pixi`` key in ``--json`` mode so callers don't have
+  to repeat the subprocess.
+* ``--project-type {pixi,anaconda-project}`` forces a manifest
+  format when both are present in the directory (e.g. mid-conversion).
+
 publication_info
 ================
 
@@ -181,6 +228,21 @@ the anaconda-project side; relevant additions for the pixi side:
 * ``env_specs[name]['locked']`` — ``True`` when ``pixi.lock`` has an
   ``environments[<name>]`` entry. Best-effort: any read or parse
   failure silently falls back to ``False``.
+
+Optional arguments:
+
+* ``project_type='pixi' | 'anaconda-project'`` forces a specific
+  manifest format. Default behavior is auto-detect, with ``pixi.toml``
+  winning when both are present. It is an error to ask for a format
+  whose manifest is not in the directory.
+* ``env_paths=True`` populates ``env_specs[name]['path']`` with the
+  on-disk prefix for each declared environment. For anaconda-project
+  this is derived from each ``EnvSpec``; for pixi it requires a
+  ``pixi info --json`` subprocess (so it is opt-in). Failure to
+  invoke pixi or parse its output raises ``RuntimeError``. When the
+  source is pixi, the full ``pixi info --json`` payload is also
+  stored under the top-level ``_pixi`` key so callers that want
+  richer pixi-specific data don't pay for a second subprocess.
 
 Limitations
 ===========

--- a/docs/source/pixi-support.rst
+++ b/docs/source/pixi-support.rst
@@ -66,6 +66,65 @@ Environment layout
   not assume environments solve together, and pixi shouldn't be told
   otherwise on import.
 
+The ``--use-default`` flag
+--------------------------
+
+Projects that have no env_spec literally named ``default`` route every
+dependency, task, and prepare body through ``[feature.{name}.*]``
+indirection — clean for projects that need explicit fan-out, but verbose
+for the common case of a single env (or a default command bound to one
+specific env in a multi-env project). Passing ``--use-default`` to
+``export-pixi`` collapses that:
+
+* The exporter picks one env_spec to promote to ``default``: the env_spec
+  attached to the project's default command (the one a bare
+  ``anaconda-project run`` would invoke), or — if there are no commands —
+  the first ``env_specs:`` entry declared.
+* That env_spec's packages, tasks, and prepare body land in top-level
+  ``[dependencies]`` / ``[tasks.X]`` / ``[tasks.prepare]`` instead of
+  inside ``[feature.{name}.*]`` blocks. Other env_specs (in a multi-env
+  project) keep their ``[feature.{name}.*]`` scoping unchanged.
+* The flag is a no-op when an env_spec literally named ``default``
+  already exists — there's nothing to rename.
+* Under ``--use-default`` the no-op ``prepare`` task is dropped. When
+  there are no ``downloads:`` to fetch, the unflagged export emits an
+  ``echo`` placeholder in ``[feature.{name}.tasks.prepare]`` so
+  ``pixi run prepare`` resolves to the project's intended env even
+  when that env's name isn't ``default``. Under ``--use-default`` the
+  promoted env *is* the implicit default, so the placeholder loses
+  its purpose; ``prepare`` is only emitted when there's real work to
+  do.
+
+When the user runs ``export-pixi`` without the flag and the project would
+benefit, the CLI prints a recommendation naming the env that would be
+promoted. With the flag on, the CLI confirms which env was renamed.
+The renaming applies only to the exported ``pixi.toml``; the source
+``anaconda-project.yml`` is not modified.
+
+The ``--add-current-platform`` flag
+-----------------------------------
+
+Pixi rejects an env that doesn't list the host platform; anaconda-project
+is more forgiving, so it's common to find a ported project with a
+``platforms:`` list that worked under conda but breaks at pixi install
+time on the developer's machine. Passing ``--add-current-platform`` to
+``export-pixi`` widens the converted manifest's ``platforms`` list to
+include the host's conda subdir (e.g. ``osx-arm64``) when it isn't
+already declared.
+
+Behavior mirrors ``--use-default``:
+
+* Off by default. The exporter does not silently mutate the user's
+  platforms list — the user explicitly chose what to support.
+* When omitted, the CLI prints a recommendation if the host platform
+  is missing.
+* When passed, the CLI prints a confirmation listing the platform
+  that was added — or stays quiet when the platform was already
+  present.
+
+The change applies only to the exported ``pixi.toml``; the source
+``anaconda-project.yml`` is not modified.
+
 Channel handling
 ================
 
@@ -243,6 +302,54 @@ Optional arguments:
   source is pixi, the full ``pixi info --json`` payload is also
   stored under the top-level ``_pixi`` key so callers that want
   richer pixi-specific data don't pay for a second subprocess.
+
+Programmatic export API
+=======================
+
+For tools that wrap the conversion (launchers, IDE plugins, custom CLIs),
+the export pipeline is exposed so downstream code never has to scrape
+generated TOML or re-implement the conversion rules.
+
+* ``project_ops.export_pixi(project, filename, use_default=False,
+  add_current_platform=False)`` writes ``pixi.toml`` to disk and returns
+  a ``PixiExportStatus``. On success the status carries:
+
+  - ``default_rename_from`` — the env_spec promoted to ``default`` by
+    ``use_default``, or ``None`` when the flag was off, no-op'd
+    (because ``default`` already existed), or the export failed.
+  - ``current_platform_added`` — the platform string added to the
+    ``platforms`` list by ``add_current_platform``, or ``None`` when
+    the flag was off, no-op'd (the platform was already declared), or
+    the export failed.
+
+  Callers use these to surface "Renamed env X → default" or "Added
+  platform Y" in their success notification without re-querying the
+  project.
+* ``project_ops.preview_pixi_export(project, use_default=False,
+  add_current_platform=False)`` runs the conversion in memory and
+  returns a dict
+  ``{pixi_toml, default_rename_from, current_platform_addition_target,
+  warnings}``. The ``pixi_toml`` entry is the would-be file content;
+  the rename / platform-addition fields report the *candidates*
+  (whether or not their flag was passed), so a confirmation dialog
+  can offer "re-render with --use-default" or "re-render with
+  --add-current-platform" as actions; ``warnings`` is the leading
+  ``# WARNING:`` block already extracted from the rendered TOML, so
+  callers don't have to grep for it themselves. Raises
+  ``CondaNotAvailableError`` if the conversion needs ``conda config
+  --show default_channels`` and conda isn't reachable.
+* ``anaconda_project.internal.pixi_export.default_rename_target(project)``
+  returns the env_spec name that ``--use-default`` would promote, or
+  ``None`` when promotion is a no-op (project already has a
+  ``default`` env_spec, or has no env_specs at all). Stable contract;
+  the underlying selection rule (default-command's env, else first
+  declared env_spec) lives in this one function.
+* ``anaconda_project.internal.pixi_export.current_platform_addition_target(project)``
+  returns the host's conda subdir if it would be added by
+  ``--add-current-platform``, or ``None`` when it's already in the
+  union of declared platforms. Same shape as
+  ``default_rename_target`` so callers can decide both flags
+  symmetrically.
 
 Limitations
 ===========

--- a/docs/source/user-guide/concepts.rst
+++ b/docs/source/user-guide/concepts.rst
@@ -57,7 +57,7 @@ Projects are affected by 3 configuration files:
   ``anaconda-project.yml``. For more information on
   ``anaconda-project-lock.yml``, see :doc:`reference`.
 
-To modify these files, use Project commands, Anaconda Navigator,
+To modify these files, use anaconda-project commands, Anaconda Navigator,
 or any text editor.
 
 
@@ -75,7 +75,7 @@ file that specifies 2 variables::
     - AMAZON_EC2_USERNAME
     - AMAZON_EC2_PASSWORD
 
-When a user runs your project, Project asks them for values to
+When a user runs your project, anaconda-project asks them for values to
 assign to these variables.
 
 In your script, you can use ``os.getenv()`` to obtain these
@@ -83,12 +83,12 @@ variables. This is a much better option than hardcoding passwords
 into your script, which can be a security risk.
 
 
-Comparing Project to conda env and environment.yml
-==================================================
+Comparing anaconda-project to conda env and environment.yml
+===========================================================
 
-Project has similar functionality to the ``conda env`` command
+anaconda-project has similar functionality to the ``conda env`` command
 and the ``environment.yml`` file, but it may be more convenient.
-The advantage of Project for environment handling is that it
+The advantage of anaconda-project for environment handling is that it
 performs conda operations and records them in a configuration
 file for reproducibility, all in one step.
 
@@ -103,7 +103,7 @@ The effect is comparable to adding the environment spec to
 environment and your configuration to be shared with others will
 not get out of sync.
 
-Project also automatically sets up environments for other users
+anaconda-project also automatically sets up environments for other users
 when they type ``anaconda-project run`` on their machines. They
 do not have to separately create, update or activate environments
 before they run the code. This may be especially useful when you
@@ -112,6 +112,6 @@ forget to rerun it and update their packages, while
 ``anaconda-project run`` automatically adds missing packages
 every time.
 
-In addition to creating environments, Project can perform other
+In addition to creating environments, anaconda-project can perform other
 kinds of setup, such as adding data files and running a database
 server. In that sense, it is a superset of ``conda env``.

--- a/docs/source/user-guide/tasks/clean-project.rst
+++ b/docs/source/user-guide/tasks/clean-project.rst
@@ -13,7 +13,7 @@ Run the following command from within the project directory::
 
   anaconda-project clean
 
-Project removes automatically created files and downloaded data.
+anaconda-project removes automatically created files and downloaded data.
 
 To restore these files:
 

--- a/docs/source/user-guide/tasks/create-project-archive.rst
+++ b/docs/source/user-guide/tasks/create-project-archive.rst
@@ -12,7 +12,7 @@ Excluding files from the archive
 ================================
 
 The ``anaconda-project archive`` command automatically omits the
-files that Project can reproduce automatically, which includes
+files that anaconda-project can reproduce automatically, which includes
 the ``envs/`` directory and any downloaded data files defined in the
 :ref:`downloads <downloads>` section of the ``anaconda-project.yml`` file.
 
@@ -49,7 +49,7 @@ EXAMPLE: To create a zip archive called "iris"::
 
   anaconda-project archive iris.zip
 
-Project creates the archive file.
+anaconda-project creates the archive file.
 
 If you list the files in the archive, you will see that
 automatically generated files are not listed.

--- a/docs/source/user-guide/tasks/work-with-commands.rst
+++ b/docs/source/user-guide/tasks/work-with-commands.rst
@@ -22,7 +22,7 @@ You could run your Python code with the command::
 
 NOTE: Replace ``file`` with the name of your file.
 
-However, to gain the benefits of Anaconda Project, use Project
+However, to gain the benefits of Anaconda Project, use anaconda-project
 to add code files to your project:
 
 #. Put the code file, application file, or notebook file into
@@ -98,11 +98,11 @@ dependencies. Add these environment specs with
 Using commands to automatically start processes
 ===============================================
 
-Project can automatically start processes that your commands
+anaconda-project can automatically start processes that your commands
 depend on. Currently it only supports starting Redis, for
 demonstration purposes.
 
-To see Project automatically start the Redis process::
+To see anaconda-project automatically start the Redis process::
 
   anaconda-project add-service redis
 


### PR DESCRIPTION
## Summary

Stacked on #435 (which is itself stacked on #430). Documentation refresh and infrastructure work to get the docs building cleanly on Read the Docs again, plus a new pixi support page covering the conversion features in #428–#430 and the export flags / public API in #435.

## Read the Docs revival

Three CI/config commits to get RTD building again:

* **`.readthedocs.yaml`** — RTD now requires a config file in the repo root or it fails to detect the project. Use the v2 schema with `miniforge3-latest`, our existing `docs/environment.yml`, and `docs/source/conf.py`.
* **`docs/environment.yml`** — drop `defaults` from the channel list (RTD can't accept the Anaconda ToS gate, and the solver was silently dropping `pydata-sphinx-theme`); unpin the theme so we get whatever conda-forge has shipped (currently 0.17.1).
* **`conf.py` html_theme guard** — fix the inverted `not on_rtd` check that left the theme at sphinx's default (alabaster) on RTD, then crashed because the pydata-only theme options below assumed pydata was loaded.

## Documentation refresh

* **New "Project status" section** on the front page acknowledging that anaconda-project has not been actively developed in some time and is largely superseded. Inline links to the four alternatives:
  * [conda-project](https://conda-incubator.github.io/conda-project/)
  * [pixi](https://pixi.sh/)
  * [uv](https://docs.astral.sh/uv/)
  * [conda-workspaces](https://github.com/conda-incubator/conda-workspaces)

  Notes that recent activity is centered on conversion to pixi / conda-workspaces.
* **New `pixi-support.rst` page** under its own caption in the docs nav, alongside Get started, User guide, and Reference. Covers:
  * Conversion conventions for env layout, channel handling, and command translation (the work in #428–#430).
  * The `prepare` task contract — when it's emitted and what it does — including the new behavior under `--use-default` (no-op prepare is dropped; only emitted when there are real downloads to fetch).
  * The HTTP-options dispatch table per command type (`unix:`, `notebook:`, `bokeh_app:`).
  * The `--use-default` and `--add-current-platform` flags from #435: what they do, the selection rules, when they're no-ops, and the recommendation/confirmation messages the CLI prints around them.
  * A "Programmatic export API" section documenting the hooks downstream consumers depend on: `project_ops.export_pixi` (returns `PixiExportStatus`), `project_ops.preview_pixi_export` (returns the four-key preview dict), and the public pickers `default_rename_target` / `current_platform_addition_target`.
  * The `info` command and the `publication_info` schema added in #429–#430.
  * The limitations that can't be translated faithfully (services, prompted variables).
* **Help and support page rewrite** — adds a "Project scope" callout pointing readers to pixi / conda-workspaces / uv for new project work, and replaces the stale `documentation@continuum.io` email with a redirect to the GitHub Issue Tracker. Anaconda, Inc. (formerly Continuum Analytics) hasn't monitored that address in years.
* **Disambiguate "Project"** — the bare word was ambiguous between the generic noun ("a project directory") and the tool itself. Walk the docs and replace bare `Project` with `anaconda-project` whenever the tool was meant. Brand-form `Anaconda Project` references and genuinely generic uses left alone. Drop the orphan "Stability" section and refresh the copyright header. Affects `index.rst`, `getting-started.rst`, `user-guide/concepts.rst`, and three task pages.
* **Install page rewrite** — anaconda-project hasn't been bundled with the Anaconda installer since 2022.05; the page still claimed it was and walked users through `conda list` to look for it. Replace with a short page covering install from defaults and conda-forge, the verify command, and a Miniconda pointer for users who don't yet have conda. (-73 / +11 lines.)

Fixes #432

## Test plan

* [x] No tests changed — existing tests unaffected.
* [x] Local sphinx build with `docs/environment.yml` passes under `-W` (warnings-as-errors). All four inline links resolve in the rendered HTML; the new section appears in the page TOC between the intro and Quick Start.
* [x] Verified RTD config locally with the same env file using a clean conda env.
* [ ] CI sphinx build passes.
* [ ] Read the Docs build passes after merge.
