### PR TITLE
AENT-8881: no-solver anaconda-project-lock → pixi.lock translator (Items 1/2/4/5, live-verified)

### DIFF
--- a/anaconda_project/internal/pixi_lock.py
+++ b/anaconda_project/internal/pixi_lock.py
@@ -53,6 +53,7 @@ launcher in any JupyterLab host, CI, the CLI) gets it.
 from __future__ import absolute_import
 
 from anaconda_project.internal import conda_api
+from anaconda_project.internal.py2_compat import is_string, is_dict
 
 
 # anaconda-project lock files group package specs into "buckets" keyed by
@@ -116,19 +117,52 @@ def parse_locked_specs(lock_set, platform):
         raise LockTranslationError("lock set has no entry for platform %r (has %r)" %
                                    (platform, list(lock_set.platforms)))
 
+    if lock_set.disabled:
+        raise LockTranslationError("lock set for platform %r is not locked (locking disabled)" % platform)
+
+    try:
+        specs_for_platform = lock_set.package_specs_for_platform(platform)
+    except TypeError as e:
+        # package_specs_for_platform's own bucket-merge (_conda_combine_key)
+        # calls conda_api.parse_spec on every entry BEFORE we see any of
+        # them, so a non-string entry (e.g. a nested {"pip": [...]} bucket
+        # parsed alongside conda specs) raises conda_api's raw TypeError
+        # here, not in the loop below. assert_no_pip_packages only catches
+        # the top-level "pip" platform key; surface this case as our own
+        # typed error too, rather than let the TypeError leak.
+        raise LockTranslationError(
+            "locked spec list for platform %r contains a non-spec-string entry: %s" % (platform, e))
+
     locked = []
-    for spec in lock_set.package_specs_for_platform(platform):
+    for spec in specs_for_platform:
+        if not is_string(spec):
+            # Belt-and-suspenders: a non-string entry that survives the
+            # bucket merge above (e.g. from a single-bucket platform with no
+            # merge to trigger the TypeError) is caught here too.
+            raise LockTranslationError(
+                "locked spec for platform %r is not a package spec string: %r" % (platform, spec))
         parsed = conda_api.parse_spec(spec)
         if parsed is None:
             raise LockTranslationError("could not parse locked spec %r for platform %r" % (spec, platform))
-        if parsed.exact_version is None or parsed.exact_build_string is None:
-            # A real lock pins name=version=build. A spec missing the version
-            # or build means this platform isn't actually locked -> a re-solve
-            # would be required, which is precisely what we refuse to do.
+        # conda_api.parse_spec's exact_version rejects |,* -- but that filter
+        # does NOT extend to exact_build_string, so a build of e.g. "*" or
+        # "py37*" is (wrongly) reported as "exact". A wildcard/partial build
+        # is exactly the "this platform was never truly locked" condition
+        # this strict gate exists to catch -- reject it explicitly rather
+        # than let it surface later as a misattributed BuildNotFoundError.
+        build = parsed.exact_build_string
+        if (parsed.exact_version is None or build is None or
+                any(c in build for c in ('*', '|', ','))):
             raise LockTranslationError(
                 "locked spec %r for platform %r is not pinned to an exact version=build; "
                 "the lock set is not fully resolved for this platform" % (spec, platform))
-        locked.append((parsed.name, parsed.exact_version, parsed.exact_build_string))
+        locked.append((parsed.name, parsed.exact_version, build))
+
+    names = [name for (name, _version, _build) in locked]
+    if len(names) != len(set(names)):
+        dupes = sorted({n for n in names if names.count(n) > 1})
+        raise LockTranslationError(
+            "locked spec list for platform %r has duplicate/conflicting pins for: %s" % (platform, ", ".join(dupes)))
     return locked
 
 
@@ -140,9 +174,30 @@ def assert_no_pip_packages(lock_set):
     that installs but is missing packages -> a delayed runtime ImportError,
     the exact silent-degradation we refuse. So we surface it as an explicit,
     actionable error instead.
+
+    Pip packages can appear in a CondaLockSet's specs in two shapes:
+    (1) a top-level "pip" platform key (the shape ``project.py``'s loader
+    produces), and (2) a nested ``{"pip": [...]}`` dict INSIDE another
+    platform's spec list (the environment.yml-style shape ``project.py``
+    matches via ``special_filter`` elsewhere in the codebase). This function
+    must not assume the caller's CondaLockSet went through project.py's
+    loader/sanitizer -- it accepts any CondaLockSet -- so both shapes are
+    checked here.
     """
-    # CondaLockSet stores the pip bucket under the "pip" platform key.
-    pip_specs = lock_set._package_specs_by_platform.get('pip', [])
+    # Shape 1: CondaLockSet stores the pip bucket under the "pip" platform key.
+    pip_specs = list(lock_set._package_specs_by_platform.get('pip', []))
+
+    # Shape 2: a nested pip dict living inside a per-platform spec list.
+    for platform, specs in lock_set._package_specs_by_platform.items():
+        if platform == 'pip':
+            continue
+        for spec in specs:
+            if is_dict(spec) and 'pip' in spec:
+                nested = spec.get('pip') or []
+                if is_string(nested):
+                    nested = [nested]
+                pip_specs.extend(nested)
+
     if pip_specs:
         raise UnsupportedLockContentError(
             "lock set contains %d pip package(s) (%s%s); pip enrichment is not supported in v1 "
@@ -396,12 +451,23 @@ def translate_lock_set(lock_set, channels, path, env_name="default", query=None)
     document, and write it atomically. Strict mode throughout — any missing
     build (BuildNotFoundError) or unreachable mirror (MirrorUnavailableError)
     aborts BEFORE any file is written.
+
+    Raises ``LockTranslationError`` if the lock set has no platforms, or if
+    the assembled closure has zero packages on every platform — either would
+    otherwise write a valid-but-empty pixi.lock (install nothing), which is
+    a silent no-op degradation, not a faithful translation.
     """
+    if not lock_set.platforms:
+        raise LockTranslationError("lock set has no platforms; nothing to translate")
     assert_no_pip_packages(lock_set)
     enriched_by_subdir = {}
     for platform in lock_set.platforms:
         locked = parse_locked_specs(lock_set, platform)
         enriched_by_subdir[platform] = enrich_locked_packages(locked, channels, platform, query=query)
+    if not any(enriched_by_subdir.values()):
+        raise LockTranslationError(
+            "lock set for platforms %r resolved to zero packages; refusing to write an empty pixi.lock" %
+            (list(lock_set.platforms), ))
     document = build_pixi_lock(enriched_by_subdir, channels, env_name=env_name)
     write_pixi_lock(document, path)
     return document

--- a/anaconda_project/internal/pixi_lock.py
+++ b/anaconda_project/internal/pixi_lock.py
@@ -140,18 +140,59 @@ def assert_no_pip_packages(lock_set):
             (len(pip_specs), ", ".join(pip_specs[:3]), " ..." if len(pip_specs) > 3 else ""))
 
 
+class CondaIndexAPIError(LockTranslationError):
+    """conda's in-process index API (SubdirData.query_all) is not importable
+    or not callable in the way this module needs.
+
+    SubdirData.query_all is a conda INTERNAL/private API; this module is the
+    only place anaconda-project imports conda as a library rather than
+    shelling out to it. A conda upgrade could move/rename/resignature it. We
+    surface that loud and diagnosably (with the installed conda version)
+    rather than letting an opaque ImportError/AttributeError leak, and a CI
+    canary (test_default_query_backend_shape) exercises the import+shape
+    against the pinned conda so a breaking bump is caught in CI, not at a
+    user's convert-time.
+    """
+
+
+def _resolve_subdir_data():
+    """Return conda's SubdirData class, or raise CondaIndexAPIError with the
+    conda version if the private import path moved.
+
+    Imported locally (never at module import) so importing pixi_lock never
+    imports conda's solver — see test_module_import_graph_never_imports_conda_solver.
+    """
+    try:
+        from conda.core.subdir_data import SubdirData
+    except Exception as e:  # noqa: BLE001
+        try:
+            import conda
+            ver = getattr(conda, "__version__", "unknown")
+        except Exception:  # noqa: BLE001
+            ver = "unknown"
+        raise CondaIndexAPIError(
+            "could not import conda.core.subdir_data.SubdirData (conda %s); the conda index "
+            "API this module relies on may have moved. %s" % (ver, e))
+    if not hasattr(SubdirData, "query_all"):
+        import conda
+        raise CondaIndexAPIError(
+            "conda.core.subdir_data.SubdirData has no query_all (conda %s); the conda index "
+            "API this module relies on changed." % getattr(conda, "__version__", "unknown"))
+    return SubdirData
+
+
 def _default_query(name, channels, subdir):
     """Real enrichment backend: conda's repodata index reader.
 
     Returns a tuple of PackageRecord-like objects for ``name`` on the given
     channels+subdir, reading repodata with ZERO solver invocation
     (SubdirData.query_all does an index lookup, not a solve). Imported
-    locally so importing this module never imports conda's solver (the
-    import-graph assertion in the tests enforces that), and so a conda that
-    moved query_all surfaces as an ImportError at call time, not at import.
+    locally so importing this module never imports conda's solver, and a conda
+    that moved/renamed the API surfaces as a typed CondaIndexAPIError (with the
+    version) at call time, not an opaque error.
     """
-    from conda.core.subdir_data import SubdirData
-    return SubdirData.query_all(name, channels=list(channels), subdirs=[subdir])
+    subdir_data = _resolve_subdir_data()
+    return subdir_data.query_all(name, channels=list(channels), subdirs=[subdir])
 
 
 def enrich_locked_packages(locked, channels, subdir, query=None):

--- a/anaconda_project/internal/pixi_lock.py
+++ b/anaconda_project/internal/pixi_lock.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016, Anaconda, Inc. All rights reserved.
+#
+# Licensed under the terms of the BSD 3-Clause License.
+# The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Translate an anaconda-project lock set into a pixi.lock by DIRECT
+translation (no solver).
+
+Why this exists (AENT-8881): ``export_pixi`` emits ``pixi.toml`` only; the
+lock is otherwise (re)created later by ``pixi install`` *re-solving*. A
+re-solve — even when every package is pinned to an exact version — does NOT
+reproduce a complex environment: it re-evaluates transitive constraints
+against *today's* repodata under strict channel priority, and package
+metadata / channel availability drift after the lock was made, so the solver
+rejects a combination that demonstrably worked at lock time (proven live on
+the holoviz ``census`` project: 251 pkgs, both loose and fully-pinned
+re-solve fail). Writing ``pixi.lock`` directly from the recorded packages and
+``pixi install --locked`` (never invoking the solver) is the only path that
+reproduces such environments.
+
+Scope of this module (v1):
+
+* ``strict`` mode only — every recorded build is reproduced exactly, or the
+  translation fails loud. (A ``best-effort`` nearest-build substitution mode
+  was deliberately deferred: doing it correctly requires re-deriving
+  cross-package constraints, which is a solver by another name.)
+* conda packages only. The anaconda-project lock does not carry pip packages
+  in a form we can faithfully lock, and ``pixi.lock`` pip entries need PyPI
+  enrichment; a ``pip:`` bucket therefore fails fast rather than being
+  silently dropped.
+* Provenance is trust-on-first-use against the configured channels/mirror:
+  the anaconda-project lock format records only ``name=version=build`` (see
+  ``conda_api.ParsedSpec`` — there is no per-package hash), so there is no
+  lock-time hash to validate the enriched ``sha256`` against. Integrity rests
+  on the channels being trusted/pinned (in AE5: the airgap mirror).
+
+This module is intentionally host-agnostic — it lives in anaconda-project and
+shells out to nothing AE5-specific, so any consumer of anaconda-project (the
+launcher in any JupyterLab host, CI, the CLI) gets it.
+"""
+from __future__ import absolute_import
+
+from anaconda_project.internal import conda_api
+
+
+# anaconda-project lock files group package specs into "buckets" keyed by
+# platform OR by a cross-platform selector ("all", "unix", "linux", "osx",
+# "win"). CondaLockSet.package_specs_for_platform() already merges the right
+# buckets for a concrete platform (all -> unix -> <platform_name> ->
+# <platform>); we lean on it rather than re-implementing bucket precedence
+# (anaconda-project owns that logic; re-forking it is exactly the mistake
+# AENT-8833 / standalone_export taught us to avoid).
+
+
+class LockTranslationError(Exception):
+    """A lock set could not be faithfully translated to a pixi.lock.
+
+    Always raised loud and never swallowed: a half-translated or
+    silently-degraded lock defeats the entire reproducibility purpose.
+    """
+
+
+class UnsupportedLockContentError(LockTranslationError):
+    """The lock set contains content this translator cannot faithfully
+    reproduce in v1 (e.g. pip packages)."""
+
+
+def parse_locked_specs(lock_set, platform):
+    """Return the exact locked conda packages for ``platform`` as a list of
+    ``(name, version, build)`` tuples.
+
+    ``lock_set`` is an ``anaconda_project.conda_manager.CondaLockSet``.
+    ``package_specs_for_platform`` yields the merged, bucket-expanded
+    ``name=version=build`` strings (the full closure for that platform,
+    including the cross-platform ``all``/``unix`` buckets, which carry
+    noarch packages — completeness of that closure is what ``pixi install
+    --locked`` verifies, so we must not drop any of it).
+
+    Raises ``LockTranslationError`` if any spec is not pinned to an exact
+    version AND build (strict mode requires a fully-resolved lock; a loose
+    spec means the lock was never actually locked for this platform).
+    """
+    if platform not in lock_set.platforms:
+        raise LockTranslationError("lock set has no entry for platform %r (has %r)" %
+                                   (platform, list(lock_set.platforms)))
+
+    locked = []
+    for spec in lock_set.package_specs_for_platform(platform):
+        parsed = conda_api.parse_spec(spec)
+        if parsed is None:
+            raise LockTranslationError("could not parse locked spec %r for platform %r" % (spec, platform))
+        if parsed.exact_version is None or parsed.exact_build_string is None:
+            # A real lock pins name=version=build. A spec missing the version
+            # or build means this platform isn't actually locked -> a re-solve
+            # would be required, which is precisely what we refuse to do.
+            raise LockTranslationError(
+                "locked spec %r for platform %r is not pinned to an exact version=build; "
+                "the lock set is not fully resolved for this platform" % (spec, platform))
+        locked.append((parsed.name, parsed.exact_version, parsed.exact_build_string))
+    return locked
+
+
+def assert_no_pip_packages(lock_set):
+    """Fail fast if the lock set carries pip packages.
+
+    v1 is conda-only. Pip entries in a pixi.lock need PyPI enrichment (a
+    separate, phase-2 concern). Silently dropping them would yield a lock
+    that installs but is missing packages -> a delayed runtime ImportError,
+    the exact silent-degradation we refuse. So we surface it as an explicit,
+    actionable error instead.
+    """
+    # CondaLockSet stores the pip bucket under the "pip" platform key.
+    pip_specs = lock_set._package_specs_by_platform.get('pip', [])
+    if pip_specs:
+        raise UnsupportedLockContentError(
+            "lock set contains %d pip package(s) (%s%s); pip enrichment is not supported in v1 "
+            "(AENT-8881 phase 2). Translating without them would silently drop packages." %
+            (len(pip_specs), ", ".join(pip_specs[:3]), " ..." if len(pip_specs) > 3 else ""))

--- a/anaconda_project/internal/pixi_lock.py
+++ b/anaconda_project/internal/pixi_lock.py
@@ -67,6 +67,26 @@ class UnsupportedLockContentError(LockTranslationError):
     reproduce in v1 (e.g. pip packages)."""
 
 
+class BuildNotFoundError(LockTranslationError):
+    """A locked build is authoritatively absent from the channel's repodata.
+
+    This is the AUTHORITATIVE "the exact build is gone" case (the channel
+    answered, and the build is not in it) — distinct from a transport
+    failure. In strict mode this is fatal: we will not substitute.
+    """
+
+
+class MirrorUnavailableError(LockTranslationError):
+    """Enrichment could not reach the channel/mirror (transport error,
+    429, timeout, connection reset).
+
+    CRITICAL: this is NOT "the build is gone." A transient mirror failure
+    must never be mistaken for an absent build and must never trigger
+    substitution. Surfaced loud with the cause so an operator can retry,
+    rather than silently producing a wrong or partial lock.
+    """
+
+
 def parse_locked_specs(lock_set, platform):
     """Return the exact locked conda packages for ``platform`` as a list of
     ``(name, version, build)`` tuples.
@@ -118,3 +138,93 @@ def assert_no_pip_packages(lock_set):
             "lock set contains %d pip package(s) (%s%s); pip enrichment is not supported in v1 "
             "(AENT-8881 phase 2). Translating without them would silently drop packages." %
             (len(pip_specs), ", ".join(pip_specs[:3]), " ..." if len(pip_specs) > 3 else ""))
+
+
+def _default_query(name, channels, subdir):
+    """Real enrichment backend: conda's repodata index reader.
+
+    Returns a tuple of PackageRecord-like objects for ``name`` on the given
+    channels+subdir, reading repodata with ZERO solver invocation
+    (SubdirData.query_all does an index lookup, not a solve). Imported
+    locally so importing this module never imports conda's solver (the
+    import-graph assertion in the tests enforces that), and so a conda that
+    moved query_all surfaces as an ImportError at call time, not at import.
+    """
+    from conda.core.subdir_data import SubdirData
+    return SubdirData.query_all(name, channels=list(channels), subdirs=[subdir])
+
+
+def enrich_locked_packages(locked, channels, subdir, query=None):
+    """Enrich each ``(name, version, build)`` with its exact url/sha256/md5/
+    depends from repodata, by EXACT match. No solver, no substitution.
+
+    Parameters
+    ----------
+    locked : list of (name, version, build) tuples (from parse_locked_specs)
+    channels : iterable of channel names/URLs (pass the project's configured
+        channels with `defaults` already expanded to the mirror via the
+        AENT-8838 default_channels= seam — never None; query_all silently
+        falls back to context.channels when channels is empty, which would
+        read the wrong source).
+    subdir : the conda subdir these records target (e.g. "linux-64",
+        "noarch"). Passed EXPLICITLY so a lock targeting a foreign subdir
+        (aarch64 records translated on a linux-64 host) queries the right
+        repodata rather than the host's.
+    query : injectable callable(name, channels, subdir) -> records, for
+        offline testing. Defaults to the real conda index reader.
+
+    Returns a list of dicts: {name, version, build, url, sha256, md5, depends}.
+
+    Raises
+    ------
+    MirrorUnavailableError : the channel/mirror could not be reached
+        (transport error). NEVER treated as "build gone" — no substitution.
+    BuildNotFoundError : the channel answered but the exact build is absent
+        (strict mode: fatal, we do not substitute).
+    LockTranslationError : programmer error (empty channels).
+    """
+    if not channels:
+        raise LockTranslationError("enrich_locked_packages requires explicit non-empty channels "
+                                   "(passing none lets conda fall back to the wrong source)")
+    if query is None:
+        query = _default_query
+
+    enriched = []
+    for (name, version, build) in locked:
+        try:
+            records = query(name, channels, subdir)
+        except Exception as e:  # noqa: BLE001 - we re-raise as a typed transport error
+            # Any failure to READ the index is a transport/mirror problem, not
+            # evidence the build is gone. Distinguish it loud; never fall
+            # through to substitution or to a BuildNotFound.
+            raise MirrorUnavailableError(
+                "could not reach channel(s) %r for %s=%s=%s on subdir %r: %s" %
+                (list(channels), name, version, build, subdir, e))
+
+        match = None
+        for rec in records or ():
+            # Exact identity: name+version+build, and the record must be for
+            # the requested subdir (query_all can return multiple subdirs).
+            if (rec.name == name and rec.version == version and rec.build == build
+                    and getattr(rec, "subdir", subdir) == subdir):
+                match = rec
+                break
+
+        if match is None:
+            raise BuildNotFoundError(
+                "exact build not found in channel(s) %r: %s=%s=%s on subdir %r "
+                "(strict mode does not substitute)" % (list(channels), name, version, build, subdir))
+
+        enriched.append({
+            "name": name,
+            "version": version,
+            "build": build,
+            # Trust-on-first-use: the lock carries no hash, so we record the
+            # channel's CURRENT sha256/md5. Integrity rests on a trusted/pinned
+            # channel (the airgap mirror in AE5).
+            "url": match.url,
+            "sha256": getattr(match, "sha256", None),
+            "md5": getattr(match, "md5", None),
+            "depends": list(getattr(match, "depends", ()) or ()),
+        })
+    return enriched

--- a/anaconda_project/internal/pixi_lock.py
+++ b/anaconda_project/internal/pixi_lock.py
@@ -228,3 +228,117 @@ def enrich_locked_packages(locked, channels, subdir, query=None):
             "depends": list(getattr(match, "depends", ()) or ()),
         })
     return enriched
+
+
+def build_pixi_lock(enriched_by_subdir, channels, env_name="default"):
+    """Assemble a pixi.lock (schema version 6) dict from enriched packages.
+
+    Parameters
+    ----------
+    enriched_by_subdir : {subdir: [enriched-pkg-dict, ...]} where each dict is
+        the output of enrich_locked_packages (name/version/build/url/sha256/
+        md5/depends). Every subdir's full closure must be present (pixi
+        rejects an incomplete closure with "lock-file not up-to-date").
+    channels : ordered channel URLs for the environment.
+    env_name : the pixi environment name (default "default").
+
+    Returns a plain dict matching pixi.lock v6:
+      version: 6
+      environments: {<env>: {channels: [{url}], packages: {<subdir>: [{conda: url}]}}}
+      packages: [{conda: url, sha256, md5, depends}]   # deduped, by url
+
+    The per-environment `packages.<subdir>` entries REFERENCE packages by url;
+    the top-level `packages` list holds each unique record once. We emit only
+    the minimal 4 fields (conda/sha256/md5/depends) which pixi accepts for
+    `pixi install --locked` (verified: pixi's own lock stripped to these still
+    installs). license/size/timestamp are intentionally omitted — not needed
+    for a faithful locked install, and we don't have authoritative values.
+    """
+    # Per-subdir reference lists for the environment.
+    env_packages = {}
+    # Top-level package records, deduped by url (a noarch package shared across
+    # subdirs appears once in `packages` but is referenced from each subdir).
+    records_by_url = {}
+    for subdir in sorted(enriched_by_subdir):
+        refs = []
+        for pkg in enriched_by_subdir[subdir]:
+            url = pkg["url"]
+            refs.append({"conda": url})
+            if url not in records_by_url:
+                rec = {"conda": url}
+                if pkg.get("sha256") is not None:
+                    rec["sha256"] = pkg["sha256"]
+                if pkg.get("md5") is not None:
+                    rec["md5"] = pkg["md5"]
+                if pkg.get("depends"):
+                    rec["depends"] = list(pkg["depends"])
+                records_by_url[url] = rec
+        env_packages[subdir] = refs
+
+    document = {
+        "version": 6,
+        "environments": {
+            env_name: {
+                "channels": [{"url": c} for c in channels],
+                "packages": env_packages,
+            }
+        },
+        # Stable order: sort the top-level package list by url for a
+        # deterministic lock (pixi doesn't require a particular order, but a
+        # stable emit makes diffs/tests reproducible).
+        "packages": [records_by_url[u] for u in sorted(records_by_url)],
+    }
+    return document
+
+
+def write_pixi_lock(document, path):
+    """Write the pixi.lock dict to ``path`` ATOMICALLY.
+
+    Full closure is already assembled in memory by build_pixi_lock; we
+    serialize to a temp file in the same directory and os.replace() it into
+    place, so a crash/interruption mid-write can never leave a half-written
+    (incomplete-closure) pixi.lock that pixi would reject with a confusing
+    "lock-file not up-to-date" error. Either the complete lock appears, or the
+    previous file is untouched.
+    """
+    import os
+    import tempfile
+    from ruamel.yaml import YAML
+
+    directory = os.path.dirname(os.path.abspath(path))
+    yaml = YAML()
+    # Package URLs are long; ruamel's default 80-col wrap folds them onto a
+    # continuation line ("conda:\n    https://...") which, while pixi tolerates
+    # it, is fragile for diffs/other readers and looks broken. Disable wrapping
+    # so each url stays on one line (matches how pixi writes its own lock).
+    yaml.width = 4096
+    fd, tmp_path = tempfile.mkstemp(prefix=".pixi.lock.", dir=directory, text=True)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.dump(document, f)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.remove(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def translate_lock_set(lock_set, channels, path, env_name="default", query=None):
+    """End-to-end: anaconda-project CondaLockSet -> faithful pixi.lock on disk.
+
+    Ties Items 1+2+4 together: fail-fast on pip, parse the exact closure for
+    every platform, enrich each via repodata (no solver), assemble the v6
+    document, and write it atomically. Strict mode throughout — any missing
+    build (BuildNotFoundError) or unreachable mirror (MirrorUnavailableError)
+    aborts BEFORE any file is written.
+    """
+    assert_no_pip_packages(lock_set)
+    enriched_by_subdir = {}
+    for platform in lock_set.platforms:
+        locked = parse_locked_specs(lock_set, platform)
+        enriched_by_subdir[platform] = enrich_locked_packages(locked, channels, platform, query=query)
+    document = build_pixi_lock(enriched_by_subdir, channels, env_name=env_name)
+    write_pixi_lock(document, path)
+    return document

--- a/anaconda_project/internal/pixi_lock.py
+++ b/anaconda_project/internal/pixi_lock.py
@@ -35,6 +35,16 @@ Scope of this module (v1):
   ``conda_api.ParsedSpec`` — there is no per-package hash), so there is no
   lock-time hash to validate the enriched ``sha256`` against. Integrity rests
   on the channels being trusted/pinned (in AE5: the airgap mirror).
+* Same limit applies to ``depends``/``sha256``/``md5``: the anaconda-project
+  lock carries NONE of them, so we read them from the channel's CURRENT
+  repodata. For the same ``name=version=build`` a channel's recorded
+  ``depends`` can drift over time (this is the very metadata drift that breaks
+  a re-solve), so the emitted ``depends`` reflects the mirror's metadata at
+  translate-time, not necessarily lock-time. This does not affect WHICH
+  artifacts install (those are pinned by url+build), only the recorded
+  dependency edges; ``pixi install --locked`` verifies the artifact closure,
+  which is exact. Faithfully reproducing lock-time ``depends`` is impossible
+  from a lock that never recorded them.
 
 This module is intentionally host-agnostic — it lives in anaconda-project and
 shells out to nothing AE5-specific, so any consumer of anaconda-project (the
@@ -230,36 +240,48 @@ def enrich_locked_packages(locked, channels, subdir, query=None):
     if query is None:
         query = _default_query
 
+    # A platform's closure mixes packages built for that platform with noarch
+    # packages (Python-only deps, tzdata, etc.). A package lives in EXACTLY one
+    # of {<platform>, noarch}, so we search both. The matched record's own
+    # subdir is recorded (each enriched dict carries "subdir") so the caller
+    # can place it in the right pixi.lock section — a noarch package must be
+    # emitted under noarch, not under the platform.
+    search_subdirs = [subdir] if subdir == "noarch" else [subdir, "noarch"]
+
     enriched = []
     for (name, version, build) in locked:
-        try:
-            records = query(name, channels, subdir)
-        except Exception as e:  # noqa: BLE001 - we re-raise as a typed transport error
-            # Any failure to READ the index is a transport/mirror problem, not
-            # evidence the build is gone. Distinguish it loud; never fall
-            # through to substitution or to a BuildNotFound.
-            raise MirrorUnavailableError(
-                "could not reach channel(s) %r for %s=%s=%s on subdir %r: %s" %
-                (list(channels), name, version, build, subdir, e))
-
         match = None
-        for rec in records or ():
-            # Exact identity: name+version+build, and the record must be for
-            # the requested subdir (query_all can return multiple subdirs).
-            if (rec.name == name and rec.version == version and rec.build == build
-                    and getattr(rec, "subdir", subdir) == subdir):
-                match = rec
+        for sd in search_subdirs:
+            try:
+                records = query(name, channels, sd)
+            except Exception as e:  # noqa: BLE001 - re-raise as a typed transport error
+                # Any failure to READ the index is a transport/mirror problem,
+                # not evidence the build is gone. Distinguish it loud; never
+                # fall through to substitution or to a BuildNotFound.
+                raise MirrorUnavailableError(
+                    "could not reach channel(s) %r for %s=%s=%s on subdir %r: %s" %
+                    (list(channels), name, version, build, sd, e))
+            for rec in records or ():
+                # Exact identity: name+version+build, for the subdir queried
+                # (query_all can return multiple subdirs).
+                if (rec.name == name and rec.version == version and rec.build == build
+                        and getattr(rec, "subdir", sd) == sd):
+                    match = rec
+                    break
+            if match is not None:
                 break
 
         if match is None:
             raise BuildNotFoundError(
-                "exact build not found in channel(s) %r: %s=%s=%s on subdir %r "
-                "(strict mode does not substitute)" % (list(channels), name, version, build, subdir))
+                "exact build not found in channel(s) %r: %s=%s=%s on subdir(s) %r "
+                "(strict mode does not substitute)" % (list(channels), name, version, build, search_subdirs))
 
         enriched.append({
             "name": name,
             "version": version,
             "build": build,
+            # the subdir the package was ACTUALLY found in (platform or noarch)
+            "subdir": getattr(match, "subdir", subdir),
             # Trust-on-first-use: the lock carries no hash, so we record the
             # channel's CURRENT sha256/md5. Integrity rests on a trusted/pinned
             # channel (the airgap mirror in AE5).

--- a/anaconda_project/internal/test/test_pixi_lock.py
+++ b/anaconda_project/internal/test/test_pixi_lock.py
@@ -346,3 +346,28 @@ def test_default_query_backend_shape_against_real_conda():
     r = recs[0]
     for field in ("url", "sha256", "md5", "depends"):
         assert hasattr(r, field), "PackageRecord missing %r (conda API changed)" % field
+
+
+def test_enrich_finds_noarch_package_when_platform_subdir_empty():
+    # A platform closure includes noarch packages (tzdata, pip, pure-python
+    # deps). Enrichment must search noarch in addition to the platform subdir,
+    # and record the package's ACTUAL subdir (noarch), not the platform.
+    def _query(name, channels, subdir):
+        if name == "tzdata" and subdir == "noarch":
+            return (_FakeRecord("tzdata", "2024a", "h0", "noarch",
+                                "https://m/noarch/tzdata-2024a-h0.conda", "s", "m", []),)
+        return ()   # nothing under the platform subdir
+    enriched = pixi_lock.enrich_locked_packages(
+        [("tzdata", "2024a", "h0")], channels=["pkgs/main"], subdir="osx-arm64", query=_query)
+    assert enriched[0]["subdir"] == "noarch"
+    assert "/noarch/" in enriched[0]["url"]
+
+
+def test_enrich_noarch_target_does_not_double_search():
+    # When the target IS noarch, don't search noarch twice; a miss is a miss.
+    def _query(name, channels, subdir):
+        assert subdir == "noarch"   # only ever queried for noarch
+        return ()
+    with pytest.raises(pixi_lock.BuildNotFoundError):
+        pixi_lock.enrich_locked_packages(
+            [("x", "1", "b")], channels=["pkgs/main"], subdir="noarch", query=_query)

--- a/anaconda_project/internal/test/test_pixi_lock.py
+++ b/anaconda_project/internal/test/test_pixi_lock.py
@@ -297,6 +297,17 @@ def test_write_pixi_lock_does_not_wrap_long_urls(tmpdir):
 
 # --- Item 5: SubdirData private-API guards ----------------------------------
 
+# conda-the-LIBRARY is not a dependency of anaconda-project (it shells out to a
+# conda BINARY), so the import may be absent in this test env. pixi_lock's
+# enrichment requires conda importable in-process (true in the editor image);
+# tests that need the real conda module skip cleanly where it isn't present.
+try:
+    import conda.core.subdir_data as _conda_subdir_data  # noqa: F401
+    _HAS_CONDA = True
+except Exception:  # noqa: BLE001
+    _HAS_CONDA = False
+
+
 def test_resolve_subdir_data_raises_typed_error_when_api_missing(monkeypatch):
     # Simulate a conda where the import path moved: _resolve_subdir_data must
     # raise our typed CondaIndexAPIError (with version context), not an opaque
@@ -315,6 +326,7 @@ def test_resolve_subdir_data_raises_typed_error_when_api_missing(monkeypatch):
     assert "subdir_data" in str(exc.value).lower()
 
 
+@pytest.mark.skipif(not _HAS_CONDA, reason="conda library not importable in this env")
 def test_resolve_subdir_data_raises_when_query_all_removed(monkeypatch):
     # conda imports fine, but query_all is gone (API renamed) -> typed error.
     class _NoQueryAll(object):
@@ -326,8 +338,8 @@ def test_resolve_subdir_data_raises_when_query_all_removed(monkeypatch):
     assert "query_all" in str(exc.value)
 
 
-@pytest.mark.skipif("CI_OFFLINE" in __import__("os").environ,
-                    reason="repodata canary needs network/mirror; skipped offline")
+@pytest.mark.skipif(not _HAS_CONDA or "CI_OFFLINE" in __import__("os").environ,
+                    reason="repodata canary needs conda + network/mirror; skipped without them")
 def test_default_query_backend_shape_against_real_conda():
     # CI CANARY (gated on editor-image build): against the installed/pinned
     # conda, SubdirData.query_all must import AND return records exposing the

--- a/anaconda_project/internal/test/test_pixi_lock.py
+++ b/anaconda_project/internal/test/test_pixi_lock.py
@@ -293,3 +293,56 @@ def test_write_pixi_lock_does_not_wrap_long_urls(tmpdir):
     # the full url appears on a single physical line (no fold)
     assert any(long_url in line for line in text.splitlines()), \
         "long url was wrapped onto a continuation line"
+
+
+# --- Item 5: SubdirData private-API guards ----------------------------------
+
+def test_resolve_subdir_data_raises_typed_error_when_api_missing(monkeypatch):
+    # Simulate a conda where the import path moved: _resolve_subdir_data must
+    # raise our typed CondaIndexAPIError (with version context), not an opaque
+    # ImportError, so convert-time failure is diagnosable.
+    import builtins
+    real_import = builtins.__import__
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "conda.core.subdir_data":
+            raise ImportError("No module named 'conda.core.subdir_data'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    with pytest.raises(pixi_lock.CondaIndexAPIError) as exc:
+        pixi_lock._resolve_subdir_data()
+    assert "subdir_data" in str(exc.value).lower()
+
+
+def test_resolve_subdir_data_raises_when_query_all_removed(monkeypatch):
+    # conda imports fine, but query_all is gone (API renamed) -> typed error.
+    class _NoQueryAll(object):
+        pass
+    import conda.core.subdir_data as sd
+    monkeypatch.setattr(sd, "SubdirData", _NoQueryAll, raising=True)
+    with pytest.raises(pixi_lock.CondaIndexAPIError) as exc:
+        pixi_lock._resolve_subdir_data()
+    assert "query_all" in str(exc.value)
+
+
+@pytest.mark.skipif("CI_OFFLINE" in __import__("os").environ,
+                    reason="repodata canary needs network/mirror; skipped offline")
+def test_default_query_backend_shape_against_real_conda():
+    # CI CANARY (gated on editor-image build): against the installed/pinned
+    # conda, SubdirData.query_all must import AND return records exposing the
+    # 4 fields we read (url/sha256/md5/depends). Catches a conda bump that
+    # silently breaks enrichment. Uses a tiny, stable noarch pkg on pkgs/main.
+    SubdirData = pixi_lock._resolve_subdir_data()        # import must work
+    assert hasattr(SubdirData, "query_all")
+    try:
+        recs = pixi_lock._default_query("tzdata", ["https://repo.anaconda.com/pkgs/main"], "noarch")
+    except pixi_lock.CondaIndexAPIError:
+        raise
+    except Exception:
+        pytest.skip("no network/mirror for repodata canary")
+    if not recs:
+        pytest.skip("tzdata not found on pkgs/main/noarch (channel/network)")
+    r = recs[0]
+    for field in ("url", "sha256", "md5", "depends"):
+        assert hasattr(r, field), "PackageRecord missing %r (conda API changed)" % field

--- a/anaconda_project/internal/test/test_pixi_lock.py
+++ b/anaconda_project/internal/test/test_pixi_lock.py
@@ -188,3 +188,108 @@ def test_module_import_graph_never_imports_conda_solver():
     importlib.import_module("anaconda_project.internal.pixi_lock")
     assert "conda.core.solve" not in sys.modules, \
         "pixi_lock must not import conda's solver at import time"
+
+
+# --- Item 4: assemble v6 doc + atomic write + pixi --locked acceptance -------
+
+def test_build_pixi_lock_v6_structure_and_noarch_dedup():
+    # tzdata is noarch -> shared across both subdirs; it must appear ONCE in
+    # the top-level packages list but be referenced from each subdir.
+    tz = {"name": "tzdata", "version": "2024a", "build": "h0c530f3_0",
+          "url": "https://m/noarch/tzdata-2024a-h0c530f3_0.conda",
+          "sha256": "tzsha", "md5": "tzmd5", "depends": []}
+    py64 = {"name": "python", "version": "3.12.2", "build": "x64",
+            "url": "https://m/linux-64/python-3.12.2-x64.conda",
+            "sha256": "p64", "md5": "m64", "depends": ["tzdata"]}
+    pyarm = {"name": "python", "version": "3.12.2", "build": "arm",
+             "url": "https://m/linux-aarch64/python-3.12.2-arm.conda",
+             "sha256": "parm", "md5": "marm", "depends": ["tzdata"]}
+    doc = pixi_lock.build_pixi_lock(
+        {"linux-64": [tz, py64], "linux-aarch64": [tz, pyarm]},
+        channels=["https://m"], env_name="default")
+
+    assert doc["version"] == 6
+    env = doc["environments"]["default"]
+    assert env["channels"] == [{"url": "https://m"}]
+    # each subdir references its own packages by url
+    assert {"conda": tz["url"]} in env["packages"]["linux-64"]
+    assert {"conda": py64["url"]} in env["packages"]["linux-64"]
+    assert {"conda": pyarm["url"]} in env["packages"]["linux-aarch64"]
+    # top-level packages: tzdata once (deduped), both pythons present = 3 total
+    urls = [p["conda"] for p in doc["packages"]]
+    assert urls.count(tz["url"]) == 1
+    assert len(doc["packages"]) == 3
+    # minimal 4-field schema only (no license/size/timestamp)
+    rec = next(p for p in doc["packages"] if p["conda"] == py64["url"])
+    assert set(rec.keys()) <= {"conda", "sha256", "md5", "depends"}
+    assert rec["sha256"] == "p64" and rec["depends"] == ["tzdata"]
+
+
+def test_write_pixi_lock_is_atomic_and_roundtrips(tmpdir):
+    import os
+    from ruamel.yaml import YAML
+    doc = {"version": 6, "environments": {}, "packages": []}
+    target = str(tmpdir.join("pixi.lock"))
+    pixi_lock.write_pixi_lock(doc, target)
+    assert os.path.exists(target)
+    # no leftover temp files in the dir
+    leftovers = [f for f in os.listdir(str(tmpdir)) if f.startswith(".pixi.lock.")]
+    assert leftovers == []
+    # reads back as the same document
+    with open(target) as f:
+        loaded = YAML().load(f)
+    assert loaded["version"] == 6
+
+
+def test_write_pixi_lock_failure_leaves_no_partial_file(tmpdir, monkeypatch):
+    import os
+    target = str(tmpdir.join("pixi.lock"))
+    # Force the serialize step to blow up AFTER the temp file is opened.
+    import anaconda_project.internal.pixi_lock as plmod
+
+    class _BoomYAML(object):
+        def dump(self, *a, **k):
+            raise RuntimeError("disk full mid-dump")
+    # monkeypatch the YAML class used inside write_pixi_lock
+    monkeypatch.setattr("ruamel.yaml.YAML", lambda *a, **k: _BoomYAML())
+    with pytest.raises(RuntimeError):
+        plmod.write_pixi_lock({"version": 6}, target)
+    assert not os.path.exists(target)                       # no partial target
+    assert [f for f in os.listdir(str(tmpdir)) if f.startswith(".pixi.lock.")] == []  # temp cleaned
+
+
+def test_translate_lock_set_end_to_end_with_injected_query(tmpdir):
+    import os
+    lock_set = CondaLockSet(
+        {"all": ["tzdata=2024a=h0c530f3_0"], "linux-64": ["python=3.12.2=x64"]},
+        platforms=["linux-64"])
+    recs = {
+        "tzdata": [_FakeRecord("tzdata", "2024a", "h0c530f3_0", "linux-64",
+                               "https://m/noarch/tzdata-2024a-h0c530f3_0.conda", "s", "m", [])],
+        "python": [_FakeRecord("python", "3.12.2", "x64", "linux-64",
+                               "https://m/linux-64/python-3.12.2-x64.conda", "s2", "m2", ["tzdata"])],
+    }
+    target = str(tmpdir.join("pixi.lock"))
+    doc = pixi_lock.translate_lock_set(lock_set, channels=["https://m"], path=target,
+                                       query=_fake_query_factory(recs))
+    assert os.path.exists(target)
+    assert len(doc["packages"]) == 2
+    assert "linux-64" in doc["environments"]["default"]["packages"]
+
+
+def test_write_pixi_lock_does_not_wrap_long_urls(tmpdir):
+    # Long package URLs must stay on one line (ruamel's default 80-col wrap
+    # folds "conda:" onto a continuation line, which is fragile for diffs and
+    # other readers). Regression for the canary finding.
+    long_url = ("https://repo.anaconda.com/pkgs/main/noarch/"
+                "some-rather-long-package-name-1.2.3-py312habcdef0_0.conda")
+    pkg = {"name": "x", "version": "1.2.3", "build": "py312habcdef0_0",
+           "url": long_url, "sha256": "s", "md5": "m", "depends": []}
+    doc = pixi_lock.build_pixi_lock({"linux-64": [pkg]}, channels=["https://repo.anaconda.com/pkgs/main"])
+    target = str(tmpdir.join("pixi.lock"))
+    pixi_lock.write_pixi_lock(doc, target)
+    with open(target) as f:
+        text = f.read()
+    # the full url appears on a single physical line (no fold)
+    assert any(long_url in line for line in text.splitlines()), \
+        "long url was wrapped onto a continuation line"

--- a/anaconda_project/internal/test/test_pixi_lock.py
+++ b/anaconda_project/internal/test/test_pixi_lock.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016, Anaconda, Inc. All rights reserved.
+#
+# Licensed under the terms of the BSD 3-Clause License.
+# The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Offline tests for anaconda_project.internal.pixi_lock (AENT-8881).
+
+These are fully offline (no network, no solver, no conda index): they cover
+the lock-set -> exact-package-closure reader and the fail-fast guards. The
+SubdirData enrichment + pixi-install --locked acceptance are exercised
+separately (Items 2/4) since those need repodata fixtures / a real pixi.
+"""
+from __future__ import absolute_import
+
+import pytest
+
+from anaconda_project.conda_manager import CondaLockSet
+from anaconda_project.internal import pixi_lock
+
+
+def test_parse_locked_specs_merges_buckets_incl_noarch():
+    # "all" carries the cross-platform (noarch) closure; package_specs_for_platform
+    # must merge it into the per-platform list, and we must preserve all of it
+    # (closure completeness is the pixi --locked acceptance gate).
+    lock_set = CondaLockSet(
+        {
+            "all": ["tzdata=2024a=h0c530f3_0"],            # noarch, shared
+            "linux-64": ["python=3.12.2=hab00c5b_0", "numpy=1.26.4=py312heda63a1_0"],
+        },
+        platforms=["linux-64"])
+    locked = pixi_lock.parse_locked_specs(lock_set, "linux-64")
+    names = sorted(n for (n, _v, _b) in locked)
+    assert names == ["numpy", "python", "tzdata"]            # noarch NOT dropped
+    assert ("python", "3.12.2", "hab00c5b_0") in locked
+    assert ("tzdata", "2024a", "h0c530f3_0") in locked
+
+
+def test_parse_locked_specs_unknown_platform_fails_loud():
+    lock_set = CondaLockSet({"linux-64": ["python=3.12.2=hab00c5b_0"]}, platforms=["linux-64"])
+    with pytest.raises(pixi_lock.LockTranslationError) as exc:
+        pixi_lock.parse_locked_specs(lock_set, "osx-arm64")
+    assert "no entry for platform" in str(exc.value)
+
+
+def test_parse_locked_specs_rejects_unpinned_spec():
+    # A spec without an exact version=build means this platform isn't actually
+    # locked; strict mode must refuse it rather than imply a re-solve.
+    lock_set = CondaLockSet({"linux-64": ["python=3.12.2=hab00c5b_0", "requests"]}, platforms=["linux-64"])
+    with pytest.raises(pixi_lock.LockTranslationError) as exc:
+        pixi_lock.parse_locked_specs(lock_set, "linux-64")
+    assert "not pinned to an exact version=build" in str(exc.value)
+
+
+def test_parse_locked_specs_rejects_version_without_build():
+    lock_set = CondaLockSet({"linux-64": ["python=3.12.2"]}, platforms=["linux-64"])
+    with pytest.raises(pixi_lock.LockTranslationError):
+        pixi_lock.parse_locked_specs(lock_set, "linux-64")
+
+
+def test_assert_no_pip_packages_passes_when_conda_only():
+    lock_set = CondaLockSet({"linux-64": ["python=3.12.2=hab00c5b_0"]}, platforms=["linux-64"])
+    # Should not raise.
+    pixi_lock.assert_no_pip_packages(lock_set)
+
+
+def test_assert_no_pip_packages_fails_fast_on_pip_bucket():
+    lock_set = CondaLockSet(
+        {
+            "linux-64": ["python=3.12.2=hab00c5b_0"],
+            "pip": ["some-pypi-only-pkg==1.2.3"],
+        },
+        platforms=["linux-64"])
+    with pytest.raises(pixi_lock.UnsupportedLockContentError) as exc:
+        pixi_lock.assert_no_pip_packages(lock_set)
+    assert "pip package" in str(exc.value)
+    assert "phase 2" in str(exc.value)

--- a/anaconda_project/internal/test/test_pixi_lock.py
+++ b/anaconda_project/internal/test/test_pixi_lock.py
@@ -7,10 +7,10 @@
 # -----------------------------------------------------------------------------
 """Offline tests for anaconda_project.internal.pixi_lock (AENT-8881).
 
-These are fully offline (no network, no solver, no conda index): they cover
-the lock-set -> exact-package-closure reader and the fail-fast guards. The
-SubdirData enrichment + pixi-install --locked acceptance are exercised
-separately (Items 2/4) since those need repodata fixtures / a real pixi.
+These are fully offline (no network, no solver, no conda index): enrichment
+is exercised through an injected fake query callable, so no repodata is
+fetched. The pixi-install --locked acceptance (Item 4) and the live census
+E2E (July) are separate.
 """
 from __future__ import absolute_import
 
@@ -18,6 +18,26 @@ import pytest
 
 from anaconda_project.conda_manager import CondaLockSet
 from anaconda_project.internal import pixi_lock
+
+
+class _FakeRecord(object):
+    """Stand-in for a conda PackageRecord (only the fields we read)."""
+    def __init__(self, name, version, build, subdir, url, sha256, md5, depends):
+        self.name = name
+        self.version = version
+        self.build = build
+        self.subdir = subdir
+        self.url = url
+        self.sha256 = sha256
+        self.md5 = md5
+        self.depends = depends
+
+
+def _fake_query_factory(records_by_name):
+    """Build an injectable query(name, channels, subdir) -> records."""
+    def _query(name, channels, subdir):
+        return tuple(records_by_name.get(name, ()))
+    return _query
 
 
 def test_parse_locked_specs_merges_buckets_incl_noarch():
@@ -76,3 +96,95 @@ def test_assert_no_pip_packages_fails_fast_on_pip_bucket():
         pixi_lock.assert_no_pip_packages(lock_set)
     assert "pip package" in str(exc.value)
     assert "phase 2" in str(exc.value)
+
+
+# --- Item 2: enrichment (offline, injected query) ---------------------------
+
+def test_enrich_exact_match_returns_four_fields():
+    recs = {
+        "python": [_FakeRecord("python", "3.12.2", "hab00c5b_0", "linux-64",
+                               "https://mirror/linux-64/python-3.12.2-hab00c5b_0.conda",
+                               "abc123", "def456", ["libffi", "openssl"])],
+    }
+    enriched = pixi_lock.enrich_locked_packages(
+        [("python", "3.12.2", "hab00c5b_0")],
+        channels=["pkgs/main"], subdir="linux-64",
+        query=_fake_query_factory(recs))
+    assert len(enriched) == 1
+    e = enriched[0]
+    assert e["url"].endswith("python-3.12.2-hab00c5b_0.conda")
+    assert e["sha256"] == "abc123"
+    assert e["md5"] == "def456"
+    assert e["depends"] == ["libffi", "openssl"]
+
+
+def test_enrich_build_not_found_fails_loud_no_substitution():
+    # Channel answers, but only a DIFFERENT build of the same name exists.
+    recs = {
+        "numpy": [_FakeRecord("numpy", "1.26.4", "py311_OTHER", "linux-64",
+                              "u", "s", "m", [])],
+    }
+    with pytest.raises(pixi_lock.BuildNotFoundError) as exc:
+        pixi_lock.enrich_locked_packages(
+            [("numpy", "1.26.4", "py312heda63a1_0")],
+            channels=["pkgs/main"], subdir="linux-64",
+            query=_fake_query_factory(recs))
+    assert "exact build not found" in str(exc.value)
+    assert "does not substitute" in str(exc.value)
+
+
+def test_enrich_transport_error_is_mirror_unavailable_not_build_gone():
+    # A transient failure to READ the index must NOT look like "build gone".
+    def _boom(name, channels, subdir):
+        raise OSError("connection reset / HTTP 429")
+    with pytest.raises(pixi_lock.MirrorUnavailableError) as exc:
+        pixi_lock.enrich_locked_packages(
+            [("python", "3.12.2", "hab00c5b_0")],
+            channels=["pkgs/main"], subdir="linux-64", query=_boom)
+    assert "could not reach" in str(exc.value)
+    # And crucially NOT a BuildNotFoundError (no substitution path).
+    assert not isinstance(exc.value, pixi_lock.BuildNotFoundError)
+
+
+def test_enrich_foreign_subdir_matches_only_target_subdir():
+    # query_all can return records for multiple subdirs; we must pick the one
+    # for the TARGET subdir (aarch64 record while running on a linux-64 host),
+    # not whatever happens to be first.
+    recs = {
+        "numpy": [
+            _FakeRecord("numpy", "1.26.4", "b0", "linux-64", "u-x64", "s-x64", "m-x64", []),
+            _FakeRecord("numpy", "1.26.4", "b0", "linux-aarch64", "u-arm", "s-arm", "m-arm", []),
+        ],
+    }
+    enriched = pixi_lock.enrich_locked_packages(
+        [("numpy", "1.26.4", "b0")],
+        channels=["pkgs/main"], subdir="linux-aarch64",
+        query=_fake_query_factory(recs))
+    assert enriched[0]["url"] == "u-arm"
+    assert enriched[0]["sha256"] == "s-arm"
+
+
+def test_enrich_empty_channels_is_programmer_error():
+    with pytest.raises(pixi_lock.LockTranslationError) as exc:
+        pixi_lock.enrich_locked_packages(
+            [("python", "3.12.2", "hab00c5b_0")],
+            channels=[], subdir="linux-64", query=lambda *a: ())
+    assert "non-empty channels" in str(exc.value)
+
+
+def test_module_import_graph_never_imports_conda_solver():
+    # The whole premise is NO SOLVER. Importing pixi_lock must not drag in
+    # conda's solver. (Belt + suspenders to the runtime tripwire: a future
+    # refactor that imports conda.core.solve at module scope fails here.)
+    import sys
+    import importlib
+
+    # Drop any already-imported solver + our module so the check is real.
+    for mod in list(sys.modules):
+        if mod == "conda.core.solve" or mod.startswith("conda.core.solve."):
+            del sys.modules[mod]
+    sys.modules.pop("anaconda_project.internal.pixi_lock", None)
+
+    importlib.import_module("anaconda_project.internal.pixi_lock")
+    assert "conda.core.solve" not in sys.modules, \
+        "pixi_lock must not import conda's solver at import time"

--- a/anaconda_project/internal/test/test_pixi_lock.py
+++ b/anaconda_project/internal/test/test_pixi_lock.py
@@ -79,6 +79,55 @@ def test_parse_locked_specs_rejects_version_without_build():
         pixi_lock.parse_locked_specs(lock_set, "linux-64")
 
 
+def test_parse_locked_specs_rejects_wildcard_build():
+    # conda_api.parse_spec's exact_version wildcard filter does NOT extend to
+    # exact_build_string, so "numpy=1.0=*" reports exact_build_string="*" --
+    # this is not a real pin and must be rejected here, not later as a
+    # misattributed BuildNotFoundError.
+    lock_set = CondaLockSet({"linux-64": ["numpy=1.0=*"]}, platforms=["linux-64"])
+    with pytest.raises(pixi_lock.LockTranslationError) as exc:
+        pixi_lock.parse_locked_specs(lock_set, "linux-64")
+    assert "not pinned to an exact version=build" in str(exc.value)
+
+
+def test_parse_locked_specs_rejects_partial_wildcard_build():
+    lock_set = CondaLockSet({"linux-64": ["numpy=1.0=py37*"]}, platforms=["linux-64"])
+    with pytest.raises(pixi_lock.LockTranslationError):
+        pixi_lock.parse_locked_specs(lock_set, "linux-64")
+
+
+def test_parse_locked_specs_rejects_disabled_lock_set():
+    # A disabled lock set means this platform was never actually locked;
+    # package_specs_for_platform's bare `assert self.enabled` must not leak
+    # as an opaque AssertionError.
+    lock_set = CondaLockSet({"linux-64": ["python=3.12.2=hab00c5b_0"]}, platforms=["linux-64"], enabled=False)
+    with pytest.raises(pixi_lock.LockTranslationError) as exc:
+        pixi_lock.parse_locked_specs(lock_set, "linux-64")
+    assert "not locked" in str(exc.value)
+
+
+def test_parse_locked_specs_rejects_duplicate_names_within_bucket():
+    # Two conflicting pins for the same name in one platform bucket must be
+    # caught here, not surfaced later as a confusing pixi-side rejection.
+    lock_set = CondaLockSet({"linux-64": ["bokeh=1.0=0", "bokeh=2.0=9"]}, platforms=["linux-64"])
+    with pytest.raises(pixi_lock.LockTranslationError) as exc:
+        pixi_lock.parse_locked_specs(lock_set, "linux-64")
+    assert "duplicate" in str(exc.value)
+    assert "bokeh" in str(exc.value)
+
+
+def test_parse_locked_specs_rejects_nested_pip_dict_as_typed_error():
+    # A nested {"pip": [...]} entry inside a platform bucket (not the
+    # top-level "pip" key) is not a valid conda spec string. This must
+    # surface as a typed LockTranslationError, not conda_api.parse_spec's
+    # raw TypeError.
+    lock_set = CondaLockSet(
+        {"linux-64": ["numpy=1.0=0", {"pip": ["flask==2.0"]}]}, platforms=["linux-64"])
+    with pytest.raises(pixi_lock.LockTranslationError) as exc:
+        pixi_lock.parse_locked_specs(lock_set, "linux-64")
+    assert "non-spec-string entry" in str(exc.value)
+
+
 def test_assert_no_pip_packages_passes_when_conda_only():
     lock_set = CondaLockSet({"linux-64": ["python=3.12.2=hab00c5b_0"]}, platforms=["linux-64"])
     # Should not raise.
@@ -96,6 +145,20 @@ def test_assert_no_pip_packages_fails_fast_on_pip_bucket():
         pixi_lock.assert_no_pip_packages(lock_set)
     assert "pip package" in str(exc.value)
     assert "phase 2" in str(exc.value)
+
+
+def test_assert_no_pip_packages_fails_fast_on_nested_pip_dict():
+    # A pip package can also appear NESTED inside a platform's spec list (the
+    # environment.yml-style {"pip": [...]} shape project.py matches via
+    # special_filter), not just under the top-level "pip" key. This function
+    # accepts any CondaLockSet -- it must not assume project.py's loader ran
+    # and stripped this shape first.
+    lock_set = CondaLockSet(
+        {"linux-64": ["numpy=1.0=0", {"pip": ["flask==2.0", "requests==2.0"]}]},
+        platforms=["linux-64"])
+    with pytest.raises(pixi_lock.UnsupportedLockContentError) as exc:
+        pixi_lock.assert_no_pip_packages(lock_set)
+    assert "pip package" in str(exc.value)
 
 
 # --- Item 2: enrichment (offline, injected query) ---------------------------
@@ -275,6 +338,28 @@ def test_translate_lock_set_end_to_end_with_injected_query(tmpdir):
     assert os.path.exists(target)
     assert len(doc["packages"]) == 2
     assert "linux-64" in doc["environments"]["default"]["packages"]
+
+
+def test_translate_lock_set_rejects_zero_platforms(tmpdir):
+    # A lock set with no platforms would otherwise assemble a valid-but-empty
+    # pixi.lock (install nothing) -- a silent no-op degradation.
+    lock_set = CondaLockSet({}, platforms=[])
+    target = str(tmpdir.join("pixi.lock"))
+    with pytest.raises(pixi_lock.LockTranslationError) as exc:
+        pixi_lock.translate_lock_set(lock_set, channels=["https://m"], path=target, query=lambda *a: ())
+    assert "no platforms" in str(exc.value)
+    assert not __import__("os").path.exists(target)
+
+
+def test_translate_lock_set_rejects_zero_packages(tmpdir):
+    # A lock set with platforms but zero locked packages on all of them would
+    # also otherwise write an empty-but-valid pixi.lock.
+    lock_set = CondaLockSet({"linux-64": []}, platforms=["linux-64"])
+    target = str(tmpdir.join("pixi.lock"))
+    with pytest.raises(pixi_lock.LockTranslationError) as exc:
+        pixi_lock.translate_lock_set(lock_set, channels=["https://m"], path=target, query=lambda *a: ())
+    assert "zero packages" in str(exc.value)
+    assert not __import__("os").path.exists(target)
 
 
 def test_write_pixi_lock_does_not_wrap_long_urls(tmpdir):


### PR DESCRIPTION
## Summary

Adds a no-solver `anaconda-project-lock.yml` → `pixi.lock` translator so a converted pixi project installs the *exact* packages it was locked with via `pixi install --locked`, instead of `pixi install` re-solving (which provably does NOT reproduce complex environments). Live-verified on ROSA (see "Live verification" below). Ready for review.

**Scope correction:** earlier revisions of this PR description said "Item 1 only." That's no longer accurate — this branch has accumulated Items 1, 2, 4, and 5 (Item 3, foreign-subdir handling, was folded into Item 2's enrichment). Only the **consumer wiring** (calling this from the launcher/CLI convert path) and the live census E2E are still pending, tracked as follow-ups on AENT-8881. See "What's in this PR" below for the real scope.

## Why (proven, not theoretical)
Spike on the holoviz `census` project (251 pkgs): **both** loose re-solve AND fully-pinned re-solve FAIL — any re-solve re-evaluates transitive constraints against *today's* repodata under strict channel priority, and metadata/channel drift after lock-time makes the solver reject a combination that worked. Only direct lock translation + `--locked` (never invoking the solver) reproduces it. Customer model-dev environments (bank/high-profile) are in scope, so this is a real reproducibility risk.

## What's in this PR
`anaconda_project/internal/pixi_lock.py`:
- `parse_locked_specs(lock_set, platform)` → exact `(name, version, build)` closure, reusing `CondaLockSet.package_specs_for_platform` (merges all/unix/<platform> buckets → cross-platform **noarch** included). Fails loud if any spec isn't pinned to exact `version=build`.
- `assert_no_pip_packages(lock_set)` → fails fast on a pip bucket (v1 is conda-only).
- `enrich_locked_packages(locked, channels, subdir, query=None)` → exact-match repodata enrichment (url/sha256/md5/depends) via conda's `SubdirData.query_all`, no solver, no substitution. Distinguishes a transport failure (`MirrorUnavailableError`) from an authoritatively-absent build (`BuildNotFoundError`) so a flaky mirror is never mistaken for "build is gone."
- `build_pixi_lock(...)` / `write_pixi_lock(...)` → assembles a pixi.lock v6 document and writes it atomically (temp file + `os.replace`).
- `translate_lock_set(lock_set, channels, path, ...)` → end-to-end entry point tying it all together.
- `_resolve_subdir_data()` → guards the conda private-API seam (`SubdirData.query_all`) with a typed `CondaIndexAPIError` + a CI canary, since this is the one place anaconda-project imports conda as a library rather than shelling out to it.

## Design decisions (settled via adversarial review — see AENT-8881)
- **strict-only v1.** A `best-effort` nearest-build mode was deliberately deferred: doing it correctly needs cross-package constraint re-derivation = a solver by another name.
- **Trust-on-first-use provenance.** `conda_api.ParsedSpec` carries **no per-package hash** — there is no lock-time hash to validate the enriched `sha256` against; integrity rests on trusted/pinned channels (the airgap mirror in AE5).
- **No re-fork** — reuses `CondaLockSet` + `conda_api.parse_spec` (the standalone_export / AENT-8833 lesson).

## Follow-up fixes (this push)
A fresh adversarial re-review after the branch had accumulated Items 1/2/4/5 found 5 spec shapes that slipped past the strict fail-loud gate the whole feature depends on:
1. **Wildcard/partial build strings accepted as exact pins.** `conda_api.parse_spec`'s wildcard filter (`|`, `*`, `,`) covers `exact_version` but not `exact_build_string`, so `numpy=1.0=*` or `numpy=1.0=py37*` were treated as fully resolved. Now explicitly rejected in `parse_locked_specs`.
2. **Nested pip packages escaped `assert_no_pip_packages`.** It only checked the top-level `"pip"` platform key, missing a `{"pip": [...]}` dict nested inside another platform's spec list (the environment.yml-style shape). Both shapes are now checked, and the nested case in `parse_locked_specs` raises a typed `LockTranslationError` instead of leaking `conda_api.parse_spec`'s raw `TypeError`.
3. **Disabled lock set surfaced an opaque `AssertionError`.** `CondaLockSet.package_specs_for_platform` has a bare `assert self.enabled`; `parse_locked_specs` now checks `lock_set.disabled` up front.
4. **Duplicate/conflicting pins within one platform bucket passed through unresolved**, deferring the failure to a confusing pixi-side rejection instead of a clear translate-time error.
5. **Zero-platform / zero-package lock sets silently wrote a valid-but-empty pixi.lock** (install nothing). `translate_lock_set` now refuses.

## Tests / verification
**30 offline unit tests** (no network, no solver, no conda index) — up from the original 6, covering all of the above plus the pre-existing enrichment/build/write/end-to-end coverage. All pass; flake8 clean.

## Live verification (ROSA)

Built this branch's `anaconda-project` conda package, overlaid it into a real editor image, pushed to a real ROSA cluster, and ran `translate_lock_set` from inside a real JupyterLab session against the **real** `repo.anaconda.com/pkgs/main` mirror — not an offline fixture:

- Hand-built a `CondaLockSet` with 3 real, exactly-pinned specs (`python=3.12.13=h4d16e0c_1`, `readline=8.3=hc2a1206_0`, `sqlite=3.53.2=h795bf6d_0`) and called `translate_lock_set` against the live channel.
- Result: a correct pixi.lock v6 document — real download URLs, real `sha256`/`md5` from the channel's actual current repodata, real `depends` edges, deduped top-level `packages` list. Exactly the shape the design promises.
- This also incidentally exercised the `CondaIndexAPIError`/`MirrorUnavailableError` guard for real: run first from the editor's `lab_launch` env (no `conda` library installed there, only the `pixi` CLI) — it correctly raised the typed error instead of an opaque `ModuleNotFoundError`, confirming the private-API guard fires correctly on a genuinely conda-less environment. Re-ran from an env with `conda` importable to get the full enrichment path.
- This is the same overlay/session used to verify anaconda-project-launcher#343 (AENT-8884), so the fix is confirmed present in the actual editor image build path (`editor/lab_launch/pixi.toml`), not just in this repo's own test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


