### PR TITLE
AENT-8833 / AENT-8838: export-pixi shell-quote fix + default_channels= seam

### DIFF
--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -647,9 +647,15 @@ def _command_to_task(command, declared_vars):
         raw_cmd = command.unix_shell_commandline
         raw_forms.append(raw_cmd)
     elif command.notebook is not None:
-        raw_cmd = 'jupyter notebook {}'.format(command.notebook)
+        # Quote the path: anaconda-project runs notebooks as an argv list
+        # (['jupyter-notebook', path], no shell), so a notebook field
+        # containing shell metacharacters is inert there. Here we synthesize a
+        # deno_task_shell command string, so an unquoted path would let
+        # metacharacters (;, |, $(), backtick) break out and execute when a
+        # user later runs `pixi run`. _shell_quote neutralizes them.
+        raw_cmd = 'jupyter notebook {}'.format(_shell_quote(command.notebook))
     elif command.bokeh_app is not None:
-        raw_cmd = 'bokeh serve {}'.format(command.bokeh_app)
+        raw_cmd = 'bokeh serve {}'.format(_shell_quote(command.bokeh_app))
     elif command.windows_cmd_commandline:
         # No unix variant — normalize the windows form so it runs under
         # deno_task_shell on every platform pixi targets.

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -779,7 +779,7 @@ def current_platform_addition_target(project):
     return None if here in declared else here
 
 
-def export_pixi_toml(project, use_default=False, add_current_platform=False):
+def export_pixi_toml(project, use_default=False, add_current_platform=False, default_channels=None):
     """Convert an anaconda-project Project to pixi.toml content.
 
     Args:
@@ -797,6 +797,15 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False):
             but pixi refuses to install an env whose declared platforms
             don't include the host, so adding the current platform on
             export prevents that foot-gun.
+        default_channels: optional list of concrete channel URLs that the
+            ``defaults`` meta-channel should expand to (and the fallback
+            when the project declares no channels). When provided, it is
+            used as-is and the local ``conda config --show
+            default_channels`` lookup is skipped entirely — so a caller
+            that already knows its channels (e.g. one running where
+            shelling out to ``conda`` is slow or unavailable) can export
+            without any subprocess. When None (the default), the channels
+            are resolved from the local conda configuration as before.
 
     Returns:
         A string containing the pixi.toml file content.
@@ -820,8 +829,12 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False):
                 all_channels.append(ch)
                 seen_channels.add(ch)
 
+    # Resolve what `defaults` (or an empty channel list) expands to. Prefer a
+    # caller-supplied list and only fall back to the local conda lookup — which
+    # shells out — when one wasn't given and is actually needed.
     needs_defaults = (not all_channels) or ('defaults' in all_channels)
-    default_channels = _resolve_default_channels() if needs_defaults else None
+    if needs_defaults and default_channels is None:
+        default_channels = _resolve_default_channels()
     if not all_channels:
         all_channels = list(default_channels)
     elif 'defaults' in all_channels:

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -223,7 +223,8 @@ commands:
     bokeh_app: myapp
 """)
         result = export_pixi_toml(project)
-        assert 'bokeh serve myapp' in result
+        # The app path is shell-quoted (harmless for a clean name).
+        assert 'bokeh serve "myapp"' in result
 
     def test_notebook_conversion(self):
         project = self._make_project("""
@@ -236,7 +237,51 @@ commands:
     notebook: analysis.ipynb
 """)
         result = export_pixi_toml(project)
-        assert 'jupyter notebook analysis.ipynb' in result
+        # The notebook path is shell-quoted (harmless for a clean name).
+        assert 'jupyter notebook "analysis.ipynb"' in result
+
+    def test_notebook_path_shell_metacharacters_neutralized(self):
+        # A notebook field carrying shell metacharacters must not break out of
+        # the generated deno_task_shell command. anaconda-project's own runner
+        # execs notebooks as an argv list (no shell), so this injection is one
+        # the converter would otherwise introduce.
+        project = self._make_project("""
+name: NbInjection
+packages: []
+platforms:
+  - linux-64
+commands:
+  analysis:
+    notebook: "x.ipynb; touch PWNED"
+""")
+        result = export_pixi_toml(project)
+        # The whole path stays inside one double-quoted token; the ';' is data,
+        # not a command separator. No bare `; touch PWNED` escapes the quotes.
+        assert 'jupyter notebook "x.ipynb; touch PWNED"' in result
+        assert '.ipynb; touch PWNED\n' not in result
+        assert 'notebook x.ipynb;' not in result
+
+    def test_bokeh_app_shell_metacharacters_neutralized(self):
+        project = self._make_project("""
+name: BokehInjection
+packages:
+  - bokeh
+platforms:
+  - linux-64
+commands:
+  app:
+    bokeh_app: "app$(touch PWNED)"
+""")
+        result = export_pixi_toml(project)
+        # In the task command, the path is shell-quoted AND the '$' is escaped,
+        # so after TOML parsing deno_task_shell sees `"app\$(touch PWNED)"` and
+        # does NOT perform command substitution. At the TOML layer the backslash
+        # is itself escaped, so the serve line contains the doubled form.
+        task_lines = [ln for ln in result.splitlines() if 'serve' in ln]
+        assert task_lines, "expected a bokeh serve task line"
+        assert 'app\\\\$(touch PWNED)' in task_lines[0]
+        # No serve task line carries a bare, unescaped command-substitution.
+        assert not any('serve "app$(touch PWNED)"' in ln for ln in task_lines)
 
     def test_default_channels_when_empty(self):
         # When the yml declares no channels, fall back to the URLs that
@@ -706,6 +751,38 @@ class TestStripCondaPrefixPaths:
 
     def test_strips_at_end_of_string(self):
         assert _strip_conda_prefix_paths('exec ${CONDA_PREFIX}/bin/python') == 'exec python'
+
+
+class TestShellQuote:
+    # _shell_quote is the neutralizer for any path/value interpolated into a
+    # generated deno_task_shell command. Pin its escaping directly so a
+    # regression in the escape set is caught regardless of caller.
+    _shell_quote = staticmethod(pixi_export_module._shell_quote)
+
+    def test_plain_value_is_wrapped(self):
+        assert self._shell_quote('analysis.ipynb') == '"analysis.ipynb"'
+
+    def test_double_quote_escaped(self):
+        assert self._shell_quote('a"b') == '"a\\"b"'
+
+    def test_backslash_escaped(self):
+        assert self._shell_quote('a\\b') == '"a\\\\b"'
+
+    def test_dollar_escaped(self):
+        # prevents deno_task_shell command/var substitution
+        assert self._shell_quote('$(touch x)') == '"\\$(touch x)"'
+
+    def test_backtick_escaped(self):
+        assert self._shell_quote('a`b`') == '"a\\`b\\`"'
+
+    def test_separators_survive_as_data_inside_quotes(self):
+        # ; | & are NOT escaped because, inside double quotes, deno_task_shell
+        # treats them as literal data — they only matter unquoted.
+        out = self._shell_quote('x.ipynb; rm -rf ~ | cat & echo')
+        assert out.startswith('"') and out.endswith('"')
+        assert '\\$' not in out  # nothing to escape here
+        # the dangerous chars are contained within the single quoted token
+        assert out == '"x.ipynb; rm -rf ~ | cat & echo"'
 
 
 class TestHttpOptions:

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -90,6 +90,127 @@ platforms:
             export_pixi_toml(project)
 
 
+class TestDefaultChannelsParam:
+    """The ``default_channels=`` seam lets a caller supply the concrete
+    URLs that ``defaults`` expands to, so the export never shells out to
+    ``conda config`` — the path used by frontends (e.g. the editor
+    launcher) running where conda is slow or unavailable.
+    """
+
+    def _make_project(self, yml_content):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, 'anaconda-project.yml'), 'w') as f:
+            f.write(yml_content)
+        return Project(tmpdir)
+
+    @pytest.fixture
+    def _resolve_must_not_be_called(self, monkeypatch):
+        # Make the conda lookup explode: if a code path reaches it despite a
+        # supplied default_channels, the test fails loudly instead of silently
+        # falling back to the (stubbed) resolver.
+        def boom():
+            raise AssertionError(
+                "_resolve_default_channels() was called even though "
+                "default_channels= was supplied")
+        monkeypatch.setattr(
+            pixi_export_module, '_resolve_default_channels', boom)
+
+    def test_supplied_channels_expand_defaults_without_conda(self, _resolve_must_not_be_called):
+        project = self._make_project("""
+name: Supplied
+packages: []
+channels:
+  - defaults
+  - conda-forge
+platforms:
+  - linux-64
+""")
+        result = export_pixi_toml(
+            project,
+            default_channels=['https://mirror.test/main', 'https://mirror.test/r'])
+        assert ('channels = ["https://mirror.test/main", '
+                '"https://mirror.test/r", "conda-forge"]') in result
+        assert '"defaults"' not in result
+
+    def test_supplied_channels_used_as_fallback_when_empty(self, _resolve_must_not_be_called):
+        # No channels declared: the supplied list is the fallback (and conda
+        # is still never consulted).
+        project = self._make_project("""
+name: SuppliedEmpty
+packages: []
+platforms:
+  - linux-64
+""")
+        result = export_pixi_toml(
+            project, default_channels=['https://mirror.test/main'])
+        assert 'channels = ["https://mirror.test/main"]' in result
+
+    def test_supplied_channels_ignored_when_no_defaults_token(self, _resolve_must_not_be_called):
+        # When the project lists only concrete channels (no `defaults` and
+        # not empty), default_channels is irrelevant and, again, conda is not
+        # consulted.
+        project = self._make_project("""
+name: NoDefaultsToken
+packages: []
+channels:
+  - conda-forge
+platforms:
+  - linux-64
+""")
+        result = export_pixi_toml(
+            project, default_channels=['https://mirror.test/main'])
+        assert 'channels = ["conda-forge"]' in result
+
+    def test_none_falls_back_to_conda_lookup(self):
+        # Default (None) preserves the original behavior: the autouse stub's
+        # FAKE_DEFAULTS are used, proving the conda path still runs.
+        project = self._make_project("""
+name: DefaultNone
+packages: []
+channels:
+  - defaults
+platforms:
+  - linux-64
+""")
+        result = export_pixi_toml(project, default_channels=None)
+        assert ('channels = ["https://example.test/main", '
+                '"https://example.test/r"]') in result
+
+    def test_export_pixi_threads_default_channels(self, _resolve_must_not_be_called, tmpdir):
+        # The public project_ops.export_pixi wrapper must pass the kwarg
+        # through to export_pixi_toml.
+        src = tmpdir.mkdir('proj')
+        src.join('anaconda-project.yml').write("""
+name: ThreadExport
+packages: []
+channels:
+  - defaults
+platforms:
+  - linux-64
+""")
+        project = Project(str(src))
+        out = str(tmpdir.join('pixi.toml'))
+        status = project_ops.export_pixi(
+            project, out, default_channels=['https://mirror.test/main'])
+        assert bool(status)
+        with open(out) as f:
+            content = f.read()
+        assert 'channels = ["https://mirror.test/main"]' in content
+
+    def test_preview_pixi_export_threads_default_channels(self, _resolve_must_not_be_called):
+        project = self._make_project("""
+name: ThreadPreview
+packages: []
+channels:
+  - defaults
+platforms:
+  - linux-64
+""")
+        preview = project_ops.preview_pixi_export(
+            project, default_channels=['https://mirror.test/main'])
+        assert 'channels = ["https://mirror.test/main"]' in preview['pixi_toml']
+
+
 class TestCondaSpecToPixi:
     def test_bare_name(self):
         assert _conda_spec_to_pixi('numpy') == ('numpy', '*')

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -625,7 +625,7 @@ def export_env_spec(project, name, filename):
     return SimpleStatus(success=True, description="Exported environment spec {} to {}.".format(name, filename))
 
 
-def export_pixi(project, filename, use_default=False, add_current_platform=False):
+def export_pixi(project, filename, use_default=False, add_current_platform=False, default_channels=None):
     """Export the project as a pixi.toml file.
 
     Returns a ``Status`` subtype.
@@ -645,6 +645,11 @@ def export_pixi(project, filename, use_default=False, add_current_platform=False
             doesn't list the host platform; anaconda-project is more
             forgiving, so this prevents a pixi install error on a project
             whose ``platforms:`` list happens to omit the developer's box.
+        default_channels (list or None): optional concrete channel URLs to
+            expand ``defaults`` to (and to fall back on when the project
+            declares no channels). When provided, the local ``conda config``
+            lookup is skipped — letting a caller export without shelling out
+            to conda. See :func:`export_pixi_toml`.
 
     Returns:
         ``PixiExportStatus`` on success (carries ``default_rename_from``
@@ -665,7 +670,8 @@ def export_pixi(project, filename, use_default=False, add_current_platform=False
                       if add_current_platform else None)
     try:
         content = export_pixi_toml(project, use_default=use_default,
-                                   add_current_platform=add_current_platform)
+                                   add_current_platform=add_current_platform,
+                                   default_channels=default_channels)
     except CondaNotAvailableError as e:
         return SimpleStatus(
             success=False,
@@ -696,7 +702,7 @@ def export_pixi(project, filename, use_default=False, add_current_platform=False
         current_platform_added=platform_added)
 
 
-def preview_pixi_export(project, use_default=False, add_current_platform=False):
+def preview_pixi_export(project, use_default=False, add_current_platform=False, default_channels=None):
     """Render the pixi.toml conversion in memory without writing to disk.
 
     Returns a dict with four keys, suitable for driving a preview UI
@@ -735,6 +741,9 @@ def preview_pixi_export(project, use_default=False, add_current_platform=False):
             controls the content of ``pixi_toml`` but not
             ``current_platform_addition_target`` (which is reported
             regardless).
+        default_channels (list or None): same semantics as
+            ``export_pixi`` — when provided, ``defaults`` is expanded from
+            this list and the conda lookup is skipped.
 
     Returns:
         dict
@@ -744,7 +753,8 @@ def preview_pixi_export(project, use_default=False, add_current_platform=False):
         export_pixi_toml, extract_warnings,
     )
     pixi_toml = export_pixi_toml(project, use_default=use_default,
-                                 add_current_platform=add_current_platform)
+                                 add_current_platform=add_current_platform,
+                                 default_channels=default_channels)
     return {
         'pixi_toml': pixi_toml,
         'default_rename_from': default_rename_target(project),


### PR DESCRIPTION
## Summary

`export-pixi` could produce a `pixi.toml` task that runs attacker-controlled shell commands. For `notebook:` and `bokeh_app:` commands, `_command_to_task` synthesized the deno_task_shell command string by interpolating the path directly:

```python
raw_cmd = 'jupyter notebook {}'.format(command.notebook)
raw_cmd = 'bokeh serve {}'.format(command.bokeh_app)
```

The result was escaped only by `_toml_string`, which handles TOML syntax but **not** shell metacharacters (`;`, `|`, `$(...)`, backtick). So a project whose `notebook:`/`bokeh_app:` field contains those would generate a pixi task that executes the injected command on the next `pixi run`.

anaconda-project's own runner execs these as an **argv list** (`['jupyter-notebook', path]`, no shell — `project_commands.py`), where the path is inert. The converter was *introducing* a shell-injection that does not exist in the native run path.

### Why it matters

The project author is usually the person who runs the project, so for self-authored projects this is low impact. But `export-pixi` is explicitly used to convert **shared / sample / gallery** projects (e.g. the sample-projects → pixi conversion), where author ≠ runner — a supply-chain-flavored RCE: convert someone else's project, then `pixi run` executes their payload.

## Fix

Route both paths through the existing `_shell_quote` helper (escapes `" \ $` and backtick). Clean filenames are unaffected — they just gain surrounding quotes, which deno_task_shell treats identically.

## Tests

- New: notebook/bokeh metacharacter-neutralization cases — **mutation-verified** (both fail if the quoting is removed).
- New: direct `_shell_quote` escaping coverage (the helper was previously untested).
- Updated: the two happy-path notebook/bokeh assertions for the now-quoted form.
- `106 passed` locally (was 96 + happy-path edits + 6 new).

## Notes

- Found via an adversarial correctness audit of the merged pixi pipeline; verified against the actual code + the native runner's argv behavior.
- Touches `pixi_export.py`, which has had recent activity — opening as **draft** for now; not requesting review yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added: AENT-8838 — `default_channels=` seam (commit 702add8)

`export_pixi_toml` (and the `export_pixi` / `preview_pixi_export` wrappers) gain an optional `default_channels=` parameter. When supplied, it expands the `defaults` meta-channel and serves as the empty-channels fallback, and the `conda config --show default_channels` subprocess is **skipped entirely**.

This is the seam the editor pixi-launcher needs: it can resolve channels itself from the session `.condarc` and call this canonical converter with **no conda subprocess**, so the editor's standalone `standalone_export.py` fork (which exists only to dodge the conda-info hang under Rosetta) can later be deleted.

- `default_channels=None` (default) → unchanged behavior (local conda lookup).
- New `TestDefaultChannelsParam` (6 tests); the "conda must not be called" assertions are **mutation-verified** (fail if the param is ignored or the wrappers stop threading it).

Bundling with the injection fix because both touch `pixi_export.py` and ship in one ae-dev release.