### PR TITLE
Add conda-workspaces support (conda.toml read/write, pyproject.toml embedding)

### DIFF
--- a/anaconda_project/internal/cli/conda_export_commands.py
+++ b/anaconda_project/internal/cli/conda_export_commands.py
@@ -8,61 +8,14 @@
 """Commands related to conda-workspaces (conda.toml) export."""
 from __future__ import absolute_import, print_function
 
-from anaconda_project.internal.cli.project_load import load_project
-from anaconda_project.internal.cli import console_utils
+from anaconda_project.internal.cli.pixi_commands import _export_workspace
 from anaconda_project import project_ops
 
 
 def export_conda(project_dir, filename, use_default=False, add_current_platform=False):
     """Export the project as a conda.toml file."""
-    import os
-    project = load_project(project_dir)
-    if console_utils.print_project_problems(project):
-        return 1
-    # Default to writing conda.toml in the project directory
-    if filename == 'conda.toml' and not os.path.isabs(filename):
-        filename = os.path.join(project_dir, filename)
-    status = project_ops.export_conda(project, filename=filename,
-                                      use_default=use_default,
-                                      add_current_platform=add_current_platform)
-    if status:
-        print(status.status_description)
-        # When the corresponding flag actually changed something, the
-        # status carries the value (rename source / added platform);
-        # surface it so the user can see what we did. When the user
-        # didn't pass the flag but the project would benefit, recommend
-        # the flag instead.
-        from anaconda_project.internal.pixi_export import (
-            current_platform_addition_target, default_rename_target,
-        )
-        if use_default and status.default_rename_from:
-            print(
-                'The "{}" environment has been renamed "default" in the '
-                'exported conda-workspaces specification.'.format(status.default_rename_from))
-        elif not use_default:
-            promoted = default_rename_target(project)
-            if promoted is not None:
-                print(
-                    'Recommendation: re-run using the --use-default flag to '
-                    'rename the "{}" environment to "default". This will '
-                    'simplify the resulting conda-workspaces specification.'.format(promoted))
-        if add_current_platform and status.current_platform_added:
-            print(
-                'The current platform "{}" has been added to the platforms '
-                'list in the exported conda-workspaces specification.'
-                .format(status.current_platform_added))
-        elif not add_current_platform:
-            missing = current_platform_addition_target(project)
-            if missing is not None:
-                print(
-                    'Recommendation: re-run using the --add-current-platform '
-                    'flag to add "{}" to the platforms list. conda-workspaces '
-                    'requires the host platform to be declared before it will '
-                    'install the environment.'.format(missing))
-        return 0
-    else:
-        console_utils.print_status_errors(status)
-        return 1
+    return _export_workspace(project_dir, filename, use_default, add_current_platform,
+                            project_ops.export_conda, 'conda.toml', 'conda-workspaces')
 
 
 def main_export_conda(args):

--- a/anaconda_project/internal/cli/conda_export_commands.py
+++ b/anaconda_project/internal/cli/conda_export_commands.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016, Anaconda, Inc. All rights reserved.
+#
+# Licensed under the terms of the BSD 3-Clause License.
+# The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Commands related to conda-workspaces (conda.toml) export."""
+from __future__ import absolute_import, print_function
+
+from anaconda_project.internal.cli.project_load import load_project
+from anaconda_project.internal.cli import console_utils
+from anaconda_project import project_ops
+
+
+def export_conda(project_dir, filename, use_default=False, add_current_platform=False):
+    """Export the project as a conda.toml file."""
+    import os
+    project = load_project(project_dir)
+    if console_utils.print_project_problems(project):
+        return 1
+    # Default to writing conda.toml in the project directory
+    if filename == 'conda.toml' and not os.path.isabs(filename):
+        filename = os.path.join(project_dir, filename)
+    status = project_ops.export_conda(project, filename=filename,
+                                      use_default=use_default,
+                                      add_current_platform=add_current_platform)
+    if status:
+        print(status.status_description)
+        # When the corresponding flag actually changed something, the
+        # status carries the value (rename source / added platform);
+        # surface it so the user can see what we did. When the user
+        # didn't pass the flag but the project would benefit, recommend
+        # the flag instead.
+        from anaconda_project.internal.pixi_export import (
+            current_platform_addition_target, default_rename_target,
+        )
+        if use_default and status.default_rename_from:
+            print(
+                'The "{}" environment has been renamed "default" in the '
+                'exported conda-workspaces specification.'.format(status.default_rename_from))
+        elif not use_default:
+            promoted = default_rename_target(project)
+            if promoted is not None:
+                print(
+                    'Recommendation: re-run using the --use-default flag to '
+                    'rename the "{}" environment to "default". This will '
+                    'simplify the resulting conda-workspaces specification.'.format(promoted))
+        if add_current_platform and status.current_platform_added:
+            print(
+                'The current platform "{}" has been added to the platforms '
+                'list in the exported conda-workspaces specification.'
+                .format(status.current_platform_added))
+        elif not add_current_platform:
+            missing = current_platform_addition_target(project)
+            if missing is not None:
+                print(
+                    'Recommendation: re-run using the --add-current-platform '
+                    'flag to add "{}" to the platforms list. conda-workspaces '
+                    'requires the host platform to be declared before it will '
+                    'install the environment.'.format(missing))
+        return 0
+    else:
+        console_utils.print_status_errors(status)
+        return 1
+
+
+def main_export_conda(args):
+    """Start the export-conda command and return exit status code."""
+    return export_conda(args.directory, args.filename,
+                        use_default=args.use_default,
+                        add_current_platform=args.add_current_platform)

--- a/anaconda_project/internal/cli/info.py
+++ b/anaconda_project/internal/cli/info.py
@@ -12,7 +12,6 @@ import json
 import sys
 
 from anaconda_project.project_info import (
-    PROJECT_TYPE_PIXI,
     PROJECT_TYPE_KEY,
     publication_info,
 )

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -427,9 +427,9 @@ def _parse_args_and_run_subcommand(argv):
     preset = subparsers.add_parser(
         'info',
         help=("Show a summary of the project: name, environments, commands, "
-              "variables. Reads pixi.toml when present (and an "
-              "anaconda-project.yml otherwise) and can also surface env "
-              "prefix locations."))
+              "variables. Reads conda.toml, then pixi.toml, then "
+              "anaconda-project.yml, then pyproject.toml (tool.conda/tool.pixi), "
+              "in that order, and can also surface env prefix locations."))
     add_directory_arg(preset)
     preset.add_argument('--json',
                         action='store_true',
@@ -442,10 +442,11 @@ def _parse_args_and_run_subcommand(argv):
                               "For pixi projects this shells out to `pixi info --json` "
                               "and stashes its full output under `_pixi` in --json mode."))
     preset.add_argument('--project-type',
-                        choices=('pixi', 'anaconda-project'),
+                        choices=('conda-workspaces', 'pixi', 'anaconda-project'),
                         default=None,
                         help=("Force a manifest format. The default behavior reads "
-                              "pixi.toml if present, otherwise anaconda-project.yml."))
+                              "conda.toml, then pixi.toml, then anaconda-project.yml, "
+                              "then pyproject.toml (tool.conda/tool.pixi), in that order."))
     preset.set_defaults(main=info_cli.main)
 
     # argparse doesn't do this for us for whatever reason

--- a/anaconda_project/internal/cli/main.py
+++ b/anaconda_project/internal/cli/main.py
@@ -39,6 +39,7 @@ import anaconda_project.internal.cli.service_commands as service_commands
 import anaconda_project.internal.cli.environment_commands as environment_commands
 import anaconda_project.internal.cli.command_commands as command_commands
 import anaconda_project.internal.cli.pixi_commands as pixi_commands
+import anaconda_project.internal.cli.conda_export_commands as conda_export_commands
 import anaconda_project.internal.cli.info as info_cli
 
 
@@ -423,6 +424,28 @@ def _parse_args_and_run_subcommand(argv):
                               "more forgiving, so this prevents a pixi install error after "
                               "conversion."))
     preset.set_defaults(main=pixi_commands.main_export_pixi)
+
+    preset = subparsers.add_parser(
+        'export-conda', help="Export the project as a conda.toml file (conda-workspaces)")
+    add_directory_arg(preset)
+    preset.add_argument('filename', metavar='CONDA_TOML_FILE', nargs='?', default='conda.toml')
+    preset.add_argument('--use-default',
+                        action='store_true',
+                        default=False,
+                        help=("If the project has no env_spec named 'default', rename the "
+                              "default-command's env_spec (or the first one declared) to "
+                              "'default' on export. Collapses [feature.{name}.*] blocks "
+                              "into top-level [dependencies] / [tasks.X] for a cleaner "
+                              "conda.toml."))
+    preset.add_argument('--add-current-platform',
+                        action='store_true',
+                        default=False,
+                        help=("If the host's conda subdir (e.g. osx-arm64) isn't already in "
+                              "the project's platforms list, add it on export. "
+                              "conda-workspaces rejects envs that don't list the host "
+                              "platform; anaconda-project is more forgiving, so this "
+                              "prevents an install error after conversion."))
+    preset.set_defaults(main=conda_export_commands.main_export_conda)
 
     preset = subparsers.add_parser(
         'info',

--- a/anaconda_project/internal/cli/pixi_commands.py
+++ b/anaconda_project/internal/cli/pixi_commands.py
@@ -82,7 +82,7 @@ def _export_workspace(project_dir, filename, use_default, add_current_platform,
 def export_pixi(project_dir, filename, use_default=False, add_current_platform=False):
     """Export the project as a pixi.toml file."""
     return _export_workspace(project_dir, filename, use_default, add_current_platform,
-                            project_ops.export_pixi, 'pixi.toml', 'pixi')
+                            project_ops.export_pixi, 'pixi.toml', 'Pixi')
 
 
 def main_export_pixi(args):

--- a/anaconda_project/internal/cli/pixi_commands.py
+++ b/anaconda_project/internal/cli/pixi_commands.py
@@ -13,18 +13,32 @@ from anaconda_project.internal.cli import console_utils
 from anaconda_project import project_ops
 
 
-def export_pixi(project_dir, filename, use_default=False, add_current_platform=False):
-    """Export the project as a pixi.toml file."""
+def _export_workspace(project_dir, filename, use_default, add_current_platform,
+                     export_fn, default_filename, format_label):
+    """Shared workspace export logic for both pixi and conda-workspaces formats.
+
+    Args:
+        project_dir: Directory containing the project.
+        filename: Output filename (or 'pixi.toml'/'conda.toml' for project_dir default).
+        use_default: Whether to promote a non-default env to 'default'.
+        add_current_platform: Whether to add the current platform to the list.
+        export_fn: Function to call from project_ops (export_pixi or export_conda).
+        default_filename: Default filename if relative ('pixi.toml' or 'conda.toml').
+        format_label: Format name for user-facing messages (e.g. 'pixi' or 'conda-workspaces').
+
+    Returns:
+        Exit status code (0 on success, 1 on error).
+    """
     import os
     project = load_project(project_dir)
     if console_utils.print_project_problems(project):
         return 1
-    # Default to writing pixi.toml in the project directory
-    if filename == 'pixi.toml' and not os.path.isabs(filename):
+    # Default to writing the manifest file in the project directory
+    if filename == default_filename and not os.path.isabs(filename):
         filename = os.path.join(project_dir, filename)
-    status = project_ops.export_pixi(project, filename=filename,
-                                     use_default=use_default,
-                                     add_current_platform=add_current_platform)
+    status = export_fn(project, filename=filename,
+                       use_default=use_default,
+                       add_current_platform=add_current_platform)
     if status:
         print(status.status_description)
         # When the corresponding flag actually changed something, the
@@ -38,31 +52,37 @@ def export_pixi(project_dir, filename, use_default=False, add_current_platform=F
         if use_default and status.default_rename_from:
             print(
                 'The "{}" environment has been renamed "default" in the '
-                'exported Pixi specification.'.format(status.default_rename_from))
+                'exported {} specification.'.format(status.default_rename_from, format_label))
         elif not use_default:
             promoted = default_rename_target(project)
             if promoted is not None:
                 print(
                     'Recommendation: re-run using the --use-default flag to '
                     'rename the "{}" environment to "default". This will '
-                    'simplify the resulting Pixi specification.'.format(promoted))
+                    'simplify the resulting {} specification.'.format(promoted, format_label))
         if add_current_platform and status.current_platform_added:
             print(
                 'The current platform "{}" has been added to the platforms '
-                'list in the exported Pixi specification.'
-                .format(status.current_platform_added))
+                'list in the exported {} specification.'
+                .format(status.current_platform_added, format_label))
         elif not add_current_platform:
             missing = current_platform_addition_target(project)
             if missing is not None:
                 print(
                     'Recommendation: re-run using the --add-current-platform '
-                    'flag to add "{}" to the platforms list. Pixi requires '
+                    'flag to add "{}" to the platforms list. {} requires '
                     'the host platform to be declared before it will install '
-                    'the environment.'.format(missing))
+                    'the environment.'.format(missing, format_label))
         return 0
     else:
         console_utils.print_status_errors(status)
         return 1
+
+
+def export_pixi(project_dir, filename, use_default=False, add_current_platform=False):
+    """Export the project as a pixi.toml file."""
+    return _export_workspace(project_dir, filename, use_default, add_current_platform,
+                            project_ops.export_pixi, 'pixi.toml', 'pixi')
 
 
 def main_export_pixi(args):

--- a/anaconda_project/internal/cli/test/test_info.py
+++ b/anaconda_project/internal/cli/test/test_info.py
@@ -28,6 +28,12 @@ def _write_anaconda_project(d, content):
         f.write(content)
 
 
+def _write_conda_toml(d, content):
+    path = os.path.join(d, 'conda.toml')
+    with open(path, 'w') as f:
+        f.write(content)
+
+
 _PIXI_TOML = textwrap.dedent("""\
     [workspace]
     name = "demo"
@@ -139,6 +145,17 @@ class TestInfoProjectType:
             assert code == 1
             _, err = capsys.readouterr()
             assert 'pixi.toml' in err
+
+    def test_project_type_conda_workspaces_accepted_by_argparse(self, capsys):
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(td, '[workspace]\nname = "from-conda"\n')
+            code = _parse_args_and_run_subcommand(
+                ['anaconda-project', 'info', '--directory', td,
+                 '--project-type', 'conda-workspaces', '--json'])
+            assert code == 0
+            data = json.loads(capsys.readouterr().out)
+            assert data['project_type'] == 'conda-workspaces'
+            assert data['name'] == 'from-conda'
 
 
 class TestInfoEnvPaths:

--- a/anaconda_project/internal/cli/test/test_main.py
+++ b/anaconda_project/internal/cli/test/test_main.py
@@ -23,7 +23,7 @@ all_subcommands = ('init', 'run', 'prepare', 'clean', 'activate', 'archive', 'un
                    'list-services', 'add-env-spec', 'remove-env-spec', 'list-env-specs', 'export-env-spec', 'lock',
                    'unlock', 'update', 'add-packages', 'remove-packages', 'list-packages', 'add-platforms',
                    'remove-platforms', 'list-platforms', 'add-command', 'remove-command', 'list-default-command',
-                   'list-commands', 'export-pixi', 'info')
+                   'list-commands', 'export-pixi', 'export-conda', 'info')
 all_subcommands_in_curlies = "{" + ",".join(all_subcommands) + "}"
 all_subcommands_comma_space = ", ".join(["'" + s + "'" for s in all_subcommands])
 
@@ -134,9 +134,12 @@ expected_usage_msg_format = (  # noqa
     '                        List only the default command on the project\n'
     '    list-commands       List the commands on the project\n'
     '    export-pixi         Export the project as a pixi.toml file\n'
+    '    export-conda        Export the project as a conda.toml file (conda-\n'
+    '                        workspaces)\n'
     '    info                Show a summary of the project: name, environments,\n'
-    '                        commands, variables. Reads pixi.toml when present (and\n'
-    '                        an anaconda-project.yml otherwise) and can also\n'
+    '                        commands, variables. Reads conda.toml, then pixi.toml,\n'
+    '                        then anaconda-project.yml, then pyproject.toml\n'
+    '                        (tool.conda/tool.pixi), in that order, and can also\n'
     '                        surface env prefix locations.\n'
     '\n'
     'optional arguments:\n'

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -1215,3 +1215,22 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False, def
         lines.append('')
 
     return '\n'.join(lines).rstrip() + '\n'
+
+
+def export_conda_toml(project, use_default=False, add_current_platform=False, default_channels=None):
+    """Convert an anaconda-project Project to conda.toml (conda-workspaces) content.
+
+    This delegates directly to :func:`export_pixi_toml` and returns its result
+    unchanged. conda-workspaces 0.7.0's TOML shape for `[workspace]`,
+    `[dependencies]`, `[feature.*]`, `[environments]`, and `[tasks]` is
+    field-for-field identical to pixi.toml's for every field this exporter
+    emits: the `args` table form the task emitter already writes is accepted
+    by `conda_workspaces.manifests.normalize.normalize_args` (both the bare
+    string and detailed table forms are supported), so no translation is
+    needed for the content this function produces today. See the Args/Returns
+    docs on :func:`export_pixi_toml` for the full parameter and output
+    semantics — they carry over unchanged.
+    """
+    return export_pixi_toml(project, use_default=use_default,
+                            add_current_platform=add_current_platform,
+                            default_channels=default_channels)

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -27,7 +27,8 @@ class CondaNotAvailableError(Exception):
 
 
 class PixiExportStatus(SimpleStatus):
-    """Status returned by :func:`anaconda_project.project_ops.export_pixi`.
+    """Status returned by :func:`anaconda_project.project_ops.export_pixi` and
+    :func:`anaconda_project.project_ops.export_conda`.
 
     Carries fields downstream consumers (launchers, IDE plugins) use to
     surface what the export actually changed without re-querying the

--- a/anaconda_project/internal/pixi_export.py
+++ b/anaconda_project/internal/pixi_export.py
@@ -57,6 +57,12 @@ class PixiExportStatus(SimpleStatus):
         return self._current_platform_added
 
 
+_FORMAT_NAMES = {
+    'pixi': {'tool': 'pixi', 'manifest': 'pixi.toml', 'run_verb': 'pixi run'},
+    'conda-workspaces': {'tool': 'conda-workspaces', 'manifest': 'conda.toml', 'run_verb': 'conda task run'},
+}
+
+
 def _resolve_default_channels():
     """Return the list of URLs that `defaults` expands to, taken from the
     user's local ``conda config --show default_channels``.
@@ -621,7 +627,7 @@ def _format_args_block(args):
     return 'args = [{}]'.format(', '.join(parts))
 
 
-def _command_to_task(command, declared_vars):
+def _command_to_task(command, declared_vars, target_format='pixi'):
     """Convert a ProjectCommand to a pixi task string or None.
 
     Pixi runs tasks under deno_task_shell, which speaks unix-style syntax on
@@ -703,7 +709,7 @@ def _command_to_task(command, declared_vars):
     if unresolved:
         comments.append(
             'unresolved env var(s): {} — set them via [activation.env] or '
-            'before running pixi'.format(', '.join(unresolved)))
+            'before running {}'.format(', '.join(unresolved), _FORMAT_NAMES[target_format]['run_verb']))
     return cmd_rendered, raw_forms, comments, args_line
 
 
@@ -779,7 +785,7 @@ def current_platform_addition_target(project):
     return None if here in declared else here
 
 
-def export_pixi_toml(project, use_default=False, add_current_platform=False, default_channels=None):
+def export_pixi_toml(project, use_default=False, add_current_platform=False, default_channels=None, target_format='pixi'):
     """Convert an anaconda-project Project to pixi.toml content.
 
     Args:
@@ -1053,7 +1059,7 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False, def
         lines.append('[environments]')
         for env_name in env_specs:
             if env_name == 'default':
-                lines.append('# default  (pixi creates this implicitly from the default feature)')
+                lines.append('# default  ({} creates this implicitly from the default feature)'.format(_FORMAT_NAMES[target_format]['tool']))
             else:
                 pixi_env_name = _sanitize_env_name(env_name)
                 lines.append('{name} = {{ features = ["{name}"] }}'.format(name=pixi_env_name))
@@ -1089,7 +1095,7 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False, def
 
         for cmd_name, command in global_tasks:
             task_cmd, raw_forms, comments, args_line = _command_to_task(
-                command, declared_vars)
+                command, declared_vars, target_format=target_format)
             if task_cmd is None:
                 lines.append('# {} — could not convert (no unix command)'.format(cmd_name))
                 continue
@@ -1110,7 +1116,7 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False, def
 
         for cmd_name, command in feature_tasks:
             task_cmd, raw_forms, comments, args_line = _command_to_task(
-                command, declared_vars)
+                command, declared_vars, target_format=target_format)
             if task_cmd is None:
                 lines.append('# {} — could not convert (no unix command)'.format(cmd_name))
                 continue
@@ -1192,7 +1198,7 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False, def
                 services[req.env_var] = req.service_type
 
     if services:
-        lines.append('# Services from anaconda-project.yml (no pixi equivalent):')
+        lines.append('# Services from anaconda-project.yml (no {} equivalent):'.format(_FORMAT_NAMES[target_format]['tool']))
         for var_name, svc_type in sorted(services.items()):
             lines.append('#   {} = {}'.format(var_name, svc_type))
         lines.append('')
@@ -1220,17 +1226,14 @@ def export_pixi_toml(project, use_default=False, add_current_platform=False, def
 def export_conda_toml(project, use_default=False, add_current_platform=False, default_channels=None):
     """Convert an anaconda-project Project to conda.toml (conda-workspaces) content.
 
-    This delegates directly to :func:`export_pixi_toml` and returns its result
-    unchanged. conda-workspaces 0.7.0's TOML shape for `[workspace]`,
-    `[dependencies]`, `[feature.*]`, `[environments]`, and `[tasks]` is
-    field-for-field identical to pixi.toml's for every field this exporter
-    emits: the `args` table form the task emitter already writes is accepted
-    by `conda_workspaces.manifests.normalize.normalize_args` (both the bare
-    string and detailed table forms are supported), so no translation is
-    needed for the content this function produces today. See the Args/Returns
-    docs on :func:`export_pixi_toml` for the full parameter and output
-    semantics — they carry over unchanged.
+    Delegates to :func:`export_pixi_toml` with ``target_format='conda-workspaces'``,
+    which produces conda-workspaces-native wording for the handful of prose strings
+    that differ between formats (env-materialization comment, services comment,
+    unresolved-env-var message) while keeping the TOML structure identical.
+    See the Args/Returns docs on :func:`export_pixi_toml` for the full parameter
+    and output semantics — they carry over unchanged.
     """
     return export_pixi_toml(project, use_default=use_default,
                             add_current_platform=add_current_platform,
-                            default_channels=default_channels)
+                            default_channels=default_channels,
+                            target_format='conda-workspaces')

--- a/anaconda_project/internal/pixi_lock.py
+++ b/anaconda_project/internal/pixi_lock.py
@@ -56,6 +56,21 @@ from anaconda_project.internal import conda_api
 from anaconda_project.internal.py2_compat import is_string, is_dict
 
 
+# conda-workspaces' conda.lock is a byte-for-byte rattler-lock v6 derivative
+# (same version/environments/packages shape build_pixi_lock already emits)
+# with one on-disk difference: the top-level "version" field is stamped 1
+# instead of 6, so conda_workspaces.lockfile.CondaLockLoader.can_handle()
+# recognizes it as its own format (it does an in-memory 1->6 swap before
+# reusing the same rattler-lock v6 conversion code pixi's own loader uses).
+# Ground-truthed against the installed conda-workspaces 0.7.0 package
+# (conda_workspaces/lockfile.py: LOCKFILE_VERSION = 1, can_handle() checks
+# data.get("version") == LOCKFILE_VERSION) rather than assumed from docs.
+_LOCK_VERSION_BY_FORMAT = {
+    'pixi': 6,
+    'conda-workspaces': 1,
+}
+
+
 # anaconda-project lock files group package specs into "buckets" keyed by
 # platform OR by a cross-platform selector ("all", "unix", "linux", "osx",
 # "win"). CondaLockSet.package_specs_for_platform() already merges the right
@@ -348,8 +363,8 @@ def enrich_locked_packages(locked, channels, subdir, query=None):
     return enriched
 
 
-def build_pixi_lock(enriched_by_subdir, channels, env_name="default"):
-    """Assemble a pixi.lock (schema version 6) dict from enriched packages.
+def build_pixi_lock(enriched_by_subdir, channels, env_name="default", target_format='pixi'):
+    """Assemble a pixi.lock/conda.lock dict from enriched packages.
 
     Parameters
     ----------
@@ -359,9 +374,15 @@ def build_pixi_lock(enriched_by_subdir, channels, env_name="default"):
         rejects an incomplete closure with "lock-file not up-to-date").
     channels : ordered channel URLs for the environment.
     env_name : the pixi environment name (default "default").
+    target_format : 'pixi' (default) or 'conda-workspaces'. The two formats
+        share an identical environments/packages schema (conda-workspaces'
+        conda.lock is a rattler-lock v6 derivative); the only on-disk
+        difference this function controls is the top-level "version" stamp
+        (6 for pixi.lock, 1 for conda.lock) that each tool's own loader
+        checks to recognize its format — see ``_LOCK_VERSION_BY_FORMAT``.
 
-    Returns a plain dict matching pixi.lock v6:
-      version: 6
+    Returns a plain dict matching the target format's lock schema:
+      version: 6 (pixi) or 1 (conda-workspaces)
       environments: {<env>: {channels: [{url}], packages: {<subdir>: [{conda: url}]}}}
       packages: [{conda: url, sha256, md5, depends}]   # deduped, by url
 
@@ -372,6 +393,10 @@ def build_pixi_lock(enriched_by_subdir, channels, env_name="default"):
     installs). license/size/timestamp are intentionally omitted — not needed
     for a faithful locked install, and we don't have authoritative values.
     """
+    if target_format not in _LOCK_VERSION_BY_FORMAT:
+        raise LockTranslationError(
+            "unknown target_format %r; expected one of %r" %
+            (target_format, sorted(_LOCK_VERSION_BY_FORMAT)))
     # Per-subdir reference lists for the environment.
     env_packages = {}
     # Top-level package records, deduped by url (a noarch package shared across
@@ -394,7 +419,7 @@ def build_pixi_lock(enriched_by_subdir, channels, env_name="default"):
         env_packages[subdir] = refs
 
     document = {
-        "version": 6,
+        "version": _LOCK_VERSION_BY_FORMAT[target_format],
         "environments": {
             env_name: {
                 "channels": [{"url": c} for c in channels],
@@ -410,14 +435,19 @@ def build_pixi_lock(enriched_by_subdir, channels, env_name="default"):
 
 
 def write_pixi_lock(document, path):
-    """Write the pixi.lock dict to ``path`` ATOMICALLY.
+    """Write the lock dict to ``path`` ATOMICALLY.
+
+    Works for either pixi.lock or conda.lock content — the document's own
+    "version" field (set by build_pixi_lock's target_format) is what a
+    reading tool actually checks; this function just serializes whatever
+    dict it's given to whatever path it's given.
 
     Full closure is already assembled in memory by build_pixi_lock; we
     serialize to a temp file in the same directory and os.replace() it into
     place, so a crash/interruption mid-write can never leave a half-written
-    (incomplete-closure) pixi.lock that pixi would reject with a confusing
-    "lock-file not up-to-date" error. Either the complete lock appears, or the
-    previous file is untouched.
+    (incomplete-closure) lock file that pixi/conda-workspaces would reject
+    with a confusing "lock-file not up-to-date" error. Either the complete
+    lock appears, or the previous file is untouched.
     """
     import os
     import tempfile
@@ -430,7 +460,11 @@ def write_pixi_lock(document, path):
     # it, is fragile for diffs/other readers and looks broken. Disable wrapping
     # so each url stays on one line (matches how pixi writes its own lock).
     yaml.width = 4096
-    fd, tmp_path = tempfile.mkstemp(prefix=".pixi.lock.", dir=directory, text=True)
+    # Prefix derived from the real target filename (pixi.lock or conda.lock)
+    # rather than hardcoded, so the temp file's name still makes sense for
+    # whichever format is being written.
+    tmp_prefix = ".{}.".format(os.path.basename(path))
+    fd, tmp_path = tempfile.mkstemp(prefix=tmp_prefix, dir=directory, text=True)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             yaml.dump(document, f)
@@ -443,18 +477,24 @@ def write_pixi_lock(document, path):
         raise
 
 
-def translate_lock_set(lock_set, channels, path, env_name="default", query=None):
-    """End-to-end: anaconda-project CondaLockSet -> faithful pixi.lock on disk.
+def translate_lock_set(lock_set, channels, path, env_name="default", query=None, target_format='pixi'):
+    """End-to-end: anaconda-project CondaLockSet -> faithful pixi.lock/conda.lock on disk.
 
     Ties Items 1+2+4 together: fail-fast on pip, parse the exact closure for
-    every platform, enrich each via repodata (no solver), assemble the v6
+    every platform, enrich each via repodata (no solver), assemble the
     document, and write it atomically. Strict mode throughout — any missing
     build (BuildNotFoundError) or unreachable mirror (MirrorUnavailableError)
     aborts BEFORE any file is written.
 
+    ``target_format`` is ``'pixi'`` (default, writes a pixi.lock-shaped
+    document) or ``'conda-workspaces'`` (writes the same shape stamped as a
+    conda.lock — see ``build_pixi_lock``'s docstring for what actually
+    differs between the two). ``path`` is the caller's choice either way;
+    this function does not infer a filename from ``target_format``.
+
     Raises ``LockTranslationError`` if the lock set has no platforms, or if
     the assembled closure has zero packages on every platform — either would
-    otherwise write a valid-but-empty pixi.lock (install nothing), which is
+    otherwise write a valid-but-empty lock file (install nothing), which is
     a silent no-op degradation, not a faithful translation.
     """
     if not lock_set.platforms:
@@ -466,8 +506,8 @@ def translate_lock_set(lock_set, channels, path, env_name="default", query=None)
         enriched_by_subdir[platform] = enrich_locked_packages(locked, channels, platform, query=query)
     if not any(enriched_by_subdir.values()):
         raise LockTranslationError(
-            "lock set for platforms %r resolved to zero packages; refusing to write an empty pixi.lock" %
+            "lock set for platforms %r resolved to zero packages; refusing to write an empty lock file" %
             (list(lock_set.platforms), ))
-    document = build_pixi_lock(enriched_by_subdir, channels, env_name=env_name)
+    document = build_pixi_lock(enriched_by_subdir, channels, env_name=env_name, target_format=target_format)
     write_pixi_lock(document, path)
     return document

--- a/anaconda_project/internal/test/test_conda_export.py
+++ b/anaconda_project/internal/test/test_conda_export.py
@@ -211,3 +211,62 @@ platforms:
         code = _parse_args_and_run_subcommand(
             ['anaconda-project', 'export-conda', '--directory', project_dir])
         assert code == 1
+
+
+class TestExportWorkspaceSharedCliWording:
+    """`export-pixi`/`export-conda` share `_export_workspace` (Item F5). That
+    helper is parameterized by a `format_label` used in every user-facing
+    recommendation/confirmation string — a collapse-the-duplication refactor
+    that flattens either format's label (e.g. losing pixi's original
+    capitalized "Pixi" wording) silently changes CLI output with no gate
+    catching it, since neither format had an exact-wording test before this
+    class. Assert both formats keep their pre-collapse wording verbatim."""
+
+    def _write_multi_env_project(self, project_dir, name):
+        with open(os.path.join(project_dir, 'anaconda-project.yml'), 'w') as f:
+            f.write("""
+name: {}
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {{}}
+""".format(name))
+
+    def test_export_pixi_cli_recommendation_wording(self, capsys, tmpdir):
+        project_dir = str(tmpdir)
+        self._write_multi_env_project(project_dir, 'PixiWording')
+        code = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'export-pixi', '--directory', project_dir, '--use-default'])
+        assert code == 0
+        out, _ = capsys.readouterr()
+        assert 'exported Pixi specification' in out
+        assert 'simplify the resulting Pixi specification' not in out  # use_default was passed, not recommended
+
+    def test_export_pixi_cli_platform_recommendation_wording(self, capsys, tmpdir):
+        project_dir = str(tmpdir)
+        self._write_multi_env_project(project_dir, 'PixiPlatform')
+        code = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'export-pixi', '--directory', project_dir])
+        assert code == 0
+        out, _ = capsys.readouterr()
+        assert 'Pixi requires the host platform' in out
+
+    def test_export_conda_cli_recommendation_wording(self, capsys, tmpdir):
+        project_dir = str(tmpdir)
+        self._write_multi_env_project(project_dir, 'CondaWording')
+        code = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'export-conda', '--directory', project_dir, '--use-default'])
+        assert code == 0
+        out, _ = capsys.readouterr()
+        assert 'exported conda-workspaces specification' in out
+
+    def test_export_conda_cli_platform_recommendation_wording(self, capsys, tmpdir):
+        project_dir = str(tmpdir)
+        self._write_multi_env_project(project_dir, 'CondaPlatform')
+        code = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'export-conda', '--directory', project_dir])
+        assert code == 0
+        out, _ = capsys.readouterr()
+        assert 'conda-workspaces requires the host platform' in out

--- a/anaconda_project/internal/test/test_conda_export.py
+++ b/anaconda_project/internal/test/test_conda_export.py
@@ -244,7 +244,14 @@ env_specs:
         assert 'exported Pixi specification' in out
         assert 'simplify the resulting Pixi specification' not in out  # use_default was passed, not recommended
 
-    def test_export_pixi_cli_platform_recommendation_wording(self, capsys, tmpdir):
+    def test_export_pixi_cli_platform_recommendation_wording(self, capsys, tmpdir, monkeypatch):
+        # Force current_platform() so the "platforms: [linux-64]" fixture is
+        # always missing the (fake) host platform, regardless of which OS
+        # actually runs this test (linux-64 is the real host platform on
+        # Linux CI runners, which would otherwise make the recommendation
+        # never fire there).
+        from anaconda_project.internal import conda_api
+        monkeypatch.setattr(conda_api, 'current_platform', lambda: 'osx-arm64')
         project_dir = str(tmpdir)
         self._write_multi_env_project(project_dir, 'PixiPlatform')
         code = _parse_args_and_run_subcommand(
@@ -262,7 +269,9 @@ env_specs:
         out, _ = capsys.readouterr()
         assert 'exported conda-workspaces specification' in out
 
-    def test_export_conda_cli_platform_recommendation_wording(self, capsys, tmpdir):
+    def test_export_conda_cli_platform_recommendation_wording(self, capsys, tmpdir, monkeypatch):
+        from anaconda_project.internal import conda_api
+        monkeypatch.setattr(conda_api, 'current_platform', lambda: 'osx-arm64')
         project_dir = str(tmpdir)
         self._write_multi_env_project(project_dir, 'CondaPlatform')
         code = _parse_args_and_run_subcommand(

--- a/anaconda_project/internal/test/test_conda_export.py
+++ b/anaconda_project/internal/test/test_conda_export.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2016, Anaconda, Inc. All rights reserved.
+#
+# Licensed under the terms of the BSD 3-Clause License.
+# The full license is in the file LICENSE.txt, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Tests for the export-conda project_ops functions (Item 5) and CLI wiring
+(Item 7). Placed in a dedicated file (per Item 6's file-placement note)
+because these exercise a new surface (project_ops.export_conda /
+preview_conda_export, and the export-conda CLI subcommand) beyond the
+exporter itself, which is covered in test_pixi_export.py::TestExportCondaToml.
+"""
+from __future__ import absolute_import, print_function
+
+import os
+import tempfile
+
+import pytest
+
+from anaconda_project.internal import pixi_export as pixi_export_module
+from anaconda_project.internal.pixi_export import PixiExportStatus
+from anaconda_project import project_ops
+from anaconda_project.project import Project
+from anaconda_project.internal.cli.main import _parse_args_and_run_subcommand
+
+
+# Use a stable, fake `defaults` expansion across the suite so tests don't
+# depend on the developer's local `conda config` and don't shell out to
+# conda once per test. Mirrors test_pixi_export.py's autouse fixture.
+FAKE_DEFAULTS = ['https://example.test/main', 'https://example.test/r']
+
+
+@pytest.fixture(autouse=True)
+def _stub_default_channels(monkeypatch):
+    monkeypatch.setattr(
+        pixi_export_module, '_resolve_default_channels',
+        lambda: list(FAKE_DEFAULTS),
+    )
+
+
+def _make_project(yml_content):
+    tmpdir = tempfile.mkdtemp()
+    with open(os.path.join(tmpdir, 'anaconda-project.yml'), 'w') as f:
+        f.write(yml_content)
+    return Project(tmpdir)
+
+
+class TestExportCondaProjectOps:
+    """project_ops.export_conda / preview_conda_export (Item 5)."""
+
+    def test_export_conda_writes_file(self, tmpdir):
+        project = _make_project("""
+name: Test
+description: A test project
+packages:
+  - numpy
+platforms:
+  - linux-64
+""")
+        target = str(tmpdir.join('conda.toml'))
+        status = project_ops.export_conda(project, filename=target)
+        assert status
+        assert isinstance(status, PixiExportStatus)
+        assert os.path.isfile(target)
+        with open(target) as f:
+            content = f.read()
+        assert 'name = "Test"' in content
+        assert 'numpy = "*"' in content
+
+    def test_export_conda_status_carries_rename_when_used(self, tmpdir):
+        project = _make_project("""
+name: ApiRename
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        target = str(tmpdir.join('conda.toml'))
+        status = project_ops.export_conda(project, filename=target,
+                                          use_default=True)
+        assert status
+        assert status.default_rename_from == 'sampleproj'
+
+    def test_export_conda_status_rename_none_without_flag(self, tmpdir):
+        project = _make_project("""
+name: NoFlag
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        target = str(tmpdir.join('conda.toml'))
+        status = project_ops.export_conda(project, filename=target)
+        assert status
+        assert status.default_rename_from is None
+
+    def test_preview_conda_export_shape(self):
+        project = _make_project("""
+name: Preview
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        result = project_ops.preview_conda_export(project, use_default=True)
+        # Stable contract: exactly these four keys, with conda_toml
+        # (not pixi_toml) per the rename-only-where-format-differs rule.
+        assert set(result) == {
+            'conda_toml', 'default_rename_from',
+            'current_platform_addition_target', 'warnings',
+        }
+        assert isinstance(result['conda_toml'], str)
+        assert isinstance(result['warnings'], list)
+        assert '[dependencies]' in result['conda_toml']
+        assert result['default_rename_from'] == 'sampleproj'
+
+    def test_preview_conda_export_matches_pixi_content(self):
+        # Per F1, export_conda_toml delegates verbatim to export_pixi_toml,
+        # so the two previews should carry identical toml content (modulo
+        # the dict key rename).
+        project = _make_project("""
+name: SameContent
+packages:
+  - python
+platforms:
+  - linux-64
+""")
+        conda_result = project_ops.preview_conda_export(project)
+        pixi_result = project_ops.preview_pixi_export(project)
+        assert conda_result['conda_toml'] == pixi_result['pixi_toml']
+
+    def test_export_conda_failure_status_on_bad_path(self, tmpdir):
+        project = _make_project("""
+name: BadPath
+packages: []
+platforms:
+  - linux-64
+""")
+        # A directory that doesn't exist, so open() fails.
+        target = str(tmpdir.join('nonexistent-dir', 'conda.toml'))
+        status = project_ops.export_conda(project, filename=target)
+        assert not status
+
+
+class TestExportCondaCli:
+    """`anaconda-project export-conda` CLI wiring (Item 7).
+
+    No precedent CLI-level test for `export-pixi` exists in
+    anaconda_project/internal/cli/test/ (searched; only test_main.py
+    references the subcommand name in its help-text assertions, not an
+    invocation test). Per Item 7's gate, a project_ops-level test for
+    export_conda/preview_conda_export (above) is sufficient coverage, plus
+    this argparse-smoke-test minimum bar: does `export-conda --help` exit 0,
+    does the subparser exist, and does a real invocation via the CLI
+    entrypoint work end to end.
+    """
+
+    def test_export_conda_help_exits_zero(self, capsys):
+        code = _parse_args_and_run_subcommand(['anaconda-project', 'export-conda', '--help'])
+        assert code == 0
+        out, err = capsys.readouterr()
+        assert 'CONDA_TOML_FILE' in out
+        assert '--use-default' in out
+        assert '--add-current-platform' in out
+
+    def test_export_conda_cli_invocation_writes_file(self, tmpdir):
+        project_dir = str(tmpdir)
+        with open(os.path.join(project_dir, 'anaconda-project.yml'), 'w') as f:
+            f.write("""
+name: CliTest
+packages:
+  - python
+platforms:
+  - linux-64
+""")
+        code = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'export-conda', '--directory', project_dir])
+        assert code == 0
+        target = os.path.join(project_dir, 'conda.toml')
+        assert os.path.isfile(target)
+        with open(target) as f:
+            content = f.read()
+        assert 'name = "CliTest"' in content
+
+    def test_export_conda_cli_with_custom_filename(self, tmpdir):
+        project_dir = str(tmpdir)
+        with open(os.path.join(project_dir, 'anaconda-project.yml'), 'w') as f:
+            f.write("""
+name: CustomFile
+packages: []
+platforms:
+  - linux-64
+""")
+        custom_target = str(tmpdir.join('custom-conda.toml'))
+        code = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'export-conda', '--directory', project_dir, custom_target])
+        assert code == 0
+        assert os.path.isfile(custom_target)
+
+    def test_export_conda_cli_project_problems_return_1(self, capsys, tmpdir):
+        # An empty directory (no manifest at all) fails project loading /
+        # problem checks, mirroring how export-pixi would behave.
+        project_dir = str(tmpdir)
+        code = _parse_args_and_run_subcommand(
+            ['anaconda-project', 'export-conda', '--directory', project_dir])
+        assert code == 1

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -23,6 +23,7 @@ from anaconda_project.internal.pixi_export import (
     _strip_conda_prefix_paths,
     _translate_command_env_vars,
     _windows_to_deno_shell,
+    export_conda_toml,
     export_pixi_toml,
     extract_warnings,
     project_would_benefit_from_use_default,
@@ -732,6 +733,113 @@ commands:
 """)
         result = export_pixi_toml(project)
         assert 'unresolved env var(s): SOMETHING_RANDOM' in result
+
+
+class TestExportCondaToml:
+    """export_conda_toml delegates directly to export_pixi_toml (Item 6):
+    zero content differences, per F1. These tests confirm the delegation
+    is exact (same content for the same project/args) and exercise a
+    fuller feature surface (multi-env features, tasks with http-options
+    args, activation env vars) to guard the emitted [workspace] table's
+    keys against a hardcoded allow-list — the F2 schema safety net."""
+
+    def _make_project(self, yml_content):
+        tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(tmpdir, 'anaconda-project.yml'), 'w') as f:
+            f.write(yml_content)
+        return Project(tmpdir)
+
+    def test_delegates_to_export_pixi_toml_verbatim(self):
+        project = self._make_project("""
+name: Test
+description: A test project
+packages:
+  - numpy
+  - pandas>=2.0
+channels:
+  - defaults
+platforms:
+  - linux-64
+commands:
+  run:
+    unix: python main.py
+""")
+        conda_result = export_conda_toml(project)
+        pixi_result = export_pixi_toml(project)
+        assert conda_result == pixi_result
+
+    def test_delegates_with_all_kwargs(self):
+        project = self._make_project("""
+name: KwargTest
+packages:
+  - python
+platforms:
+  - linux-64
+env_specs:
+  sampleproj: {}
+""")
+        conda_result = export_conda_toml(
+            project, use_default=True, add_current_platform=True,
+            default_channels=['https://example.test/main'])
+        pixi_result = export_pixi_toml(
+            project, use_default=True, add_current_platform=True,
+            default_channels=['https://example.test/main'])
+        assert conda_result == pixi_result
+
+    def test_workspace_keys_are_subset_of_allowlist(self):
+        # F2's "still worth building" schema safety net: conda-workspaces
+        # 0.7.0 doesn't enforce `[workspace]` additionalProperties: false
+        # at runtime, but the documented JSON Schema might become
+        # enforced in a later release — this hardcoded allow-list guards
+        # against emitting a [workspace] key outside that documented set.
+        # No local schema file ships with the package, so this is the
+        # allow-list fallback the design doc sanctions rather than a live
+        # schema fetch/validate() call.
+        project = self._make_project("""
+name: FullFeature
+description: Exercise features, tasks with args, and activation env
+packages:
+  - python
+channels:
+  - defaults
+platforms:
+  - linux-64
+env_specs:
+  web:
+    packages:
+      - flask
+  ml:
+    packages:
+      - scikit-learn
+commands:
+  serve:
+    unix: panel serve foo.ipynb
+    supports_http_options: true
+variables:
+  DATA_DIR:
+    default: /data
+""")
+        result = export_conda_toml(project)
+
+        # Parse just the [workspace] table's keys via a minimal line scan
+        # (avoids adding a tomllib parse dependency to this test file for
+        # a single small table — the file already round-trips through
+        # tomllib elsewhere in the suite if that's ever needed).
+        lines = result.splitlines()
+        in_workspace = False
+        keys = set()
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith('['):
+                in_workspace = stripped == '[workspace]'
+                continue
+            if in_workspace and '=' in stripped and not stripped.startswith('#'):
+                key = stripped.split('=', 1)[0].strip()
+                keys.add(key)
+
+        allowed = {'name', 'description', 'channels', 'platforms'}
+        assert keys, "expected to find at least one [workspace] key"
+        assert keys <= allowed, "unexpected [workspace] key(s): {}".format(keys - allowed)
 
 
 class TestTranslateCommandEnvVars:

--- a/anaconda_project/internal/test/test_pixi_export.py
+++ b/anaconda_project/internal/test/test_pixi_export.py
@@ -841,6 +841,91 @@ variables:
         assert keys, "expected to find at least one [workspace] key"
         assert keys <= allowed, "unexpected [workspace] key(s): {}".format(keys - allowed)
 
+    def test_conda_default_env_comment_uses_conda_workspaces_not_pixi(self):
+        # F1: verify that export_conda_toml uses conda-workspaces terminology
+        project = self._make_project("""
+name: DefaultEnvTest
+packages:
+  - python
+channels:
+  - defaults
+platforms:
+  - linux-64
+env_specs:
+  default: {}
+  extra: {}
+""")
+        result = export_conda_toml(project)
+        # Should contain conda-workspaces in the default env comment
+        assert 'conda-workspaces creates this implicitly' in result
+        # Should NOT contain 'pixi' in that comment
+        assert 'pixi creates this implicitly' not in result
+
+    def test_conda_services_comment_uses_conda_workspaces_not_pixi(self):
+        # F1: verify services comment uses correct terminology
+        project = self._make_project("""
+name: ServicesTest
+packages:
+  - python
+channels:
+  - defaults
+platforms:
+  - linux-64
+services:
+  redis:
+    type: redis
+""")
+        result = export_conda_toml(project)
+        # Should contain conda-workspaces in services comment
+        assert 'no conda-workspaces equivalent' in result
+        # Should NOT contain pixi in that comment
+        assert 'no pixi equivalent' not in result
+
+    def test_conda_unresolved_env_var_uses_conda_task_run(self):
+        # F1: verify unresolved env var message uses correct run command
+        project = self._make_project("""
+name: UnresolvedVarTest
+packages:
+  - python
+channels:
+  - defaults
+platforms:
+  - linux-64
+commands:
+  test:
+    unix: python $UNDEFINED_VAR/main.py
+""")
+        result = export_conda_toml(project)
+        # Should contain "conda task run", not "pixi run"
+        assert 'before running conda task run' in result
+        assert 'before running pixi run' not in result
+
+    def test_conda_no_pixi_substring_with_services_and_multi_env(self):
+        # F1: comprehensive check - no 'pixi' substring anywhere in output
+        # for a project that exercises all three leak sites
+        project = self._make_project("""
+name: ComprehensiveTest
+description: Full coverage test
+packages:
+  - python
+channels:
+  - defaults
+platforms:
+  - linux-64
+env_specs:
+  default: {}
+  other: {}
+services:
+  redis:
+    type: redis
+commands:
+  test:
+    unix: python $UNDEFINED/main.py
+""")
+        result = export_conda_toml(project)
+        # Verify no 'pixi' substring anywhere in the entire output
+        assert 'pixi' not in result.lower()
+
 
 class TestTranslateCommandEnvVars:
     def test_project_dir_braced(self):

--- a/anaconda_project/internal/test/test_pixi_lock.py
+++ b/anaconda_project/internal/test/test_pixi_lock.py
@@ -288,6 +288,39 @@ def test_build_pixi_lock_v6_structure_and_noarch_dedup():
     assert rec["sha256"] == "p64" and rec["depends"] == ["tzdata"]
 
 
+def test_build_pixi_lock_defaults_to_pixi_format():
+    doc = pixi_lock.build_pixi_lock({}, channels=["https://m"])
+    assert doc["version"] == 6
+
+
+def test_build_pixi_lock_conda_workspaces_format_stamps_version_1():
+    # conda-workspaces' conda.lock is a rattler-lock v6 derivative with the
+    # on-disk "version" field stamped 1 instead of 6 -- ground-truthed
+    # against the installed conda-workspaces 0.7.0 package
+    # (conda_workspaces.lockfile.LOCKFILE_VERSION == 1); everything else in
+    # the schema (environments/packages shape) is identical, which this
+    # test confirms by checking the rest of the document is unaffected by
+    # target_format.
+    py64 = {"name": "python", "version": "3.12.2", "build": "x64",
+            "url": "https://m/linux-64/python-3.12.2-x64.conda",
+            "sha256": "p64", "md5": "m64", "depends": []}
+    pixi_doc = pixi_lock.build_pixi_lock({"linux-64": [py64]}, channels=["https://m"], target_format='pixi')
+    conda_doc = pixi_lock.build_pixi_lock({"linux-64": [py64]}, channels=["https://m"],
+                                          target_format='conda-workspaces')
+    assert pixi_doc["version"] == 6
+    assert conda_doc["version"] == 1
+    # Only "version" differs -- everything else is byte-for-byte identical.
+    pixi_doc_no_version = {k: v for k, v in pixi_doc.items() if k != "version"}
+    conda_doc_no_version = {k: v for k, v in conda_doc.items() if k != "version"}
+    assert pixi_doc_no_version == conda_doc_no_version
+
+
+def test_build_pixi_lock_rejects_unknown_target_format():
+    with pytest.raises(pixi_lock.LockTranslationError) as exc:
+        pixi_lock.build_pixi_lock({}, channels=["https://m"], target_format='bogus-format')
+    assert 'bogus-format' in str(exc.value)
+
+
 def test_write_pixi_lock_is_atomic_and_roundtrips(tmpdir):
     import os
     from ruamel.yaml import YAML
@@ -302,6 +335,22 @@ def test_write_pixi_lock_is_atomic_and_roundtrips(tmpdir):
     with open(target) as f:
         loaded = YAML().load(f)
     assert loaded["version"] == 6
+
+
+def test_write_pixi_lock_derives_temp_prefix_from_target_filename(tmpdir):
+    import os
+    from ruamel.yaml import YAML
+    doc = {"version": 1, "environments": {}, "packages": []}
+    target = str(tmpdir.join("conda.lock"))
+    pixi_lock.write_pixi_lock(doc, target)
+    assert os.path.exists(target)
+    # no leftover temp files, using the conda.lock-derived prefix (not a
+    # hardcoded ".pixi.lock." one, which wouldn't match this filename)
+    leftovers = [f for f in os.listdir(str(tmpdir)) if f.startswith(".conda.lock.")]
+    assert leftovers == []
+    with open(target) as f:
+        loaded = YAML().load(f)
+    assert loaded["version"] == 1
 
 
 def test_write_pixi_lock_failure_leaves_no_partial_file(tmpdir, monkeypatch):
@@ -338,6 +387,31 @@ def test_translate_lock_set_end_to_end_with_injected_query(tmpdir):
     assert os.path.exists(target)
     assert len(doc["packages"]) == 2
     assert "linux-64" in doc["environments"]["default"]["packages"]
+
+
+def test_translate_lock_set_conda_workspaces_writes_conda_lock(tmpdir):
+    # End-to-end for the conda-workspaces target: writes to conda.lock and
+    # stamps version 1, same closure-building/enrichment path as pixi.
+    import os
+    lock_set = CondaLockSet(
+        {"all": ["tzdata=2024a=h0c530f3_0"], "linux-64": ["python=3.12.2=x64"]},
+        platforms=["linux-64"])
+    recs = {
+        "tzdata": [_FakeRecord("tzdata", "2024a", "h0c530f3_0", "linux-64",
+                               "https://m/noarch/tzdata-2024a-h0c530f3_0.conda", "s", "m", [])],
+        "python": [_FakeRecord("python", "3.12.2", "x64", "linux-64",
+                               "https://m/linux-64/python-3.12.2-x64.conda", "s2", "m2", ["tzdata"])],
+    }
+    target = str(tmpdir.join("conda.lock"))
+    doc = pixi_lock.translate_lock_set(lock_set, channels=["https://m"], path=target,
+                                       query=_fake_query_factory(recs), target_format='conda-workspaces')
+    assert os.path.exists(target)
+    assert doc["version"] == 1
+    assert len(doc["packages"]) == 2
+    # temp file cleanup used the real target filename, not a hardcoded
+    # "pixi.lock"-based prefix
+    leftovers = [f for f in os.listdir(str(tmpdir)) if f.startswith(".conda.lock.")]
+    assert leftovers == []
 
 
 def test_translate_lock_set_rejects_zero_platforms(tmpdir):

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -200,7 +200,9 @@ def publication_info(project_dir, project_type=None, env_paths=False):
                 raise ValueError('Failed to parse {}: {}'.format(manifest_path, e)) from e
             # Extract the [tool.conda] sub-tree
             data = pyproject_data.get('tool', {}).get('conda', {})
-            info = _conda_workspaces_publication_info(project_dir, data)
+            # Also extract the full-document [tool.anaconda.commands] for pyproject-embedded override lookup
+            tool_commands = pyproject_data.get('tool', {}).get('anaconda', {}).get('commands', {})
+            info = _conda_workspaces_publication_info(project_dir, data, tool_commands=tool_commands)
 
         elif manifest_kind == 'pyproject-pixi':
             project_type = PROJECT_TYPE_PIXI
@@ -211,7 +213,9 @@ def publication_info(project_dir, project_type=None, env_paths=False):
                 raise ValueError('Failed to parse {}: {}'.format(manifest_path, e)) from e
             # Extract the [tool.pixi] sub-tree
             data = pyproject_data.get('tool', {}).get('pixi', {})
-            info = _pixi_publication_info(project_dir, data)
+            # Also extract the full-document [tool.anaconda.commands] for pyproject-embedded override lookup
+            tool_commands = pyproject_data.get('tool', {}).get('anaconda', {}).get('commands', {})
+            info = _pixi_publication_info(project_dir, data, tool_commands=tool_commands)
             if env_paths:
                 _attach_pixi_env_paths(info, project_dir)
 
@@ -360,13 +364,16 @@ def _read_conda_lock_envs(project_dir):
     return set(envs.keys())
 
 
-def _pixi_publication_info(project_dir, data):
+def _pixi_publication_info(project_dir, data, tool_commands=None):
     """Return a publication-info dict for a pixi project.
 
     Args:
         project_dir: Path to the project directory.
         data: Pre-parsed pixi manifest dict (from tomllib.load) with top-level
               keys workspace/dependencies/feature/environments/tasks/etc.
+        tool_commands: Optional dict of [tool.anaconda.commands] overrides.
+              If None (the default), derives from data.get('tool', {}).get('anaconda', {}).get('commands', {}).
+              When explicitly passed (even if empty dict), uses that instead of deriving.
 
     Returns:
         A dict with keys: name, description, commands, env_specs, variables.
@@ -379,7 +386,8 @@ def _pixi_publication_info(project_dir, data):
     description = workspace.get('description', project_meta.get('description', ''))
     channels = workspace.get('channels', project_meta.get('channels', []))
 
-    tool_commands = data.get('tool', {}).get('anaconda', {}).get('commands', {})
+    if tool_commands is None:
+        tool_commands = data.get('tool', {}).get('anaconda', {}).get('commands', {})
 
     # Resolve the name of pixi's implicit `default` environment to the
     # user-meaningful env_spec it actually represents. Pixi always
@@ -484,7 +492,7 @@ def _pixi_publication_info(project_dir, data):
     }
 
 
-def _conda_workspaces_publication_info(project_dir, data):
+def _conda_workspaces_publication_info(project_dir, data, tool_commands=None):
     """Return a publication-info dict for a conda-workspaces project.
 
     Args:
@@ -493,6 +501,9 @@ def _conda_workspaces_publication_info(project_dir, data):
               keys workspace/dependencies/feature/environments/tasks/etc.
               Same shape as pixi.toml: this may be either a top-level conda.toml
               or the sub-dict from pyproject.toml's [tool.conda].
+        tool_commands: Optional dict of [tool.anaconda.commands] overrides.
+              If None (the default), derives from data.get('tool', {}).get('anaconda', {}).get('commands', {}).
+              When explicitly passed (even if empty dict), uses that instead of deriving.
 
     Returns:
         A dict with keys: name, description, commands, env_specs, variables.
@@ -511,7 +522,8 @@ def _conda_workspaces_publication_info(project_dir, data):
     description = workspace.get('description', '')
     channels = workspace.get('channels', [])
 
-    tool_commands = data.get('tool', {}).get('anaconda', {}).get('commands', {})
+    if tool_commands is None:
+        tool_commands = data.get('tool', {}).get('anaconda', {}).get('commands', {})
 
     # Resolve the default environment name (same logic as pixi)
     declared_envs = data.get('environments', {})

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -34,9 +34,12 @@ except ImportError:  # Python < 3.11
 
 
 PIXI_MANIFEST = 'pixi.toml'
+CONDA_TOML_MANIFEST = 'conda.toml'
 ANACONDA_PROJECT_MANIFEST = 'anaconda-project.yml'
+PYPROJECT_MANIFEST = 'pyproject.toml'
 
 PROJECT_TYPE_KEY = 'project_type'
+PROJECT_TYPE_CONDA_WORKSPACES = 'conda-workspaces'
 PROJECT_TYPE_PIXI = 'pixi'
 PROJECT_TYPE_ANACONDA_PROJECT = 'anaconda-project'
 
@@ -44,13 +47,49 @@ PROJECT_TYPE_ANACONDA_PROJECT = 'anaconda-project'
 def detect_project_type(project_dir):
     """Return the project type string for *project_dir*, or ``None`` if unknown.
 
-    Detection is by manifest presence; ``pixi.toml`` wins when both are present,
-    matching the dispatch used by :func:`publication_info`.
+    Detection is by manifest presence, in precedence order:
+    1. ``conda.toml`` → ``'conda-workspaces'``
+    2. ``pixi.toml`` → ``'pixi'``
+    3. ``anaconda-project.yml`` (or variants) → ``'anaconda-project'``
+    4. ``pyproject.toml`` with ``[tool.conda.workspace]`` or ``[tool.pixi.workspace]`` →
+       ``'conda-workspaces'`` or ``'pixi'`` respectively
+    5. Otherwise → ``None``
+
+    Detection errors (e.g., malformed ``pyproject.toml``) are silently treated as
+    non-matches and do not raise.
     """
+    # 1. Check for conda.toml
+    if os.path.isfile(os.path.join(project_dir, CONDA_TOML_MANIFEST)):
+        return PROJECT_TYPE_CONDA_WORKSPACES
+
+    # 2. Check for pixi.toml
     if os.path.isfile(os.path.join(project_dir, PIXI_MANIFEST)):
         return PROJECT_TYPE_PIXI
-    if os.path.isfile(os.path.join(project_dir, ANACONDA_PROJECT_MANIFEST)):
-        return PROJECT_TYPE_ANACONDA_PROJECT
+
+    # 3. Check for anaconda-project manifest files
+    from anaconda_project.project_file import possible_project_file_names
+    for filename in possible_project_file_names:
+        if os.path.isfile(os.path.join(project_dir, filename)):
+            return PROJECT_TYPE_ANACONDA_PROJECT
+
+    # 4. Check for pyproject.toml with tool.conda or tool.pixi workspace
+    pyproject_path = os.path.join(project_dir, PYPROJECT_MANIFEST)
+    if os.path.isfile(pyproject_path):
+        try:
+            with open(pyproject_path, 'rb') as f:
+                data = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError):
+            # Parse error or file access error — treat as non-match, don't raise
+            return None
+
+        # Check for tool.conda.workspace first
+        if data.get('tool', {}).get('conda', {}).get('workspace'):
+            return PROJECT_TYPE_CONDA_WORKSPACES
+
+        # Then check for tool.pixi.workspace
+        if data.get('tool', {}).get('pixi', {}).get('workspace'):
+            return PROJECT_TYPE_PIXI
+
     return None
 
 

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -97,6 +97,40 @@ def _locate_manifest(project_dir):
     return (None, None)
 
 
+def _locate_manifest_of_kind(project_dir, top_level_filename, pyproject_tool_key):
+    """Find the manifest for one specific format, ignoring precedence.
+
+    Unlike :func:`_locate_manifest` (which returns the single highest-precedence
+    manifest across *all* formats), this checks only whether *this* format's
+    manifest exists — a top-level file named *top_level_filename*, or a
+    ``pyproject.toml`` with a ``[tool.<pyproject_tool_key>.workspace]`` table.
+    This is what explicit ``project_type=`` overrides need: "does the requested
+    format exist here?", not "which format wins?" — so a coexisting
+    higher-precedence manifest of a *different* format never masks the one the
+    caller actually asked for.
+
+    Returns (manifest_kind, path) — manifest_kind is ``'top-level'`` or
+    ``'pyproject'`` — or (None, None) if not found. Parse errors in
+    pyproject.toml are silently treated as non-match (returns (None, None)),
+    matching _locate_manifest's existing convention.
+    """
+    top_level_path = os.path.join(project_dir, top_level_filename)
+    if os.path.isfile(top_level_path):
+        return ('top-level', top_level_path)
+
+    pyproject_path = os.path.join(project_dir, PYPROJECT_MANIFEST)
+    if os.path.isfile(pyproject_path):
+        try:
+            with open(pyproject_path, 'rb') as f:
+                data = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError):
+            return (None, None)
+        if data.get('tool', {}).get(pyproject_tool_key, {}).get('workspace'):
+            return ('pyproject', pyproject_path)
+
+    return (None, None)
+
+
 def detect_project_type(project_dir):
     """Return the project type string for *project_dir*, or ``None`` if unknown.
 
@@ -222,9 +256,11 @@ def publication_info(project_dir, project_type=None, env_paths=False):
     else:
         # Explicit project_type: recognize both top-level manifests and pyproject.toml embedding
         if project_type == PROJECT_TYPE_CONDA_WORKSPACES:
-            manifest_kind, manifest_path = _locate_manifest(project_dir)
-            # Accept both 'conda-toml' and 'pyproject-conda' as valid matches for explicit 'conda-workspaces' type
-            if manifest_kind not in ('conda-toml', 'pyproject-conda'):
+            # Look for THIS format specifically — never let a coexisting
+            # higher-precedence manifest of a different format (e.g. pixi.toml)
+            # mask a conda.toml that demonstrably exists (see _locate_manifest_of_kind).
+            manifest_kind, manifest_path = _locate_manifest_of_kind(project_dir, CONDA_TOML_MANIFEST, 'conda')
+            if manifest_kind is None:
                 raise FileNotFoundError(
                     'No conda.toml found in {} (and no [tool.conda.workspace] in pyproject.toml)'.format(project_dir)
                 )
@@ -233,18 +269,19 @@ def publication_info(project_dir, project_type=None, env_paths=False):
                     pyproject_data = tomllib.load(f)
             except (OSError, tomllib.TOMLDecodeError) as e:
                 raise ValueError('Failed to parse {}: {}'.format(manifest_path, e)) from e
-            if manifest_kind == 'conda-toml':
+            if manifest_kind == 'top-level':
                 data = pyproject_data
                 tool_commands = None  # Will be auto-derived
-            else:  # 'pyproject-conda'
+            else:  # 'pyproject'
                 data = pyproject_data.get('tool', {}).get('conda', {})
                 tool_commands = pyproject_data.get('tool', {}).get('anaconda', {}).get('commands', {})
             info = _conda_workspaces_publication_info(project_dir, data, tool_commands=tool_commands)
 
         elif project_type == PROJECT_TYPE_PIXI:
-            manifest_kind, manifest_path = _locate_manifest(project_dir)
-            # Accept both 'pixi-toml' and 'pyproject-pixi' as valid matches for explicit 'pixi' type
-            if manifest_kind not in ('pixi-toml', 'pyproject-pixi'):
+            # Same reasoning as the conda-workspaces branch above: check for
+            # pixi.toml specifically, independent of precedence.
+            manifest_kind, manifest_path = _locate_manifest_of_kind(project_dir, PIXI_MANIFEST, 'pixi')
+            if manifest_kind is None:
                 raise FileNotFoundError(
                     'No pixi.toml found in {} (and no [tool.pixi.workspace] in pyproject.toml)'.format(project_dir)
                 )
@@ -253,10 +290,10 @@ def publication_info(project_dir, project_type=None, env_paths=False):
                     pyproject_data = tomllib.load(f)
             except (OSError, tomllib.TOMLDecodeError) as e:
                 raise ValueError('Failed to parse {}: {}'.format(manifest_path, e)) from e
-            if manifest_kind == 'pixi-toml':
+            if manifest_kind == 'top-level':
                 data = pyproject_data
                 tool_commands = None  # Will be auto-derived
-            else:  # 'pyproject-pixi'
+            else:  # 'pyproject'
                 data = pyproject_data.get('tool', {}).get('pixi', {})
                 tool_commands = pyproject_data.get('tool', {}).get('anaconda', {}).get('commands', {})
             info = _pixi_publication_info(project_dir, data, tool_commands=tool_commands)

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -378,24 +378,32 @@ def _read_conda_lock_envs(project_dir):
     return set(envs.keys())
 
 
-def _pixi_publication_info(project_dir, data, tool_commands=None):
-    """Return a publication-info dict for a pixi project.
+def _toml_workspace_publication_info(project_dir, data, lock_reader, tool_commands=None, use_project_alias_fallback=False):
+    """Return a publication-info dict for a TOML workspace project (pixi or conda-workspaces).
+
+    This is the shared implementation for both pixi and conda-workspaces formats,
+    which have identical TOML structure but differ in lock file location and
+    legacy [project] alias availability.
 
     Args:
         project_dir: Path to the project directory.
-        data: Pre-parsed pixi manifest dict (from tomllib.load) with top-level
+        data: Pre-parsed manifest dict (from tomllib.load) with top-level
               keys workspace/dependencies/feature/environments/tasks/etc.
+        lock_reader: Function to call to get locked environment names
+              (either _read_pixi_lock_envs or _read_conda_lock_envs).
         tool_commands: Optional dict of [tool.anaconda.commands] overrides.
               If None (the default), derives from data.get('tool', {}).get('anaconda', {}).get('commands', {}).
               When explicitly passed (even if empty dict), uses that instead of deriving.
+        use_project_alias_fallback: If True, use [project] table as fallback for name/description
+              (pixi legacy behavior); if False, skip it (conda-workspaces).
 
     Returns:
         A dict with keys: name, description, commands, env_specs, variables.
     """
-    locked_envs = _read_pixi_lock_envs(project_dir)
+    locked_envs = lock_reader(project_dir)
 
     workspace = data.get('workspace', {})
-    project_meta = data.get('project', {})
+    project_meta = data.get('project', {}) if use_project_alias_fallback else {}
     name = workspace.get('name', project_meta.get('name', os.path.basename(project_dir)))
     description = workspace.get('description', project_meta.get('description', ''))
     channels = workspace.get('channels', project_meta.get('channels', []))
@@ -403,11 +411,8 @@ def _pixi_publication_info(project_dir, data, tool_commands=None):
     if tool_commands is None:
         tool_commands = data.get('tool', {}).get('anaconda', {}).get('commands', {})
 
-    # Resolve the name of pixi's implicit `default` environment to the
-    # user-meaningful env_spec it actually represents. Pixi always
-    # materializes a `default` env from the default feature; the
-    # exporter (and anaconda-project's own publication_info) report the
-    # resolved name, not the placeholder. Logic mirrors the exporter:
+    # Resolve the default environment name. Both pixi and conda-workspaces
+    # always materialize a `default` env. Logic mirrors the exporter:
     # a literal `default` in [environments] wins; otherwise fall back
     # to the first declared environment.
     declared_envs = data.get('environments', {})
@@ -418,7 +423,7 @@ def _pixi_publication_info(project_dir, data, tool_commands=None):
     else:
         default_env_name = 'default'
 
-    # For tasks defined under [feature.X.tasks.Y], pixi runs them in any
+    # For tasks defined under [feature.X.tasks.Y], both run them in any
     # env that includes feature X. publication_info should report a
     # specific env that "supports this task": prefer the resolved
     # default if it includes the feature, else the first declared env
@@ -476,7 +481,7 @@ def _pixi_publication_info(project_dir, data, tool_commands=None):
             pkgs.extend(_format_dep(n, s) for n, s in feat_deps.items())
         return pkgs
 
-    # Pixi always materializes a `default` env, even when [environments]
+    # Both formats always materialize a `default` env, even when [environments]
     # only declares others. Surface it unconditionally; honor the user's
     # declaration if one exists.
     env_specs = {
@@ -504,131 +509,22 @@ def _pixi_publication_info(project_dir, data, tool_commands=None):
         'env_specs': env_specs,
         'variables': variables,
     }
+
+
+def _pixi_publication_info(project_dir, data, tool_commands=None):
+    """Wrapper for pixi projects that delegates to _toml_workspace_publication_info."""
+    return _toml_workspace_publication_info(
+        project_dir, data, lock_reader=_read_pixi_lock_envs,
+        tool_commands=tool_commands, use_project_alias_fallback=True
+    )
 
 
 def _conda_workspaces_publication_info(project_dir, data, tool_commands=None):
-    """Return a publication-info dict for a conda-workspaces project.
-
-    Args:
-        project_dir: Path to the project directory.
-        data: Pre-parsed conda manifest dict (from tomllib.load) with top-level
-              keys workspace/dependencies/feature/environments/tasks/etc.
-              Same shape as pixi.toml: this may be either a top-level conda.toml
-              or the sub-dict from pyproject.toml's [tool.conda].
-        tool_commands: Optional dict of [tool.anaconda.commands] overrides.
-              If None (the default), derives from data.get('tool', {}).get('anaconda', {}).get('commands', {}).
-              When explicitly passed (even if empty dict), uses that instead of deriving.
-
-    Returns:
-        A dict with keys: name, description, commands, env_specs, variables.
-
-    Note: PEP 621 [project] name/description fallback (which upstream
-    conda-workspaces itself uses for pyproject.toml) is not read; only
-    workspace.name/workspace.description are considered, falling back to the
-    directory basename. This is a deliberate omission for this plan's scope
-    (uniform read-side summary), not a gap.
-    """
-    locked_envs = _read_conda_lock_envs(project_dir)
-
-    workspace = data.get('workspace', {})
-    # Conda.toml has no [project] legacy-alias table; skip that fallback
-    name = workspace.get('name', os.path.basename(project_dir))
-    description = workspace.get('description', '')
-    channels = workspace.get('channels', [])
-
-    if tool_commands is None:
-        tool_commands = data.get('tool', {}).get('anaconda', {}).get('commands', {})
-
-    # Resolve the default environment name (same logic as pixi)
-    declared_envs = data.get('environments', {})
-    if 'default' in declared_envs:
-        default_env_name = 'default'
-    elif declared_envs:
-        default_env_name = next(iter(declared_envs))
-    else:
-        default_env_name = 'default'
-
-    # For tasks defined under [feature.X.tasks.Y], conda-workspaces runs them in any
-    # env that includes feature X. Same logic as pixi.
-    def _env_for_feature(feat_name):
-        candidate_envs = []
-        for env_name, env_def in declared_envs.items():
-            features = env_def if isinstance(env_def, list) else env_def.get('features', [])
-            if feat_name in features:
-                candidate_envs.append(env_name)
-        if not candidate_envs:
-            return feat_name
-        if default_env_name in candidate_envs:
-            return default_env_name
-        return candidate_envs[0]
-
-    commands = {}
-    state = {'first': True}
-
-    for task_name, task_def in data.get('tasks', {}).items():
-        cmd = _build_command(task_name, task_def, default_env_name, tool_commands, state)
-        if cmd is not None:
-            commands[task_name] = cmd
-
-    for feat_name, feat_def in data.get('feature', {}).items():
-        for task_name, task_def in feat_def.get('tasks', {}).items():
-            if task_name in commands:
-                continue
-            cmd = _build_command(task_name, task_def,
-                                 _env_for_feature(feat_name),
-                                 tool_commands, state)
-            if cmd is not None:
-                commands[task_name] = cmd
-
-    top_packages = [
-        _format_dep(pkg, spec) for pkg, spec in data.get('dependencies', {}).items()
-    ]
-
-    def _packages_for_env(env_def):
-        """Resolve effective package list for a declared env: top-level
-        [dependencies] (the default feature) plus each feature listed in
-        the env's `features = [...]`. An env declared with
-        `no-default-feature = true` does not inherit the default feature."""
-        if env_def is None:
-            return list(top_packages)
-        features = env_def if isinstance(env_def, list) else env_def.get('features', [])
-        no_default = (
-            isinstance(env_def, dict) and env_def.get('no-default-feature', False)
-        )
-        pkgs = [] if no_default else list(top_packages)
-        for feat in features:
-            feat_deps = data.get('feature', {}).get(feat, {}).get('dependencies', {})
-            pkgs.extend(_format_dep(n, s) for n, s in feat_deps.items())
-        return pkgs
-
-    # Conda-workspaces always materializes a `default` env, even when [environments]
-    # only declares others. Surface it unconditionally; honor the user's
-    # declaration if one exists.
-    env_specs = {
-        'default': {
-            'packages': _packages_for_env(declared_envs.get('default')),
-            'channels': channels,
-            'locked': default_env_name in locked_envs,
-        },
-    }
-    for env_name, env_def in declared_envs.items():
-        if env_name == 'default':
-            continue
-        env_specs[env_name] = {
-            'packages': _packages_for_env(env_def),
-            'channels': channels,
-            'locked': env_name in locked_envs,
-        }
-
-    variables = dict(data.get('activation', {}).get('env', {}))
-
-    return {
-        'name': name,
-        'description': description,
-        'commands': commands,
-        'env_specs': env_specs,
-        'variables': variables,
-    }
+    """Wrapper for conda-workspaces projects that delegates to _toml_workspace_publication_info."""
+    return _toml_workspace_publication_info(
+        project_dir, data, lock_reader=_read_conda_lock_envs,
+        tool_commands=tool_commands, use_project_alias_fallback=False
+    )
 
 
 def _build_command(task_name, task_def, env_spec, tool_commands, state):

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -5,23 +5,23 @@
 # Licensed under the terms of the BSD 3-Clause License.
 # The full license is in the file LICENSE.txt, distributed with this software.
 # -----------------------------------------------------------------------------
-"""Unified publication-info extraction for anaconda-project and pixi projects.
+"""Unified publication-info extraction for project formats.
 
-The top-level :func:`publication_info` accepts a project directory, detects
-whether it is a pixi project (``pixi.toml`` present) or an anaconda-project
-(``anaconda-project.yml``), parses the relevant file, and returns a metadata
-dict with a shape compatible with :meth:`Project.publication_info`.
+The top-level :func:`publication_info` accepts a project directory and auto-detects
+whether it is a pixi project (``pixi.toml``, optionally embedded in ``pyproject.toml``),
+a conda-workspaces project (``conda.toml``, optionally embedded in ``pyproject.toml``),
+or an anaconda-project (``anaconda-project.yml``). It parses the relevant manifest(s)
+and returns a metadata dict with a shape compatible with :meth:`Project.publication_info`.
 
-The pixi branch reads ``pixi.toml`` directly rather than materializing a
-full :class:`Project` — anaconda-project is an established library for the
-legacy ``.yml`` format, and this module deliberately avoids expanding
-:class:`Project` to cover pixi. Consumers that need uniform metadata (e.g.
-anaconda-platform's publishing pipeline) get one entry point that works
-across both formats.
+The pixi and conda-workspaces branches read TOML files directly rather than materializing
+a full :class:`Project` — anaconda-project is an established library for the legacy ``.yml``
+format, and this module deliberately avoids expanding :class:`Project` to cover the newer
+TOML-based formats. Consumers that need uniform metadata (e.g. anaconda-platform's
+publishing pipeline) get one entry point that works across all formats.
 
-The pixi branch also exposes a handful of pixi-native capabilities that
-anaconda-project does not support — TOML ``[feature.*]`` sections,
-``[environments]`` composition, and ``[activation.env]`` variables.
+Both pixi and conda-workspaces support TOML ``[feature.*]`` sections, ``[environments]``
+composition, ``[activation.env]`` variables, and optional ``[tool.anaconda.commands]``
+overrides when embedded in ``pyproject.toml``.
 """
 from __future__ import absolute_import, print_function
 
@@ -345,7 +345,7 @@ def _read_pixi_lock_envs(project_dir):
         import yaml
         with open(lock_path, 'r') as f:
             lock = yaml.safe_load(f)
-    except Exception:
+    except (OSError, yaml.YAMLError):
         return set()
     if not isinstance(lock, dict):
         return set()
@@ -368,7 +368,7 @@ def _read_conda_lock_envs(project_dir):
         import yaml
         with open(lock_path, 'r') as f:
             lock = yaml.safe_load(f)
-    except Exception:
+    except (OSError, yaml.YAMLError):
         return set()
     if not isinstance(lock, dict):
         return set()

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -144,7 +144,13 @@ def publication_info(project_dir, project_type=None, env_paths=False):
         )
 
     if project_type == PROJECT_TYPE_PIXI:
-        info = _pixi_publication_info(project_dir)
+        pixi_path = os.path.join(project_dir, PIXI_MANIFEST)
+        try:
+            with open(pixi_path, 'rb') as f:
+                data = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError) as e:
+            raise ValueError('Failed to parse {}: {}'.format(pixi_path, e)) from e
+        info = _pixi_publication_info(project_dir, data)
         if env_paths:
             _attach_pixi_env_paths(info, project_dir)
     else:
@@ -218,14 +224,17 @@ def _read_pixi_lock_envs(project_dir):
     return set(envs.keys())
 
 
-def _pixi_publication_info(project_dir):
-    pixi_path = os.path.join(project_dir, PIXI_MANIFEST)
-    try:
-        with open(pixi_path, 'rb') as f:
-            data = tomllib.load(f)
-    except (OSError, tomllib.TOMLDecodeError) as e:
-        raise ValueError('Failed to parse {}: {}'.format(pixi_path, e)) from e
+def _pixi_publication_info(project_dir, data):
+    """Return a publication-info dict for a pixi project.
 
+    Args:
+        project_dir: Path to the project directory.
+        data: Pre-parsed pixi manifest dict (from tomllib.load) with top-level
+              keys workspace/dependencies/feature/environments/tasks/etc.
+
+    Returns:
+        A dict with keys: name, description, commands, env_specs, variables.
+    """
     locked_envs = _read_pixi_lock_envs(project_dir)
 
     workspace = data.get('workspace', {})

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -133,9 +133,9 @@ def publication_info(project_dir, project_type=None, env_paths=False):
     With *project_type* unset (the default), auto-detects by manifest presence
     in precedence order: conda.toml, pixi.toml, anaconda-project.*, pyproject.toml.
     Pass ``project_type='conda-workspaces'``, ``'pixi'``, or ``'anaconda-project'``
-    to force a specific format; explicit types only recognize top-level manifests
-    (not pyproject.toml embedding) — if you want pyproject.toml embedding,
-    omit the explicit *project_type* to trigger auto-detection. The returned dict
+    to force a specific format; explicit types now recognize both top-level manifests
+    (conda.toml/pixi.toml) and pyproject.toml embedding ([tool.conda.workspace] or
+    [tool.pixi.workspace]), matching auto-detect behavior. The returned dict
     always includes a ``project_type`` key identifying which manifest format was used.
 
     Pass ``env_paths=True`` to populate ``info['env_specs'][name]['path']``
@@ -220,32 +220,46 @@ def publication_info(project_dir, project_type=None, env_paths=False):
                 _attach_pixi_env_paths(info, project_dir)
 
     else:
-        # Explicit project_type: only recognizes top-level manifests, not pyproject.toml
+        # Explicit project_type: recognize both top-level manifests and pyproject.toml embedding
         if project_type == PROJECT_TYPE_CONDA_WORKSPACES:
-            conda_path = os.path.join(project_dir, CONDA_TOML_MANIFEST)
-            if not os.path.isfile(conda_path):
+            manifest_kind, manifest_path = _locate_manifest(project_dir)
+            # Accept both 'conda-toml' and 'pyproject-conda' as valid matches for explicit 'conda-workspaces' type
+            if manifest_kind not in ('conda-toml', 'pyproject-conda'):
                 raise FileNotFoundError(
-                    'No {} found in {}'.format(CONDA_TOML_MANIFEST, project_dir)
+                    'No conda.toml found in {} (and no [tool.conda.workspace] in pyproject.toml)'.format(project_dir)
                 )
             try:
-                with open(conda_path, 'rb') as f:
-                    data = tomllib.load(f)
+                with open(manifest_path, 'rb') as f:
+                    pyproject_data = tomllib.load(f)
             except (OSError, tomllib.TOMLDecodeError) as e:
-                raise ValueError('Failed to parse {}: {}'.format(conda_path, e)) from e
-            info = _conda_workspaces_publication_info(project_dir, data)
+                raise ValueError('Failed to parse {}: {}'.format(manifest_path, e)) from e
+            if manifest_kind == 'conda-toml':
+                data = pyproject_data
+                tool_commands = None  # Will be auto-derived
+            else:  # 'pyproject-conda'
+                data = pyproject_data.get('tool', {}).get('conda', {})
+                tool_commands = pyproject_data.get('tool', {}).get('anaconda', {}).get('commands', {})
+            info = _conda_workspaces_publication_info(project_dir, data, tool_commands=tool_commands)
 
         elif project_type == PROJECT_TYPE_PIXI:
-            pixi_path = os.path.join(project_dir, PIXI_MANIFEST)
-            if not os.path.isfile(pixi_path):
+            manifest_kind, manifest_path = _locate_manifest(project_dir)
+            # Accept both 'pixi-toml' and 'pyproject-pixi' as valid matches for explicit 'pixi' type
+            if manifest_kind not in ('pixi-toml', 'pyproject-pixi'):
                 raise FileNotFoundError(
-                    'No {} found in {}'.format(PIXI_MANIFEST, project_dir)
+                    'No pixi.toml found in {} (and no [tool.pixi.workspace] in pyproject.toml)'.format(project_dir)
                 )
             try:
-                with open(pixi_path, 'rb') as f:
-                    data = tomllib.load(f)
+                with open(manifest_path, 'rb') as f:
+                    pyproject_data = tomllib.load(f)
             except (OSError, tomllib.TOMLDecodeError) as e:
-                raise ValueError('Failed to parse {}: {}'.format(pixi_path, e)) from e
-            info = _pixi_publication_info(project_dir, data)
+                raise ValueError('Failed to parse {}: {}'.format(manifest_path, e)) from e
+            if manifest_kind == 'pixi-toml':
+                data = pyproject_data
+                tool_commands = None  # Will be auto-derived
+            else:  # 'pyproject-pixi'
+                data = pyproject_data.get('tool', {}).get('pixi', {})
+                tool_commands = pyproject_data.get('tool', {}).get('anaconda', {}).get('commands', {})
+            info = _pixi_publication_info(project_dir, data, tool_commands=tool_commands)
             if env_paths:
                 _attach_pixi_env_paths(info, project_dir)
 

--- a/anaconda_project/project_info.py
+++ b/anaconda_project/project_info.py
@@ -44,6 +44,59 @@ PROJECT_TYPE_PIXI = 'pixi'
 PROJECT_TYPE_ANACONDA_PROJECT = 'anaconda-project'
 
 
+def _locate_manifest(project_dir):
+    """Determine which manifest is present in *project_dir*.
+
+    Returns a tuple (manifest_kind, path_or_none) where manifest_kind is one of:
+    - 'conda-toml': conda.toml present → returns path
+    - 'pixi-toml': pixi.toml present → returns path
+    - 'anaconda-project': anaconda-project.* present → returns path
+    - 'pyproject-conda': pyproject.toml with [tool.conda.workspace] → returns path
+    - 'pyproject-pixi': pyproject.toml with [tool.pixi.workspace] → returns path
+    - None: no manifest found → returns None
+
+    Checks in precedence order. For pyproject-* cases, the file is parsed to
+    determine which [tool] section has a workspace table. Parse errors in
+    pyproject.toml are silently treated as non-match (returns None).
+    """
+    # 1. Check for conda.toml
+    conda_path = os.path.join(project_dir, CONDA_TOML_MANIFEST)
+    if os.path.isfile(conda_path):
+        return ('conda-toml', conda_path)
+
+    # 2. Check for pixi.toml
+    pixi_path = os.path.join(project_dir, PIXI_MANIFEST)
+    if os.path.isfile(pixi_path):
+        return ('pixi-toml', pixi_path)
+
+    # 3. Check for anaconda-project manifest files
+    from anaconda_project.project_file import possible_project_file_names
+    for filename in possible_project_file_names:
+        ap_path = os.path.join(project_dir, filename)
+        if os.path.isfile(ap_path):
+            return ('anaconda-project', ap_path)
+
+    # 4. Check for pyproject.toml with tool.conda or tool.pixi workspace
+    pyproject_path = os.path.join(project_dir, PYPROJECT_MANIFEST)
+    if os.path.isfile(pyproject_path):
+        try:
+            with open(pyproject_path, 'rb') as f:
+                data = tomllib.load(f)
+        except (OSError, tomllib.TOMLDecodeError):
+            # Parse error or file access error — treat as non-match, don't raise
+            return (None, None)
+
+        # Check for tool.conda.workspace first
+        if data.get('tool', {}).get('conda', {}).get('workspace'):
+            return ('pyproject-conda', pyproject_path)
+
+        # Then check for tool.pixi.workspace
+        if data.get('tool', {}).get('pixi', {}).get('workspace'):
+            return ('pyproject-pixi', pyproject_path)
+
+    return (None, None)
+
+
 def detect_project_type(project_dir):
     """Return the project type string for *project_dir*, or ``None`` if unknown.
 
@@ -58,103 +111,163 @@ def detect_project_type(project_dir):
     Detection errors (e.g., malformed ``pyproject.toml``) are silently treated as
     non-matches and do not raise.
     """
-    # 1. Check for conda.toml
-    if os.path.isfile(os.path.join(project_dir, CONDA_TOML_MANIFEST)):
+    manifest_kind, _path = _locate_manifest(project_dir)
+
+    if manifest_kind == 'conda-toml':
         return PROJECT_TYPE_CONDA_WORKSPACES
-
-    # 2. Check for pixi.toml
-    if os.path.isfile(os.path.join(project_dir, PIXI_MANIFEST)):
+    elif manifest_kind == 'pixi-toml':
         return PROJECT_TYPE_PIXI
-
-    # 3. Check for anaconda-project manifest files
-    from anaconda_project.project_file import possible_project_file_names
-    for filename in possible_project_file_names:
-        if os.path.isfile(os.path.join(project_dir, filename)):
-            return PROJECT_TYPE_ANACONDA_PROJECT
-
-    # 4. Check for pyproject.toml with tool.conda or tool.pixi workspace
-    pyproject_path = os.path.join(project_dir, PYPROJECT_MANIFEST)
-    if os.path.isfile(pyproject_path):
-        try:
-            with open(pyproject_path, 'rb') as f:
-                data = tomllib.load(f)
-        except (OSError, tomllib.TOMLDecodeError):
-            # Parse error or file access error — treat as non-match, don't raise
-            return None
-
-        # Check for tool.conda.workspace first
-        if data.get('tool', {}).get('conda', {}).get('workspace'):
-            return PROJECT_TYPE_CONDA_WORKSPACES
-
-        # Then check for tool.pixi.workspace
-        if data.get('tool', {}).get('pixi', {}).get('workspace'):
-            return PROJECT_TYPE_PIXI
-
-    return None
+    elif manifest_kind == 'anaconda-project':
+        return PROJECT_TYPE_ANACONDA_PROJECT
+    elif manifest_kind == 'pyproject-conda':
+        return PROJECT_TYPE_CONDA_WORKSPACES
+    elif manifest_kind == 'pyproject-pixi':
+        return PROJECT_TYPE_PIXI
+    else:
+        return None
 
 
 def publication_info(project_dir, project_type=None, env_paths=False):
     """Return a publication-info dict for the project at *project_dir*.
 
-    With *project_type* unset (the default), ``pixi.toml`` is preferred when
-    present and ``anaconda-project.yml`` is loaded through :class:`Project`
-    otherwise. Pass ``project_type='pixi'`` or ``'anaconda-project'`` to force
-    a specific manifest format; it is an error to ask for a format whose
-    manifest is not present in *project_dir*. The returned dict always
-    includes a ``project_type`` key identifying which manifest format was
-    used.
+    With *project_type* unset (the default), auto-detects by manifest presence
+    in precedence order: conda.toml, pixi.toml, anaconda-project.*, pyproject.toml.
+    Pass ``project_type='conda-workspaces'``, ``'pixi'``, or ``'anaconda-project'``
+    to force a specific format; explicit types only recognize top-level manifests
+    (not pyproject.toml embedding) — if you want pyproject.toml embedding,
+    omit the explicit *project_type* to trigger auto-detection. The returned dict
+    always includes a ``project_type`` key identifying which manifest format was used.
 
     Pass ``env_paths=True`` to populate ``info['env_specs'][name]['path']``
     with the filesystem prefix for each declared environment. For
     anaconda-project this is computed from each :class:`EnvSpec` and is
-    free; for pixi we shell out to ``pixi info --json`` (so it costs a
-    subprocess) and surface any error from that call.
+    free; for pixi (whether from a top-level pixi.toml or a pyproject.toml
+    ``[tool.pixi]`` embedding) we shell out to ``pixi info --json`` (so it
+    costs a subprocess) and surface any error from that call. For
+    conda-workspaces there is no equivalent path-resolution mechanism yet,
+    so ``env_paths=True`` has no effect on conda-workspaces results.
 
     Raises:
-        ValueError: *project_type* is not a recognized value, or the pixi
-            manifest cannot be parsed.
+        ValueError: *project_type* is not a recognized value, or a manifest
+            cannot be parsed.
         FileNotFoundError: the requested manifest (or, with no
-            *project_type*, neither manifest) is not present.
+            *project_type*, any manifest) is not present.
         RuntimeError: ``env_paths=True`` was requested for a pixi project
             and ``pixi info --json`` failed.
     """
     if project_type is None:
-        project_type = detect_project_type(project_dir)
-        if project_type is None:
+        # Auto-detect: use _locate_manifest to find the winning manifest,
+        # then re-derive the type from its kind
+        manifest_kind, manifest_path = _locate_manifest(project_dir)
+        if manifest_kind is None:
             raise FileNotFoundError(
-                'No {} or {} found in {}'.format(
-                    PIXI_MANIFEST, ANACONDA_PROJECT_MANIFEST, project_dir
+                'No manifest (conda.toml, pixi.toml, anaconda-project.*, or '
+                'pyproject.toml with [tool.conda.workspace] or [tool.pixi.workspace]) '
+                'found in {}'.format(project_dir)
+            )
+
+        # Determine project_type from manifest_kind and load data as needed
+        if manifest_kind == 'conda-toml':
+            project_type = PROJECT_TYPE_CONDA_WORKSPACES
+            try:
+                with open(manifest_path, 'rb') as f:
+                    data = tomllib.load(f)
+            except (OSError, tomllib.TOMLDecodeError) as e:
+                raise ValueError('Failed to parse {}: {}'.format(manifest_path, e)) from e
+            info = _conda_workspaces_publication_info(project_dir, data)
+
+        elif manifest_kind == 'pixi-toml':
+            project_type = PROJECT_TYPE_PIXI
+            try:
+                with open(manifest_path, 'rb') as f:
+                    data = tomllib.load(f)
+            except (OSError, tomllib.TOMLDecodeError) as e:
+                raise ValueError('Failed to parse {}: {}'.format(manifest_path, e)) from e
+            info = _pixi_publication_info(project_dir, data)
+            if env_paths:
+                _attach_pixi_env_paths(info, project_dir)
+
+        elif manifest_kind == 'anaconda-project':
+            project_type = PROJECT_TYPE_ANACONDA_PROJECT
+            info = _anaconda_project_publication_info(project_dir, env_paths=env_paths)
+
+        elif manifest_kind == 'pyproject-conda':
+            project_type = PROJECT_TYPE_CONDA_WORKSPACES
+            try:
+                with open(manifest_path, 'rb') as f:
+                    pyproject_data = tomllib.load(f)
+            except (OSError, tomllib.TOMLDecodeError) as e:
+                raise ValueError('Failed to parse {}: {}'.format(manifest_path, e)) from e
+            # Extract the [tool.conda] sub-tree
+            data = pyproject_data.get('tool', {}).get('conda', {})
+            info = _conda_workspaces_publication_info(project_dir, data)
+
+        elif manifest_kind == 'pyproject-pixi':
+            project_type = PROJECT_TYPE_PIXI
+            try:
+                with open(manifest_path, 'rb') as f:
+                    pyproject_data = tomllib.load(f)
+            except (OSError, tomllib.TOMLDecodeError) as e:
+                raise ValueError('Failed to parse {}: {}'.format(manifest_path, e)) from e
+            # Extract the [tool.pixi] sub-tree
+            data = pyproject_data.get('tool', {}).get('pixi', {})
+            info = _pixi_publication_info(project_dir, data)
+            if env_paths:
+                _attach_pixi_env_paths(info, project_dir)
+
+    else:
+        # Explicit project_type: only recognizes top-level manifests, not pyproject.toml
+        if project_type == PROJECT_TYPE_CONDA_WORKSPACES:
+            conda_path = os.path.join(project_dir, CONDA_TOML_MANIFEST)
+            if not os.path.isfile(conda_path):
+                raise FileNotFoundError(
+                    'No {} found in {}'.format(CONDA_TOML_MANIFEST, project_dir)
+                )
+            try:
+                with open(conda_path, 'rb') as f:
+                    data = tomllib.load(f)
+            except (OSError, tomllib.TOMLDecodeError) as e:
+                raise ValueError('Failed to parse {}: {}'.format(conda_path, e)) from e
+            info = _conda_workspaces_publication_info(project_dir, data)
+
+        elif project_type == PROJECT_TYPE_PIXI:
+            pixi_path = os.path.join(project_dir, PIXI_MANIFEST)
+            if not os.path.isfile(pixi_path):
+                raise FileNotFoundError(
+                    'No {} found in {}'.format(PIXI_MANIFEST, project_dir)
+                )
+            try:
+                with open(pixi_path, 'rb') as f:
+                    data = tomllib.load(f)
+            except (OSError, tomllib.TOMLDecodeError) as e:
+                raise ValueError('Failed to parse {}: {}'.format(pixi_path, e)) from e
+            info = _pixi_publication_info(project_dir, data)
+            if env_paths:
+                _attach_pixi_env_paths(info, project_dir)
+
+        elif project_type == PROJECT_TYPE_ANACONDA_PROJECT:
+            # Anaconda-project uses possible_project_file_names for detection
+            from anaconda_project.project_file import possible_project_file_names
+            ap_path = None
+            for filename in possible_project_file_names:
+                candidate = os.path.join(project_dir, filename)
+                if os.path.isfile(candidate):
+                    ap_path = candidate
+                    break
+            if ap_path is None:
+                raise FileNotFoundError(
+                    'No {} found in {}'.format(ANACONDA_PROJECT_MANIFEST, project_dir)
+                )
+            info = _anaconda_project_publication_info(project_dir, env_paths=env_paths)
+
+        else:
+            raise ValueError(
+                'Unknown project_type {!r}; expected {!r}, {!r}, or {!r}'.format(
+                    project_type, PROJECT_TYPE_CONDA_WORKSPACES,
+                    PROJECT_TYPE_PIXI, PROJECT_TYPE_ANACONDA_PROJECT
                 )
             )
-    elif project_type == PROJECT_TYPE_PIXI:
-        if not os.path.isfile(os.path.join(project_dir, PIXI_MANIFEST)):
-            raise FileNotFoundError(
-                'No {} found in {}'.format(PIXI_MANIFEST, project_dir)
-            )
-    elif project_type == PROJECT_TYPE_ANACONDA_PROJECT:
-        if not os.path.isfile(os.path.join(project_dir, ANACONDA_PROJECT_MANIFEST)):
-            raise FileNotFoundError(
-                'No {} found in {}'.format(ANACONDA_PROJECT_MANIFEST, project_dir)
-            )
-    else:
-        raise ValueError(
-            'Unknown project_type {!r}; expected {!r} or {!r}'.format(
-                project_type, PROJECT_TYPE_PIXI, PROJECT_TYPE_ANACONDA_PROJECT
-            )
-        )
 
-    if project_type == PROJECT_TYPE_PIXI:
-        pixi_path = os.path.join(project_dir, PIXI_MANIFEST)
-        try:
-            with open(pixi_path, 'rb') as f:
-                data = tomllib.load(f)
-        except (OSError, tomllib.TOMLDecodeError) as e:
-            raise ValueError('Failed to parse {}: {}'.format(pixi_path, e)) from e
-        info = _pixi_publication_info(project_dir, data)
-        if env_paths:
-            _attach_pixi_env_paths(info, project_dir)
-    else:
-        info = _anaconda_project_publication_info(project_dir, env_paths=env_paths)
     info[PROJECT_TYPE_KEY] = project_type
     return info
 
@@ -210,6 +323,29 @@ def _read_pixi_lock_envs(project_dir):
     lockfile.
     """
     lock_path = os.path.join(project_dir, 'pixi.lock')
+    try:
+        import yaml
+        with open(lock_path, 'r') as f:
+            lock = yaml.safe_load(f)
+    except Exception:
+        return set()
+    if not isinstance(lock, dict):
+        return set()
+    envs = lock.get('environments')
+    if not isinstance(envs, dict):
+        return set()
+    return set(envs.keys())
+
+
+def _read_conda_lock_envs(project_dir):
+    """Return the set of environment names that appear in conda.lock, or
+    empty if the lockfile is missing, malformed, or can't be loaded.
+
+    Failure is silent by design: lock detection is informational; the
+    rest of publication_info should never break because of a corrupt
+    lockfile.
+    """
+    lock_path = os.path.join(project_dir, 'conda.lock')
     try:
         import yaml
         with open(lock_path, 'r') as f:
@@ -319,6 +455,127 @@ def _pixi_publication_info(project_dir, data):
         return pkgs
 
     # Pixi always materializes a `default` env, even when [environments]
+    # only declares others. Surface it unconditionally; honor the user's
+    # declaration if one exists.
+    env_specs = {
+        'default': {
+            'packages': _packages_for_env(declared_envs.get('default')),
+            'channels': channels,
+            'locked': default_env_name in locked_envs,
+        },
+    }
+    for env_name, env_def in declared_envs.items():
+        if env_name == 'default':
+            continue
+        env_specs[env_name] = {
+            'packages': _packages_for_env(env_def),
+            'channels': channels,
+            'locked': env_name in locked_envs,
+        }
+
+    variables = dict(data.get('activation', {}).get('env', {}))
+
+    return {
+        'name': name,
+        'description': description,
+        'commands': commands,
+        'env_specs': env_specs,
+        'variables': variables,
+    }
+
+
+def _conda_workspaces_publication_info(project_dir, data):
+    """Return a publication-info dict for a conda-workspaces project.
+
+    Args:
+        project_dir: Path to the project directory.
+        data: Pre-parsed conda manifest dict (from tomllib.load) with top-level
+              keys workspace/dependencies/feature/environments/tasks/etc.
+              Same shape as pixi.toml: this may be either a top-level conda.toml
+              or the sub-dict from pyproject.toml's [tool.conda].
+
+    Returns:
+        A dict with keys: name, description, commands, env_specs, variables.
+
+    Note: PEP 621 [project] name/description fallback (which upstream
+    conda-workspaces itself uses for pyproject.toml) is not read; only
+    workspace.name/workspace.description are considered, falling back to the
+    directory basename. This is a deliberate omission for this plan's scope
+    (uniform read-side summary), not a gap.
+    """
+    locked_envs = _read_conda_lock_envs(project_dir)
+
+    workspace = data.get('workspace', {})
+    # Conda.toml has no [project] legacy-alias table; skip that fallback
+    name = workspace.get('name', os.path.basename(project_dir))
+    description = workspace.get('description', '')
+    channels = workspace.get('channels', [])
+
+    tool_commands = data.get('tool', {}).get('anaconda', {}).get('commands', {})
+
+    # Resolve the default environment name (same logic as pixi)
+    declared_envs = data.get('environments', {})
+    if 'default' in declared_envs:
+        default_env_name = 'default'
+    elif declared_envs:
+        default_env_name = next(iter(declared_envs))
+    else:
+        default_env_name = 'default'
+
+    # For tasks defined under [feature.X.tasks.Y], conda-workspaces runs them in any
+    # env that includes feature X. Same logic as pixi.
+    def _env_for_feature(feat_name):
+        candidate_envs = []
+        for env_name, env_def in declared_envs.items():
+            features = env_def if isinstance(env_def, list) else env_def.get('features', [])
+            if feat_name in features:
+                candidate_envs.append(env_name)
+        if not candidate_envs:
+            return feat_name
+        if default_env_name in candidate_envs:
+            return default_env_name
+        return candidate_envs[0]
+
+    commands = {}
+    state = {'first': True}
+
+    for task_name, task_def in data.get('tasks', {}).items():
+        cmd = _build_command(task_name, task_def, default_env_name, tool_commands, state)
+        if cmd is not None:
+            commands[task_name] = cmd
+
+    for feat_name, feat_def in data.get('feature', {}).items():
+        for task_name, task_def in feat_def.get('tasks', {}).items():
+            if task_name in commands:
+                continue
+            cmd = _build_command(task_name, task_def,
+                                 _env_for_feature(feat_name),
+                                 tool_commands, state)
+            if cmd is not None:
+                commands[task_name] = cmd
+
+    top_packages = [
+        _format_dep(pkg, spec) for pkg, spec in data.get('dependencies', {}).items()
+    ]
+
+    def _packages_for_env(env_def):
+        """Resolve effective package list for a declared env: top-level
+        [dependencies] (the default feature) plus each feature listed in
+        the env's `features = [...]`. An env declared with
+        `no-default-feature = true` does not inherit the default feature."""
+        if env_def is None:
+            return list(top_packages)
+        features = env_def if isinstance(env_def, list) else env_def.get('features', [])
+        no_default = (
+            isinstance(env_def, dict) and env_def.get('no-default-feature', False)
+        )
+        pkgs = [] if no_default else list(top_packages)
+        for feat in features:
+            feat_deps = data.get('feature', {}).get(feat, {}).get('dependencies', {})
+            pkgs.extend(_format_dep(n, s) for n, s in feat_deps.items())
+        return pkgs
+
+    # Conda-workspaces always materializes a `default` env, even when [environments]
     # only declares others. Surface it unconditionally; honor the user's
     # declaration if one exists.
     env_specs = {

--- a/anaconda_project/project_ops.py
+++ b/anaconda_project/project_ops.py
@@ -764,6 +764,148 @@ def preview_pixi_export(project, use_default=False, add_current_platform=False, 
     }
 
 
+def export_conda(project, filename, use_default=False, add_current_platform=False, default_channels=None):
+    """Export the project as a conda.toml file.
+
+    Returns a ``Status`` subtype.
+
+    Args:
+        project (Project): the project
+        filename (str): file to export to
+        use_default (bool): if True and the project has no env_spec literally
+            named ``default``, rename the env_spec attached to the default
+            command (or, failing that, the first declared env_spec) to
+            ``default`` on export, so it materializes as conda-workspaces'
+            implicit default environment with packages, commands, and the
+            prepare task at the top level instead of inside a
+            ``[feature.{name}.*]`` block.
+        add_current_platform (bool): if True, ensure the host's conda subdir
+            is in the emitted ``platforms`` list. Conda-workspaces rejects an
+            env that doesn't list the host platform; anaconda-project is more
+            forgiving, so this prevents an install error on a project whose
+            ``platforms:`` list happens to omit the developer's box.
+        default_channels (list or None): optional concrete channel URLs to
+            expand ``defaults`` to (and to fall back on when the project
+            declares no channels). When provided, the local ``conda config``
+            lookup is skipped — letting a caller export without shelling out
+            to conda. See :func:`export_conda_toml`.
+
+    Returns:
+        ``PixiExportStatus`` on success (carries ``default_rename_from``
+        and ``current_platform_added``); a plain ``Status`` on failure.
+        The same status class as ``export_pixi`` is reused — its two fields
+        are generic export concepts with no pixi-specific naming baked in.
+    """
+    failed = _check_problems(project)
+    if failed is not None:
+        return failed
+
+    from anaconda_project.internal.pixi_export import (
+        CondaNotAvailableError, DOWNLOAD_HELPER_FILENAME, PixiExportStatus,
+        current_platform_addition_target, default_rename_target,
+        export_conda_toml, extract_warnings,
+    )
+    import sys
+    rename_from = default_rename_target(project) if use_default else None
+    platform_added = (current_platform_addition_target(project)
+                      if add_current_platform else None)
+    try:
+        content = export_conda_toml(project, use_default=use_default,
+                                    add_current_platform=add_current_platform,
+                                    default_channels=default_channels)
+    except CondaNotAvailableError as e:
+        return SimpleStatus(
+            success=False,
+            description="Cannot export to conda-workspaces: {}".format(e))
+    try:
+        with open(filename, 'w') as f:
+            f.write(content)
+        # If the converted manifest invokes ap_download.py, drop the helper
+        # next to conda.toml so `conda task run prepare` has the script available.
+        if DOWNLOAD_HELPER_FILENAME in content:
+            helper_src = os.path.join(os.path.dirname(__file__),
+                                      'internal', DOWNLOAD_HELPER_FILENAME)
+            helper_dst = os.path.join(os.path.dirname(filename) or '.',
+                                      DOWNLOAD_HELPER_FILENAME)
+            shutil.copyfile(helper_src, helper_dst)
+        # Surface any warnings the exporter wrote to the file so the user
+        # sees them immediately rather than only on later inspection.
+        warning_lines = extract_warnings(content)
+        if warning_lines:
+            print('\n'.join(warning_lines), file=sys.stderr)
+    except Exception as e:
+        return SimpleStatus(success=False, description="Failed to save {}: {}.".format(filename, str(e)))
+
+    return PixiExportStatus(
+        success=True,
+        description="Exported project to {}.".format(filename),
+        default_rename_from=rename_from,
+        current_platform_added=platform_added)
+
+
+def preview_conda_export(project, use_default=False, add_current_platform=False, default_channels=None):
+    """Render the conda.toml conversion in memory without writing to disk.
+
+    Returns a dict with four keys, suitable for driving a preview UI
+    (CLI ``--dry-run``, IDE plugin dialog, launcher confirmation, etc.):
+
+    * ``conda_toml`` (str): the full ``conda.toml`` content the exporter
+      would write.
+    * ``default_rename_from`` (str or None): the env_spec name that would
+      be promoted to ``default`` if ``use_default`` were passed
+      (regardless of whether ``use_default`` was actually requested) —
+      ``None`` when the project already has a ``default`` env_spec, has
+      no env_specs, or has nothing to rename. Frontends use this to
+      offer "re-render with --use-default" as an action.
+    * ``current_platform_addition_target`` (str or None): the host's conda
+      subdir if it would be added to the platform list by
+      ``add_current_platform`` (regardless of whether the flag was
+      passed), or ``None`` when it's already declared. Frontends use
+      this to offer "re-render with --add-current-platform" as an
+      action — conda-workspaces rejects envs that don't list the host
+      platform.
+    * ``warnings`` (list of str): the lines of the leading
+      ``# WARNING:`` block the exporter included at the top of the file,
+      or ``[]`` if there are none. Already extracted so the caller
+      doesn't have to scan the toml again.
+
+    Raises ``CondaNotAvailableError`` if the conversion needs ``conda
+    config --show default_channels`` and conda isn't reachable. Failure
+    of project-problem checks raises through the caller's normal channel
+    for that — a project with problems is not previewable.
+
+    Args:
+        project (Project): the project
+        use_default (bool): same semantics as ``export_conda``; controls
+            the content of ``conda_toml`` but not ``default_rename_from``
+            (which is reported regardless).
+        add_current_platform (bool): same semantics as ``export_conda``;
+            controls the content of ``conda_toml`` but not
+            ``current_platform_addition_target`` (which is reported
+            regardless).
+        default_channels (list or None): same semantics as
+            ``export_conda`` — when provided, ``defaults`` is expanded from
+            this list and the conda lookup is skipped.
+
+    Returns:
+        dict
+    """
+    from anaconda_project.internal.pixi_export import (
+        current_platform_addition_target, default_rename_target,
+        export_conda_toml, extract_warnings,
+    )
+    conda_toml = export_conda_toml(project, use_default=use_default,
+                                   add_current_platform=add_current_platform,
+                                   default_channels=default_channels)
+    return {
+        'conda_toml': conda_toml,
+        'default_rename_from': default_rename_target(project),
+        'current_platform_addition_target':
+            current_platform_addition_target(project),
+        'warnings': extract_warnings(conda_toml),
+    }
+
+
 def add_packages(project, env_spec_name, packages, channels, pip=False):
     """Attempt to install packages then add them to anaconda-project.yml.
 

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -274,9 +274,10 @@ class TestPublicationInfoCondaWorkspaces:
                 td,
                 '[tool.conda.workspace]\nname = "x"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
             )
-            # Explicit type only recognizes top-level conda.toml, not pyproject-embedded
-            with pytest.raises(FileNotFoundError):
-                publication_info(td, project_type=PROJECT_TYPE_CONDA_WORKSPACES)
+            # F3: Explicit type now recognizes pyproject-embedded conda projects (no longer only top-level conda.toml)
+            info = publication_info(td, project_type=PROJECT_TYPE_CONDA_WORKSPACES)
+            assert info['project_type'] == PROJECT_TYPE_CONDA_WORKSPACES
+            assert info['name'] == 'x'
 
     def test_conda_toml_tasks_produce_commands(self):
         with tempfile.TemporaryDirectory() as td:
@@ -1180,6 +1181,38 @@ class TestExplicitProjectType:
             with pytest.raises(FileNotFoundError) as exc:
                 publication_info(td, project_type=PROJECT_TYPE_ANACONDA_PROJECT)
             assert 'anaconda-project.yml' in str(exc.value)
+
+    def test_explicit_pixi_recognizes_pyproject_pixi(self):
+        # F3: explicit project_type now recognizes pyproject.toml embedding
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(
+                td,
+                '[tool.pixi.workspace]\nname = "pyproject-pixi"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td, project_type=PROJECT_TYPE_PIXI)
+            assert info['project_type'] == PROJECT_TYPE_PIXI
+            assert info['name'] == 'pyproject-pixi'
+
+    def test_explicit_conda_recognizes_pyproject_conda(self):
+        # F3: explicit project_type now recognizes pyproject.toml embedding
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(
+                td,
+                '[tool.conda.workspace]\nname = "pyproject-conda"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td, project_type=PROJECT_TYPE_CONDA_WORKSPACES)
+            assert info['project_type'] == PROJECT_TYPE_CONDA_WORKSPACES
+            assert info['name'] == 'pyproject-conda'
+
+    def test_explicit_type_absent_from_everywhere_raises(self):
+        # F3: if the requested format is absent from both top-level and pyproject.toml, raise FileNotFoundError
+        with tempfile.TemporaryDirectory() as td:
+            _write_anaconda_project(td, 'name: t\n')
+            with pytest.raises(FileNotFoundError) as exc:
+                publication_info(td, project_type=PROJECT_TYPE_PIXI)
+            # Error message should mention both locations
+            assert 'pixi.toml' in str(exc.value)
+            assert 'pyproject.toml' in str(exc.value)
 
     def test_unknown_project_type_raises(self):
         with tempfile.TemporaryDirectory() as td:

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -16,6 +16,7 @@ import pytest
 
 from anaconda_project.project_info import (
     PROJECT_TYPE_ANACONDA_PROJECT,
+    PROJECT_TYPE_CONDA_WORKSPACES,
     PROJECT_TYPE_KEY,
     PROJECT_TYPE_PIXI,
     _format_dep,
@@ -35,6 +36,20 @@ def _write_pixi_toml(tmpdir, content):
 
 def _write_anaconda_project(tmpdir, content):
     path = os.path.join(tmpdir, 'anaconda-project.yml')
+    with open(path, 'w') as f:
+        f.write(content)
+    return tmpdir
+
+
+def _write_conda_toml(tmpdir, content):
+    path = os.path.join(tmpdir, 'conda.toml')
+    with open(path, 'w') as f:
+        f.write(content)
+    return tmpdir
+
+
+def _write_pyproject_toml(tmpdir, content):
+    path = os.path.join(tmpdir, 'pyproject.toml')
     with open(path, 'w') as f:
         f.write(content)
     return tmpdir
@@ -725,6 +740,51 @@ class TestDetectProjectType:
 
     def test_neither_returns_none(self):
         with tempfile.TemporaryDirectory() as td:
+            assert detect_project_type(td) is None
+
+    def test_detects_conda_toml(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(td, '[workspace]\nname = "t"\n')
+            assert detect_project_type(td) == PROJECT_TYPE_CONDA_WORKSPACES
+
+    def test_conda_toml_wins_over_pixi(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(td, '[workspace]\nname = "t"\n')
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            assert detect_project_type(td) == PROJECT_TYPE_CONDA_WORKSPACES
+
+    def test_conda_toml_wins_over_anaconda_project(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(td, '[workspace]\nname = "t"\n')
+            _write_anaconda_project(td, 'name: t\n')
+            assert detect_project_type(td) == PROJECT_TYPE_CONDA_WORKSPACES
+
+    def test_pixi_wins_over_anaconda_project(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "t"\n')
+            _write_anaconda_project(td, 'name: t\n')
+            assert detect_project_type(td) == PROJECT_TYPE_PIXI
+
+    def test_pyproject_toml_with_conda_workspace(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(td, '[tool.conda.workspace]\nname = "t"\n')
+            assert detect_project_type(td) == PROJECT_TYPE_CONDA_WORKSPACES
+
+    def test_pyproject_toml_with_pixi_workspace(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(td, '[tool.pixi.workspace]\nname = "t"\n')
+            assert detect_project_type(td) == PROJECT_TYPE_PIXI
+
+    def test_pyproject_toml_without_workspace_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(td, '[tool.other]\nkey = "value"\n')
+            assert detect_project_type(td) is None
+
+    def test_malformed_pyproject_toml_returns_none(self):
+        with tempfile.TemporaryDirectory() as td:
+            path = os.path.join(td, 'pyproject.toml')
+            with open(path, 'w') as f:
+                f.write('[invalid toml\n')
             assert detect_project_type(td) is None
 
 

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -205,6 +205,169 @@ class TestPublicationInfoBasic:
             assert info['description'] == 'A test project'
 
 
+class TestPublicationInfoCondaWorkspaces:
+    def test_conda_toml_minimal_project(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(
+                td,
+                '[workspace]\nname = "test"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert info['name'] == 'test'
+            assert info['description'] == ''
+            assert info['commands'] == {}
+            assert info['env_specs'] == {
+                'default': {'packages': [], 'channels': ['conda-forge'], 'locked': False},
+            }
+            assert info['variables'] == {}
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_CONDA_WORKSPACES
+
+    def test_conda_toml_workspace_name_only(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(
+                td,
+                '[workspace]\nname = "workspace-name"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert info['name'] == 'workspace-name'
+
+    def test_conda_toml_fallback_to_directory_name(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(
+                td, '[workspace]\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n'
+            )
+            info = publication_info(td)
+            assert info['name'] == os.path.basename(td)
+
+    def test_conda_toml_description(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(
+                td,
+                '[workspace]\nname = "x"\ndescription = "A conda workspace"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert info['description'] == 'A conda workspace'
+
+    def test_pyproject_toml_with_conda_workspace(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(
+                td,
+                '[tool.conda.workspace]\nname = "from-pyproject"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert info['name'] == 'from-pyproject'
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_CONDA_WORKSPACES
+
+    def test_pyproject_toml_with_pixi_workspace(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(
+                td,
+                '[tool.pixi.workspace]\nname = "from-pixi-pyproject"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td)
+            assert info['name'] == 'from-pixi-pyproject'
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
+
+    def test_explicit_project_type_conda_only_recognizes_conda_toml(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(
+                td,
+                '[tool.conda.workspace]\nname = "x"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            # Explicit type only recognizes top-level conda.toml, not pyproject-embedded
+            with pytest.raises(FileNotFoundError):
+                publication_info(td, project_type=PROJECT_TYPE_CONDA_WORKSPACES)
+
+    def test_conda_toml_tasks_produce_commands(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [tasks]
+                hello = "echo hi"
+
+                [tasks.serve]
+                cmd = "flask run"
+            """))
+            info = publication_info(td)
+            assert 'hello' in info['commands']
+            assert info['commands']['hello']['unix'] == 'echo hi'
+            assert info['commands']['hello']['default'] is True
+            assert info['commands']['serve']['unix'] == 'flask run'
+            assert info['commands']['serve']['supports_http_options'] is True
+
+    def test_conda_lock_populates_locked(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(td, textwrap.dedent("""\
+                [workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [environments]
+                sampleproj = { features = ["sampleproj"] }
+                test = { features = ["test"] }
+            """))
+            with open(os.path.join(td, 'conda.lock'), 'w') as f:
+                f.write(textwrap.dedent("""\
+                    version: 1
+                    environments:
+                      sampleproj:
+                        packages: {}
+                """))
+            info = publication_info(td)
+            # sampleproj is in the lock — locked. test is not — unlocked.
+            assert info['env_specs']['sampleproj']['locked'] is True
+            assert info['env_specs']['test']['locked'] is False
+
+    def test_pyproject_pixi_dependencies_and_tasks(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(td, textwrap.dedent("""\
+                [tool.pixi.workspace]
+                name = "from-pixi-pyproject"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [tool.pixi.dependencies]
+                python = ">=3.12"
+                numpy = "*"
+
+                [tool.pixi.tasks]
+                hello = "echo hi"
+            """))
+            info = publication_info(td)
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
+            pkgs = info['env_specs']['default']['packages']
+            assert 'python>=3.12' in pkgs
+            assert 'numpy' in pkgs
+            assert info['commands']['hello']['unix'] == 'echo hi'
+
+    def test_pyproject_conda_dependencies_and_tasks(self):
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(td, textwrap.dedent("""\
+                [tool.conda.workspace]
+                name = "from-conda-pyproject"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [tool.conda.dependencies]
+                python = ">=3.12"
+                numpy = "*"
+
+                [tool.conda.tasks]
+                hello = "echo hi"
+            """))
+            info = publication_info(td)
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_CONDA_WORKSPACES
+            pkgs = info['env_specs']['default']['packages']
+            assert 'python>=3.12' in pkgs
+            assert 'numpy' in pkgs
+            assert info['commands']['hello']['unix'] == 'echo hi'
+
+
 class TestPublicationInfoDependencies:
     def test_simple_deps(self):
         with tempfile.TemporaryDirectory() as td:
@@ -974,5 +1137,5 @@ class TestExplicitProjectType:
         with tempfile.TemporaryDirectory() as td:
             _write_pixi_toml(td, '[workspace]\nname = "t"\n')
             with pytest.raises(ValueError) as exc:
-                publication_info(td, project_type='conda-workspaces')
-            assert 'conda-workspaces' in str(exc.value)
+                publication_info(td, project_type='bogus-type')
+            assert 'bogus-type' in str(exc.value)

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -1257,3 +1257,18 @@ class TestExplicitProjectType:
             info = publication_info(td, project_type=PROJECT_TYPE_PIXI)
             assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
             assert info['name'] == 'pyproject-pixi'
+
+    def test_force_conda_workspaces_via_pyproject_when_pixi_toml_also_present(self):
+        # Mirror image of the test above: a top-level pixi.toml (which
+        # outranks a pyproject.toml embedding in auto-detect precedence)
+        # must not mask a conda-workspaces manifest that only exists as a
+        # [tool.conda.workspace] embedding.
+        with tempfile.TemporaryDirectory() as td:
+            _write_pixi_toml(td, '[workspace]\nname = "from-pixi"\nchannels = ["defaults"]\nplatforms = ["linux-64"]\n')
+            _write_pyproject_toml(
+                td,
+                '[tool.conda.workspace]\nname = "pyproject-conda"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td, project_type=PROJECT_TYPE_CONDA_WORKSPACES)
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_CONDA_WORKSPACES
+            assert info['name'] == 'pyproject-conda'

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -1220,3 +1220,40 @@ class TestExplicitProjectType:
             with pytest.raises(ValueError) as exc:
                 publication_info(td, project_type='bogus-type')
             assert 'bogus-type' in str(exc.value)
+
+    def test_force_pixi_when_conda_toml_also_present(self):
+        # Regression: explicit project_type='pixi' must not be masked by a
+        # coexisting conda.toml, which outranks pixi.toml in auto-detect
+        # precedence. The override asks "does pixi.toml exist here?", not
+        # "which format wins by precedence?" (the mid-conversion use case
+        # --project-type exists to support, per workspace-support.rst).
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(td, '[workspace]\nname = "from-conda"\nchannels = ["defaults"]\nplatforms = ["linux-64"]\n')
+            _write_pixi_toml(td, '[workspace]\nname = "from-pixi"\nchannels = ["defaults"]\nplatforms = ["linux-64"]\n')
+            info = publication_info(td, project_type=PROJECT_TYPE_PIXI)
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
+            assert info['name'] == 'from-pixi'
+
+    def test_force_conda_workspaces_when_pixi_toml_also_present(self):
+        # Reverse direction of the regression above: conda.toml outranks
+        # pixi.toml, so this direction already worked, but locking it in
+        # alongside the fix confirms the new helper didn't flip the winner.
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(td, '[workspace]\nname = "from-conda"\nchannels = ["defaults"]\nplatforms = ["linux-64"]\n')
+            _write_pixi_toml(td, '[workspace]\nname = "from-pixi"\nchannels = ["defaults"]\nplatforms = ["linux-64"]\n')
+            info = publication_info(td, project_type=PROJECT_TYPE_CONDA_WORKSPACES)
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_CONDA_WORKSPACES
+            assert info['name'] == 'from-conda'
+
+    def test_force_pixi_via_pyproject_when_conda_toml_also_present(self):
+        # Same regression, pyproject.toml-embedded variant: a top-level
+        # conda.toml must not mask a pixi.toml embedded in [tool.pixi.workspace].
+        with tempfile.TemporaryDirectory() as td:
+            _write_conda_toml(td, '[workspace]\nname = "from-conda"\nchannels = ["defaults"]\nplatforms = ["linux-64"]\n')
+            _write_pyproject_toml(
+                td,
+                '[tool.pixi.workspace]\nname = "pyproject-pixi"\nchannels = ["conda-forge"]\nplatforms = ["linux-64"]\n',
+            )
+            info = publication_info(td, project_type=PROJECT_TYPE_PIXI)
+            assert info[PROJECT_TYPE_KEY] == PROJECT_TYPE_PIXI
+            assert info['name'] == 'pyproject-pixi'

--- a/anaconda_project/test/test_project_info.py
+++ b/anaconda_project/test/test_project_info.py
@@ -861,6 +861,54 @@ class TestPublicationInfoToolAnaconda:
             assert cmd['description'] == 'Run the web app'
             assert cmd['notebook'] == 'app.ipynb'
 
+    def test_tool_anaconda_overrides_pyproject_pixi(self):
+        # F2: verify that [tool.anaconda.commands] overrides work in pyproject.toml with [tool.pixi]
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(td, textwrap.dedent("""\
+                [tool.pixi.workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [tool.pixi.tasks]
+                serve = "python app.py"
+
+                [tool.anaconda.commands.serve]
+                supports_http_options = true
+                description = "Run the web app in pyproject"
+                default = true
+                notebook = "app.ipynb"
+            """))
+            info = publication_info(td)
+            cmd = info['commands']['serve']
+            assert cmd['supports_http_options'] is True
+            assert cmd['description'] == 'Run the web app in pyproject'
+            assert cmd['notebook'] == 'app.ipynb'
+            assert cmd['default'] is True
+
+    def test_tool_anaconda_overrides_pyproject_conda(self):
+        # F2: verify that [tool.anaconda.commands] overrides work in pyproject.toml with [tool.conda]
+        with tempfile.TemporaryDirectory() as td:
+            _write_pyproject_toml(td, textwrap.dedent("""\
+                [tool.conda.workspace]
+                name = "t"
+                channels = ["conda-forge"]
+                platforms = ["linux-64"]
+
+                [tool.conda.tasks]
+                test = "pytest"
+
+                [tool.anaconda.commands.test]
+                supports_http_options = false
+                description = "Run tests"
+                default = false
+            """))
+            info = publication_info(td)
+            cmd = info['commands']['test']
+            assert cmd['supports_http_options'] is False
+            assert cmd['description'] == 'Run tests'
+            assert cmd['default'] is False
+
 
 class TestPublicationInfoErrors:
     def test_missing_file(self):

--- a/docs/source/help-support.rst
+++ b/docs/source/help-support.rst
@@ -15,7 +15,7 @@ development focus is limited to:
 
 * Critical bug fixes against the existing ``anaconda-project``
   command-line tool and library.
-* The conversion tooling described in :doc:`pixi-support`, which
+* The conversion tooling described in :doc:`workspace-support`, which
   helps users move existing projects onto
   `pixi <https://pixi.sh/>`_ or
   `conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,7 +42,8 @@ stay closer to the conda ecosystem.
 For that reason, recent work on this repository has been (and will
 remain) focused on critical bug fixes and on the ability to convert
 existing Anaconda Project projects into the pixi and conda-workspaces
-formats. See :doc:`pixi-support` for details on the conversion tooling.
+formats. See :doc:`workspace-support` for details on the conversion
+tooling (pixi and conda-workspaces).
 
 Quick Start
 ===========
@@ -119,9 +120,9 @@ These conditions could include:
 .. toctree::
    :maxdepth: 1
    :hidden:
-   :caption: Pixi support
+   :caption: Workspace export support
 
-   pixi-support
+   workspace-support
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/workspace-support.rst
+++ b/docs/source/workspace-support.rst
@@ -298,10 +298,13 @@ Flags:
   effect for them.
 * ``--project-type {conda-workspaces,pixi,anaconda-project}`` forces
   a manifest format when more than one is present in the directory
-  (e.g. mid-conversion). Forcing a type only recognizes the
-  corresponding top-level manifest (``conda.toml`` or ``pixi.toml``),
-  not a ``pyproject.toml`` embedding — omit ``--project-type`` to let
-  auto-detection find a pyproject.toml-embedded manifest.
+  (e.g. mid-conversion). Forcing a type recognizes that format
+  whether it is a top-level manifest (``conda.toml`` or ``pixi.toml``)
+  or a ``pyproject.toml`` embedding (``[tool.conda.workspace]`` or
+  ``[tool.pixi.workspace]``), and it is checked independently of
+  auto-detect precedence — so a coexisting higher-precedence manifest
+  of a *different* format never masks the one you asked for. It is an
+  error only when the requested format is present in neither form.
 
 publication_info
 ================
@@ -347,10 +350,12 @@ Optional arguments:
   forces a specific manifest format. Default behavior is auto-detect,
   with ``conda.toml`` winning over ``pixi.toml``, which wins over
   ``anaconda-project.yml`` (or its aliases), which wins over a
-  ``pyproject.toml`` embedding. Forcing a type only recognizes the
-  corresponding top-level manifest; it is an error to ask for a
-  format whose top-level manifest is not in the directory, even if a
-  ``pyproject.toml`` embedding of that format exists there.
+  ``pyproject.toml`` embedding. Forcing a type recognizes that format
+  whether it is the top-level manifest or a ``pyproject.toml``
+  embedding, checked independently of that precedence order, so a
+  coexisting higher-precedence manifest of a *different* format never
+  masks it. It is an error only when the requested format is present
+  in neither form in the directory.
 * ``env_paths=True`` populates ``env_specs[name]['path']`` with the
   on-disk prefix for each declared environment. For anaconda-project
   this is derived from each ``EnvSpec``; for pixi (top-level or

--- a/docs/source/workspace-support.rst
+++ b/docs/source/workspace-support.rst
@@ -1,30 +1,47 @@
-============
-Pixi support
-============
+========================
+Workspace export support
+========================
 
-Anaconda Project ships two pieces of tooling aimed at converting
-existing ``anaconda-project.yml`` projects into a form that can be
-managed by `pixi <https://pixi.sh/>`_ (and, by extension,
-`conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_,
-which consumes the same ``pixi.toml`` format).
+Anaconda Project ships tooling aimed at converting existing
+``anaconda-project.yml`` projects into forms that can be managed by
+`pixi <https://pixi.sh/>`_ or by
+`conda-workspaces <https://github.com/conda-incubator/conda-workspaces>`_.
+Both are independently-writable export targets: ``export-pixi``
+writes a ``pixi.toml``, and ``export-conda`` writes a ``conda.toml``.
+The two formats share almost all of their TOML shape — the same
+``[workspace]``, ``[dependencies]``, ``[feature.*]``,
+``[environments]``, and ``[tasks]`` tables — so a single conversion
+pipeline backs both commands; ``conda.toml`` is not merely something
+this repository reads because it happens to also consume
+``pixi.toml`` files, it is a first-class output of its own.
 
 These are the focus of recent maintenance on this repository:
 
 * The ``anaconda-project export-pixi`` command, which writes a
   ``pixi.toml`` (and a sibling ``ap_download.py`` helper when needed)
   alongside an existing ``anaconda-project.yml``.
+* The ``anaconda-project export-conda`` command, which writes a
+  ``conda.toml`` (and the same sibling ``ap_download.py`` helper when
+  needed) alongside an existing ``anaconda-project.yml``, using the
+  identical conversion rules as ``export-pixi``.
 * A ``publication_info`` function in
-  ``anaconda_project.project_info`` that can read either
-  ``anaconda-project.yml`` or ``pixi.toml`` and return a uniform
-  dictionary describing the project's commands, environments, and
-  variables. Downstream deployment tooling that ingests both formats
-  uses this as its single integration point.
+  ``anaconda_project.project_info`` that can read
+  ``anaconda-project.yml``, ``pixi.toml``, ``conda.toml``, or a
+  ``pyproject.toml`` embedding either format (``[tool.pixi]`` /
+  ``[tool.conda]``) and return a uniform dictionary describing the
+  project's commands, environments, and variables. Downstream
+  deployment tooling that ingests any of these formats uses this as
+  its single integration point.
 * The ``anaconda-project info`` command, a human-readable view of the
-  same data — modeled on ``pixi info`` — that works on either
-  manifest format.
+  same data — modeled on ``pixi info`` — that works on any of the
+  supported manifest formats.
 
 The rest of this page documents the conventions the conversion uses
 to preserve as much of the original project's behavior as possible.
+Except where noted, everything below applies equally to
+``export-pixi``/``pixi.toml`` and ``export-conda``/``conda.toml`` — the
+two exporters produce identical content for the same project and
+flags.
 
 Export goals
 ============
@@ -261,57 +278,90 @@ project, modeled on ``pixi info``::
           Dependencies: colorcet, datashader, fiona, geoviews, ...
                 Locked: yes
 
-The command works on either manifest format — ``pixi.toml`` is
-preferred when both are present.
+The command works on any supported manifest format. When no format is
+forced, detection follows this precedence: ``conda.toml``, then
+``pixi.toml``, then ``anaconda-project.yml`` (or its ``.yaml`` /
+``kapsel.*`` aliases), then ``pyproject.toml`` (checking
+``[tool.conda.workspace]`` before ``[tool.pixi.workspace]``).
 
 Flags:
 
 * ``--json`` emits the underlying ``publication_info`` dict as
   indented JSON, mirroring ``pixi info --json``.
 * ``--env-paths`` includes the on-disk prefix path for each
-  environment. For pixi projects this shells out to
+  environment. For pixi projects (top-level ``pixi.toml`` or a
+  ``pyproject.toml`` ``[tool.pixi]`` embedding) this shells out to
   ``pixi info --json``; the full pixi payload is also stashed
   under an ``_pixi`` key in ``--json`` mode so callers don't have
-  to repeat the subprocess.
-* ``--project-type {pixi,anaconda-project}`` forces a manifest
-  format when both are present in the directory (e.g. mid-conversion).
+  to repeat the subprocess. conda-workspaces projects have no
+  equivalent path-resolution mechanism yet, so this flag has no
+  effect for them.
+* ``--project-type {conda-workspaces,pixi,anaconda-project}`` forces
+  a manifest format when more than one is present in the directory
+  (e.g. mid-conversion). Forcing a type only recognizes the
+  corresponding top-level manifest (``conda.toml`` or ``pixi.toml``),
+  not a ``pyproject.toml`` embedding — omit ``--project-type`` to let
+  auto-detection find a pyproject.toml-embedded manifest.
 
 publication_info
 ================
 
 ``anaconda_project.project_info.publication_info(project_dir)``
 returns a uniform dictionary regardless of whether the project is
-managed by ``anaconda-project.yml`` or by a converted
-``pixi.toml``. The shape mirrors ``Project.publication_info()`` from
-the anaconda-project side; relevant additions for the pixi side:
+managed by ``anaconda-project.yml``, a converted ``pixi.toml``, a
+converted ``conda.toml``, or a ``pyproject.toml`` embedding either
+format under ``[tool.pixi]`` / ``[tool.conda]``. The shape mirrors
+``Project.publication_info()`` from the anaconda-project side;
+relevant additions for the pixi and conda-workspaces sides (field
+population is identical between the two — the only differences are
+the manifest filename and lockfile filename each reads):
 
-* ``commands[name]['args']`` — ordered list of pixi arg names
+* ``commands[name]['args']`` — ordered list of task arg names
   declared for the task. Empty for tasks without args. Lets
-  downstream tooling drive ``pixi run <task> *args`` to supply
-  positional values.
+  downstream tooling drive ``pixi run <task> *args`` (or the
+  conda-workspaces equivalent) to supply positional values.
 * ``commands[name]['env_spec']`` — resolves to the name of an env
   that supports the task. Top-level tasks resolve to the project's
   default env (literal ``default`` if declared, otherwise the first
   declared env). Feature-scoped tasks resolve to whichever env
   actually includes the feature.
-* ``env_specs[name]['locked']`` — ``True`` when ``pixi.lock`` has an
-  ``environments[<name>]`` entry. Best-effort: any read or parse
-  failure silently falls back to ``False``.
+* ``env_specs[name]['locked']`` — ``True`` when the sibling lockfile
+  (``pixi.lock`` or ``conda.lock``) has an ``environments[<name>]``
+  entry. Best-effort: any read or parse failure silently falls back
+  to ``False``.
+
+For the ``pyproject.toml``-embedded case, ``name``/``description``
+resolution has one documented gap: upstream conda-workspaces itself
+falls back to PEP 621 ``[project].name`` / ``[project].description``
+when ``[tool.conda.workspace]`` (or ``[tool.pixi.workspace]``) omits
+those fields. This plan's read-side summary does not replicate that
+PEP 621 fallback — if ``workspace.name`` is absent, the directory
+basename is used instead, matching the top-level-manifest behavior.
+This is a deliberate scope limitation (a uniform read-side summary,
+not full-fidelity mirroring of every upstream fallback path), not a
+bug.
 
 Optional arguments:
 
-* ``project_type='pixi' | 'anaconda-project'`` forces a specific
-  manifest format. Default behavior is auto-detect, with ``pixi.toml``
-  winning when both are present. It is an error to ask for a format
-  whose manifest is not in the directory.
+* ``project_type='conda-workspaces' | 'pixi' | 'anaconda-project'``
+  forces a specific manifest format. Default behavior is auto-detect,
+  with ``conda.toml`` winning over ``pixi.toml``, which wins over
+  ``anaconda-project.yml`` (or its aliases), which wins over a
+  ``pyproject.toml`` embedding. Forcing a type only recognizes the
+  corresponding top-level manifest; it is an error to ask for a
+  format whose top-level manifest is not in the directory, even if a
+  ``pyproject.toml`` embedding of that format exists there.
 * ``env_paths=True`` populates ``env_specs[name]['path']`` with the
   on-disk prefix for each declared environment. For anaconda-project
-  this is derived from each ``EnvSpec``; for pixi it requires a
-  ``pixi info --json`` subprocess (so it is opt-in). Failure to
-  invoke pixi or parse its output raises ``RuntimeError``. When the
-  source is pixi, the full ``pixi info --json`` payload is also
-  stored under the top-level ``_pixi`` key so callers that want
-  richer pixi-specific data don't pay for a second subprocess.
+  this is derived from each ``EnvSpec``; for pixi (top-level or
+  pyproject.toml-embedded) it requires a ``pixi info --json``
+  subprocess (so it is opt-in). Failure to invoke pixi or parse its
+  output raises ``RuntimeError``. When the source is pixi, the full
+  ``pixi info --json`` payload is also stored under the top-level
+  ``_pixi`` key so callers that want richer pixi-specific data don't
+  pay for a second subprocess. conda-workspaces projects have no
+  equivalent mechanism yet, so ``env_paths=True`` has no effect on
+  conda-workspaces results.
 
 Programmatic export API
 =======================
@@ -348,18 +398,44 @@ generated TOML or re-implement the conversion rules.
   callers don't have to grep for it themselves. Raises
   ``CondaNotAvailableError`` if the conversion needs ``conda config
   --show default_channels`` and conda isn't reachable.
+* ``project_ops.export_conda(project, filename, use_default=False,
+  add_current_platform=False)`` writes ``conda.toml`` to disk and
+  returns a ``PixiExportStatus`` — the exact same status class
+  ``export_pixi`` returns, since ``default_rename_from`` and
+  ``current_platform_added`` are generic export concepts with nothing
+  pixi-specific baked into the class. Semantics of both fields are
+  identical to ``export_pixi``'s.
+* ``project_ops.preview_conda_export(project, use_default=False,
+  add_current_platform=False)`` runs the conversion in memory and
+  returns a dict
+  ``{conda_toml, default_rename_from, current_platform_addition_target,
+  warnings}`` — the same four concepts as ``preview_pixi_export``,
+  with only the file-content key renamed (``conda_toml`` instead of
+  ``pixi_toml``) to match the format it describes.
+* ``anaconda_project.internal.pixi_export.export_conda_toml(project,
+  use_default=False, add_current_platform=False,
+  default_channels=None)`` is the module-level function
+  ``export_conda`` calls to produce ``conda.toml`` content; it
+  delegates directly to ``export_pixi_toml`` and returns its result
+  unchanged. conda-workspaces 0.7.0's TOML shape is field-for-field
+  identical to pixi.toml's for every field this exporter emits, so no
+  translation step exists between the two — the same function
+  produces both outputs, distinguished only by which file the caller
+  writes it to.
 * ``anaconda_project.internal.pixi_export.default_rename_target(project)``
   returns the env_spec name that ``--use-default`` would promote, or
   ``None`` when promotion is a no-op (project already has a
   ``default`` env_spec, or has no env_specs at all). Stable contract;
   the underlying selection rule (default-command's env, else first
-  declared env_spec) lives in this one function.
+  declared env_spec) lives in this one function. Shared by both the
+  pixi and conda-workspaces export paths.
 * ``anaconda_project.internal.pixi_export.current_platform_addition_target(project)``
   returns the host's conda subdir if it would be added by
   ``--add-current-platform``, or ``None`` when it's already in the
   union of declared platforms. Same shape as
   ``default_rename_target`` so callers can decide both flags
-  symmetrically.
+  symmetrically. Shared by both the pixi and conda-workspaces export
+  paths.
 
 Limitations
 ===========


### PR DESCRIPTION
## Summary

* Adds a third project manifest type/format, **conda-workspaces** (`conda.toml`, plus `pyproject.toml` embedding via `[tool.conda]`/`[tool.pixi]`), on both the read side (`project_info.publication_info`) and a new export side (`export-conda` CLI command).
* Reorders manifest-detection precedence to `conda.toml` > `pixi.toml` > `anaconda-project.*` > `pyproject.toml` (previously just `pixi.toml` > `anaconda-project.yml`), matching conda-workspaces' own documented directory-scan precedence.
* Renames `docs/source/pixi-support.rst` → `docs/source/workspace-support.rst` to cover both export targets.

## How this was built

This went through a full plan → spec → execute → review → fix loop:

* The design was ground-truthed against the real, installed `conda-workspaces` 0.7.0 Python package (not just its docs) — confirming its TOML parser's `args` shorthand acceptance, that `[workspace]`'s `additionalProperties: false` schema constraint isn't actually enforced at runtime, the real nesting of `pyproject.toml` embedding (`[tool.conda.workspace]`, not a flat `[tool.conda]`), and that `conda.lock` shares `pixi.lock`'s `version`/`environments`/`packages` shape (stamped `version: 1` instead of `6`).
* A first pass landed 8 gated commits implementing the feature.
* A 7-persona review standup (code-reviewer, python-reviewer, silent-failure-hunter, sre, staff-engineer, product-manager, devils-advocate) then reviewed the diff and found 2 confirmed, independently-reproduced bugs plus a confirmed API asymmetry. All three were independently re-verified against the real code before fixing.
* A second pass (7 more commits) fixed every confirmed finding, collapsed two duplication hotspots the reviewers flagged, and — caught during final independent verification, not by the review itself — fixed a wording regression the duplication-collapse had silently introduced, with a new test locking in the correct wording for both formats.

## What changed, in commit order

1. `conda.toml` and `pyproject.toml` detection in `detect_project_type()`
2. Refactor `_pixi_publication_info` to accept a pre-parsed data dict (enables format-agnostic reuse)
3. `conda-workspaces` `publication_info` branch + `pyproject.toml` fallback for both formats
4. `anaconda-project info` CLI surfaces the `conda-workspaces` project type
5. `export-conda` `project_ops` functions (`export_conda`, `preview_conda_export`)
6. `export_conda_toml` writer (delegates to `export_pixi_toml`, since the two TOML shapes are field-for-field identical for the fields this exporter emits)
7. `export-conda` CLI wiring (new `export-conda` subcommand)
8. Docs retitle: `workspace-support.rst` covers both pixi and conda-workspaces
9. **Fix**: stop leaking pixi-specific prose into `conda.toml` output (e.g. `# default (pixi creates this implicitly...)`, `...before running pixi` — the exporter's "zero content differences" claim was false for projects with services or multiple env_specs)
10. **Fix**: `[tool.anaconda.commands.*]` overrides were silently dropped for `pyproject.toml`-embedded manifests (wrong lookup path — was looking for `tool.pixi.tool.anaconda`/`tool.conda.tool.anaconda` instead of the document's top-level `tool.anaconda`)
11. **Fix**: `--project-type` explicit override now recognizes `pyproject.toml` embedding, matching auto-detect (previously `anaconda-project info --project-type pixi` failed on a directory that `anaconda-project info` alone correctly identified as a pixi project)
12. Collapse `_pixi_publication_info`/`_conda_workspaces_publication_info` (~90% duplicate logic) into one shared, parameterized implementation
13. Collapse `conda_export_commands.py`/`pixi_commands.py` (near-identical CLI wiring) into one shared `_export_workspace` helper
14. Small hygiene fixes: unused import, stale docstrings, narrowed exception handling in lockfile readers
15. **Fix**: restore "Pixi" capitalization in `export-pixi`'s CLI recommendation text, which the duplication collapse (item 13) had silently flattened to lowercase — plus a new test asserting the exact wording for both formats so this can't regress silently again

## Explicit non-goals (scoped out, on purpose)

* No `pyproject.toml` *writer* — reads only.
* No `api.py` changes — `project_ops`/`project_info` stay the real public surface, matching the pre-existing state for `export_pixi`/`preview_pixi_export`.
* No `CondaExportStatus` class — `export_conda` reuses `PixiExportStatus` (its two fields are generic export concepts, not pixi-specific).
* No support for conda.toml-only export fields (`[workspace.archive]`, `channel-priority`, `envs-dir`, etc.) — `anaconda-project.yml` has no source concept for any of them.

## Test plan

* [x] Full targeted gate green: `python -m pytest anaconda_project/test/test_project_info.py anaconda_project/internal/test/test_pixi_export.py anaconda_project/internal/cli/test/test_info.py anaconda_project/internal/test/test_conda_export.py -q` — 201 passed on the pre-change baseline, 247 passed after this PR (46 new tests added across both passes).
* [x] Full repo suite: 1265 passed, 10 skipped, 1 failed. The 1 failure (`test_prepare.py::test_default_to_system_environ`) is pre-existing and environment-specific (confirmed by reproducing the identical failure against the unmodified pre-change commit in an isolated worktree) — unrelated to this change.
* [x] Manually verified against the real, installed `conda-workspaces` 0.7.0 package: `conda workspace info` / `conda task list` against hand-written `conda.toml` fixtures, and direct calls into `conda_workspaces.manifests.toml.CondaTomlParser`/`normalize_args` to confirm shape assumptions before writing the reader/exporter.
* [x] Manually reproduced and re-verified all 3 fixed bugs (prose leak, dropped command override, `--project-type` asymmetry) directly against this branch's code, independent of the automated test suite, before and after each fix.
