### PR TITLE
fix: small bug fixes from open-issue triage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: package-${{ github.sha }}
-        path: conda-bld
+        path: ./conda-bld
     - name: Upload to anaconda.org
       shell: bash -el {0}
       env:
@@ -118,4 +118,4 @@ jobs:
       run: |
         conda install -y anaconda-client
         [[ "$GITHUB_REF" =~ ^refs/tags/ ]] || export LABEL="--label dev"
-        anaconda --verbose --token $ANACONDA_TOKEN upload --user ctools $LABEL conda-bld/*/anaconda-project-* --force
+        anaconda --verbose --token $ANACONDA_TOKEN upload --user ctools $LABEL ./conda-bld/*/anaconda-project-* --force

--- a/anaconda_project/internal/conda_api.py
+++ b/anaconda_project/internal/conda_api.py
@@ -72,6 +72,13 @@ def _call_conda(extra_args, json_mode=False, platform=None, stdout_callback=None
     if platform is not None:
         env = os.environ.copy()
         env['CONDA_SUBDIR'] = platform
+        # When solving for a non-host platform, conda has no host-side
+        # virtual package to satisfy specs like `libgcc-ng -> __glibc`.
+        # Default __glibc to 2.28 (matching conda-lock and pixi's current
+        # defaults) when cross-resolving any linux subdir, unless the
+        # caller has set CONDA_OVERRIDE_GLIBC themselves.
+        if 'linux' in platform and 'CONDA_OVERRIDE_GLIBC' not in env:
+            env['CONDA_OVERRIDE_GLIBC'] = '2.28'
 
     try:
         (p, stdout_lines, stderr_lines) = streaming_popen.popen(cmd_list,

--- a/anaconda_project/internal/test/test_conda_api.py
+++ b/anaconda_project/internal/test/test_conda_api.py
@@ -312,6 +312,50 @@ def test_conda_install_with_defaults(monkeypatch):
     conda_api.install(prefix='/prefix', pkgs=['python'], channels=['defaults', 'foo'])
 
 
+def _capture_popen_env(monkeypatch):
+    """Mock streaming_popen.popen and return a list that captures env= per call."""
+    captured = []
+
+    class _FakeProcess(object):
+        returncode = 0
+
+    def mock_popen(args, env=None, stdout_callback=None, stderr_callback=None):
+        captured.append(env.copy() if env is not None else None)
+        return (_FakeProcess(), [], [])
+
+    monkeypatch.setattr('anaconda_project.internal.streaming_popen.popen', mock_popen)
+    return captured
+
+
+def test_call_conda_no_platform_does_not_set_overrides(monkeypatch):
+    captured = _capture_popen_env(monkeypatch)
+    conda_api._call_conda(['info'])
+    assert captured == [None]
+
+
+def test_call_conda_linux_platform_injects_glibc_override(monkeypatch):
+    captured = _capture_popen_env(monkeypatch)
+    monkeypatch.delenv('CONDA_OVERRIDE_GLIBC', raising=False)
+    conda_api._call_conda(['info'], platform='linux-64')
+    assert captured[0]['CONDA_SUBDIR'] == 'linux-64'
+    assert captured[0]['CONDA_OVERRIDE_GLIBC'] == '2.28'
+
+
+def test_call_conda_non_linux_platform_does_not_inject_glibc(monkeypatch):
+    captured = _capture_popen_env(monkeypatch)
+    monkeypatch.delenv('CONDA_OVERRIDE_GLIBC', raising=False)
+    conda_api._call_conda(['info'], platform='osx-arm64')
+    assert captured[0]['CONDA_SUBDIR'] == 'osx-arm64'
+    assert 'CONDA_OVERRIDE_GLIBC' not in captured[0]
+
+
+def test_call_conda_caller_glibc_override_wins(monkeypatch):
+    captured = _capture_popen_env(monkeypatch)
+    monkeypatch.setenv('CONDA_OVERRIDE_GLIBC', '2.34')
+    conda_api._call_conda(['info'], platform='linux-aarch64')
+    assert captured[0]['CONDA_OVERRIDE_GLIBC'] == '2.34'
+
+
 def test_resolve_root_prefix():
     prefix = conda_api.resolve_env_to_prefix('root')
     assert prefix is not None

--- a/anaconda_project/local_state_file.py
+++ b/anaconda_project/local_state_file.py
@@ -58,18 +58,19 @@ __dummy__: dummy
             a new ``LocalStateFile``
 
         """
-        current_dir = directory
-        while current_dir != os.path.realpath(os.path.dirname(current_dir)):
+        current_dir = os.path.abspath(directory)
+        while True:
             for name in possible_local_state_file_names:
                 path = os.path.join(current_dir, name)
                 if os.path.isfile(path):
                     return LocalStateFile(path)
 
-            if scan_parents:
-                current_dir = os.path.dirname(os.path.abspath(current_dir))
-                continue
-            else:
+            if not scan_parents:
                 break
+            parent = os.path.dirname(current_dir)
+            if parent == current_dir:
+                break
+            current_dir = parent
 
         # No file was found, create a new one
         return LocalStateFile(os.path.join(directory, DEFAULT_LOCAL_STATE_FILENAME))

--- a/anaconda_project/project.py
+++ b/anaconda_project/project.py
@@ -1112,7 +1112,15 @@ class _ConfigCache(object):
                 for f in no_add_funcs:
                     f(project)
 
-            problem = ProjectProblem(text="No commands run notebooks %s" % (", ".join(need_to_import)),
+            _MAX_LISTED = 10
+            if len(need_to_import) > _MAX_LISTED:
+                listed = ", ".join(need_to_import[:_MAX_LISTED])
+                remaining = len(need_to_import) - _MAX_LISTED
+                notebooks_text = "%s, and %d more" % (listed, remaining)
+            else:
+                notebooks_text = ", ".join(need_to_import)
+
+            problem = ProjectProblem(text="No commands run notebooks %s" % notebooks_text,
                                      filename=project_file.filename,
                                      fix_prompt="Create commands in %s for all missing notebooks?" %
                                      (os.path.basename(project_file.filename)),

--- a/anaconda_project/project_file.py
+++ b/anaconda_project/project_file.py
@@ -147,18 +147,19 @@ env_specs: {}
             a new ``ProjectFile``
 
         """
-        current_dir = directory
-        while current_dir != os.path.realpath(os.path.dirname(current_dir)):
+        current_dir = os.path.abspath(directory)
+        while True:
             for name in possible_project_file_names:
                 path = os.path.join(current_dir, name)
                 if os.path.isfile(path):
                     return ProjectFile(path)
 
-            if scan_parents:
-                current_dir = os.path.dirname(os.path.abspath(current_dir))
-                continue
-            else:
+            if not scan_parents:
                 break
+            parent = os.path.dirname(current_dir)
+            if parent == current_dir:
+                break
+            current_dir = parent
 
         # No file was found, create a new one
         return ProjectFile(os.path.join(directory, DEFAULT_PROJECT_FILENAME), default_env_specs_func)

--- a/anaconda_project/project_lock_file.py
+++ b/anaconda_project/project_lock_file.py
@@ -63,18 +63,19 @@ env_specs: {}
             a new ``ProjectLockFile``
 
         """
-        current_dir = directory
-        while current_dir != os.path.realpath(os.path.dirname(current_dir)):
+        current_dir = os.path.abspath(directory)
+        while True:
             for name in possible_project_lock_file_names:
                 path = os.path.join(current_dir, name)
                 if os.path.isfile(path):
                     return ProjectLockFile(path)
 
-            if scan_parents:
-                current_dir = os.path.dirname(os.path.abspath(current_dir))
-                continue
-            else:
+            if not scan_parents:
                 break
+            parent = os.path.dirname(current_dir)
+            if parent == current_dir:
+                break
+            current_dir = parent
 
         # No file was found, create a new one
         return ProjectLockFile(os.path.join(directory, DEFAULT_PROJECT_LOCK_FILENAME))

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -326,6 +326,19 @@ def _map_inplace(f, items):
         i += 1
 
 
+def _packages_key(env_dict):
+    """Return the key 'dependencies' or 'packages' that env_dict already uses.
+
+    Anaconda Project accepts either name; project files imported from
+    ``environment.yml`` use ``dependencies``. Mutations should write back
+    to whichever key was already present so we don't end up with both.
+    Defaults to ``'packages'`` for newly-created env dicts.
+    """
+    if 'dependencies' in env_dict:
+        return 'dependencies'
+    return 'packages'
+
+
 class _StatusHolder(object):
     def __init__(self):
         self.status = None
@@ -424,7 +437,8 @@ def _update_env_spec(project, name, packages, channels, create, pip=False):
 
         # packages may be a "CommentedSeq" and we don't want to lose the comments,
         # so don't convert this thing to a regular list.
-        old_packages = env_dict.get('packages', [])
+        pkg_key = _packages_key(env_dict)
+        old_packages = env_dict.get(pkg_key, [])
         if pip:
             pip_idx = None
             for idx, dep in enumerate(old_packages):
@@ -480,7 +494,7 @@ def _update_env_spec(project, name, packages, channels, create, pip=False):
         else:
             old_packages.extend(new_specs)
 
-        env_dict['packages'] = old_packages
+        env_dict[pkg_key] = old_packages
 
         # channels may be a "CommentedSeq" and we don't want to lose the comments,
         # so don't convert this thing to a regular list.
@@ -756,7 +770,7 @@ def remove_packages(project, env_spec_name, packages, pip=False):
         assert len(env_dicts) > 0
 
         def _get_deps(env_dict, pip=False):
-            _pkgs = env_dict.get('packages', [])
+            _pkgs = env_dict.get(_packages_key(env_dict), [])
             if pip:
                 pip_dicts = [dep for dep in _pkgs if is_dict(dep) and 'pip' in dep]
                 assert len(pip_dicts) == 1, 'There should only be one pip: key'
@@ -769,7 +783,8 @@ def remove_packages(project, env_spec_name, packages, pip=False):
         for env_dict in env_dicts:
             # packages may be a "CommentedSeq" and we don't want to lose the comments,
             # so don't convert this thing to a regular list.
-            old_packages = env_dict.get('packages', [])
+            pkg_key = _packages_key(env_dict)
+            old_packages = env_dict.get(pkg_key, [])
             removed_set = set(packages)
 
             if pip:
@@ -780,16 +795,16 @@ def remove_packages(project, env_spec_name, packages, pip=False):
 
                 if pip_idx is None:
                     if len(old_packages):
-                        env_dict['packages'].append({'pip': []})
+                        env_dict[pkg_key].append({'pip': []})
                     else:
-                        env_dict['packages'] = [{'pip': []}]
+                        env_dict[pkg_key] = [{'pip': []}]
                 else:
                     pip_packages = old_packages.pop(pip_idx)['pip']
                     _filter_inplace(lambda dep: not (is_string(dep) and dep in removed_set), pip_packages)
-                    env_dict['packages'].append({'pip': pip_packages})
+                    env_dict[pkg_key].append({'pip': pip_packages})
             else:
                 _filter_inplace(lambda dep: not (is_string(dep) and dep in removed_set), old_packages)
-                env_dict['packages'] = old_packages
+                env_dict[pkg_key] = old_packages
 
         # if we removed any deps from global, add them to the
         # individual envs that were not supposed to be affected.
@@ -798,7 +813,8 @@ def remove_packages(project, env_spec_name, packages, pip=False):
         for env_dict in unaffected_env_dicts:
             # old_packages may be a "CommentedSeq" and we don't want to lose the comments,
             # so don't convert this thing to a regular list.
-            old_packages = env_dict.get('packages', [])
+            pkg_key = _packages_key(env_dict)
+            old_packages = env_dict.get(pkg_key, [])
             if pip:
                 pip_idx = None
                 for idx, dep in enumerate(old_packages):
@@ -810,7 +826,7 @@ def remove_packages(project, env_spec_name, packages, pip=False):
                     old_packages[pip_idx]['pip'].extend(list(removed_from_global))
             else:
                 old_packages.extend(list(removed_from_global))
-            env_dict['packages'] = old_packages
+            env_dict[pkg_key] = old_packages
 
     if status_holder.status is not None:
         project.load()  # revert

--- a/anaconda_project/test/test_project.py
+++ b/anaconda_project/test/test_project.py
@@ -1735,6 +1735,22 @@ def test_notebook_command_jupyter_not_on_path(monkeypatch):
         {DEFAULT_PROJECT_FILENAME: "commands:\n default:\n    notebook: test.ipynb\n"}, check_notebook_command)
 
 
+def test_many_notebooks_suggestion_truncated():
+    def check(dirname):
+        project = project_no_dedicated_env(dirname)
+        assert len(project.suggestions) == 1
+        msg = project.suggestions[0]
+        assert "and 5 more" in msg
+        # only the first 10 notebooks should be listed by name
+        assert "n09.ipynb" in msg
+        assert "n10.ipynb" not in msg
+
+    files = {DEFAULT_PROJECT_FILENAME: "packages: ['notebook']\n"}
+    for i in range(15):
+        files["n%02d.ipynb" % i] = '{}'
+    with_directory_contents_completing_project_file(files, check)
+
+
 def test_multiple_notebooks_suggestion_rejected():
     def check(dirname):
         project = project_no_dedicated_env(dirname)

--- a/anaconda_project/test/test_project_file.py
+++ b/anaconda_project/test/test_project_file.py
@@ -175,6 +175,36 @@ def test_load_directory_without_project_file():
     with_directory_contents(dict(), read_missing_file)
 
 
+def test_load_for_directory_terminates_at_case_insensitive_root(monkeypatch):
+    # Regression for #379: on Windows the parent-walk loop compared
+    # `current_dir` to `os.path.realpath(os.path.dirname(current_dir))`.
+    # At the drive root (e.g. C:\) dirname() is a fixed point, but
+    # realpath() may return a different case for the drive letter, so
+    # the comparison never matches and the loop spins forever.
+    real_dirname = os.path.dirname
+
+    def fake_dirname(p):
+        # Simulate Windows root behavior on POSIX: a fake "drive root"
+        # that's its own dirname.
+        if p == '/FAKEROOT':
+            return '/FAKEROOT'
+        return real_dirname(p)
+
+    def fake_realpath(p):
+        # Simulate Windows returning a case-mangled root.
+        if p == '/FAKEROOT':
+            return '/fakeroot'
+        return p
+
+    monkeypatch.setattr(os.path, 'dirname', fake_dirname)
+    monkeypatch.setattr(os.path, 'realpath', fake_realpath)
+    monkeypatch.setattr(os.path, 'abspath', lambda p: p)
+
+    project_file = ProjectFile.load_for_directory('/FAKEROOT')
+    assert project_file is not None
+    assert project_file.get_value(["a", "b"]) is None
+
+
 anaconda_global_packages = """#
 # In the packages section, list any packages that must be installed
 # before your code runs.

--- a/anaconda_project/test/test_project_ops.py
+++ b/anaconda_project/test/test_project_ops.py
@@ -1985,6 +1985,55 @@ packages:
         }, check)
 
 
+def test_add_packages_preserves_dependencies_key():
+    # Regression for #337: when the project file uses the `dependencies:`
+    # alias instead of `packages:`, add_packages must mutate the existing
+    # key rather than creating a separate `packages:` block alongside it.
+    def check(dirname):
+        def attempt():
+            project = Project(dirname)
+            status = project_ops.add_packages(project,
+                                              env_spec_name=None,
+                                              packages=['foo', 'bar'],
+                                              channels=[])
+            assert status
+            assert [] == status.errors
+
+        _with_conda_test(attempt)
+
+        project2 = Project(dirname)
+        assert ['numpy', 'foo', 'bar'] == list(project2.project_file.get_value('dependencies'))
+        assert project2.project_file.get_value('packages') is None
+
+    with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME: "dependencies:\n  - numpy\n",
+            DEFAULT_PROJECT_LOCK_FILENAME: "locking_enabled: true\n"
+        }, check)
+
+
+def test_remove_packages_preserves_dependencies_key():
+    # Regression for #337: same as add_packages, on the remove path.
+    def check(dirname):
+        def attempt():
+            project = Project(dirname)
+            status = project_ops.remove_packages(project, env_spec_name=None, packages=['bar'])
+            assert status
+            assert [] == status.errors
+
+        _with_conda_test(attempt)
+
+        project2 = Project(dirname)
+        assert ['foo'] == list(project2.project_file.get_value('dependencies'))
+        assert project2.project_file.get_value('packages') is None
+
+    with_directory_contents_completing_project_file(
+        {
+            DEFAULT_PROJECT_FILENAME: "dependencies:\n  - foo\n  - bar\n",
+            DEFAULT_PROJECT_LOCK_FILENAME: "locking_enabled: true\n"
+        }, check)
+
+
 def test_add_pip_packages_to_all_environments():
     def check(dirname):
         def attempt():

--- a/docs/source/user-guide/reference.rst
+++ b/docs/source/user-guide/reference.rst
@@ -174,6 +174,39 @@ If your notebook contains ``@fusion.register`` when you
 ``anaconda-project init`` or ``anaconda-project add-command``,
 ``registers_fusion_function: true`` will be added automatically.
 
+Suppressing notebook auto-import
+--------------------------------
+
+When ``anaconda-project`` loads a project, it scans the project
+directory for ``.ipynb`` files that don't already have a matching
+command and emits a suggestion to add commands for them. If you don't
+want this — for example, your project ships notebooks intended only
+as data or examples, or the scan picks up notebooks shipped by an
+installed package — you can suppress it with the ``skip_imports``
+key.
+
+To suppress the suggestion entirely:
+
+.. code-block:: yaml
+
+  skip_imports:
+    notebooks: true
+
+To suppress it only for specific notebooks (still suggest commands
+for any new ones added later):
+
+.. code-block:: yaml
+
+  skip_imports:
+    notebooks:
+      - examples/intro.ipynb
+      - examples/quickstart.ipynb
+
+The "skip" form is what ``anaconda-project`` writes to the project
+file when you answer "no" at the interactive auto-import prompt, so
+this is the same configuration produced by saying "no" once for each
+notebook.
+
 
 .. _http-commands:
 


### PR DESCRIPTION
## Summary

Accumulates small fixes for issues identified during open-issue triage that we decided were worth resolving in code/docs rather than closing as out-of-scope, plus one CI fix needed to keep the conda-package upload working.

* **#337** — `add-packages` and `remove-packages` now write back to whichever of `dependencies:` / `packages:` is already in use, instead of hardcoding `packages:` and creating a duplicate block in projects that use the `dependencies:` alias.
* **#343** — Truncate the "No commands run notebooks ..." auto-suggestion at 10 paths followed by `and N more`. Avoids the hundreds-of-lines-of-output behavior when an env ships its own notebooks (e.g. `nbclient`).
* **#378** — Document the `skip_imports` key in `docs/source/user-guide/reference.rst`. The key was supported in code but never mentioned in user-facing docs.
* **#379** — Fix the directory-scanning parent-walk loop so it terminates reliably on case-insensitive filesystems (Windows). The old loop mixed `realpath` and `abspath` and could spin forever at the drive root when the case differed. Same bug fixed in three places (`project_file.py`, `project_lock_file.py`, `local_state_file.py`); regression test added that hangs under the old code and passes under the new.
* **#398** — Inject `CONDA_OVERRIDE_GLIBC=2.28` into the subprocess environment when cross-platform-resolving for any `linux-*` subdir. Without this, `anaconda-project lock` from a non-Linux host fails with "nothing provides `__glibc`". 2.28 matches the current defaults used by both conda-lock and pixi. Caller-set `CONDA_OVERRIDE_GLIBC` still wins.
* **CI: conda-package upload** — `.github/workflows/main.yml` was uploading every `*.{conda,tar.bz2}` it found, which now includes the conda-build cached transitive deps as well as the package itself. Restrict the glob to `anaconda-project*` and normalize the artifact path to `./conda-bld`.

Fixes #337
Fixes #343
Fixes #378
Fixes #379
Fixes #398

## Test plan

* [x] `pytest anaconda_project/test/test_project.py -k "notebook_guess or many_notebooks or multiple_notebooks"` passes
* [x] `pytest anaconda_project/test/test_project_file.py anaconda_project/test/test_project_lock_file.py anaconda_project/test/test_local_state_file.py` passes (28 tests)
* [x] Confirmed the new `test_load_for_directory_terminates_at_case_insensitive_root` hangs under the pre-fix code (10s timeout) and passes under the new code
* [x] `pytest anaconda_project/internal/test/test_conda_api.py -k "call_conda"` — 4 new override tests pass
* [x] `pytest anaconda_project/test/test_project_ops.py -k "preserves_dependencies_key"` — 2 new regression tests pass; confirmed they fail under pre-fix code
* [ ] Full test suite passes in CI
* [ ] Docs build cleanly on Read the Docs
* [ ] Tagged release uploads correctly to anaconda.org/ctools
