### PR TITLE
docs(workspace-support): --project-type recognizes pyproject embeddings

### DIFF
--- a/docs/source/workspace-support.rst
+++ b/docs/source/workspace-support.rst
@@ -298,10 +298,13 @@ Flags:
   effect for them.
 * ``--project-type {conda-workspaces,pixi,anaconda-project}`` forces
   a manifest format when more than one is present in the directory
-  (e.g. mid-conversion). Forcing a type only recognizes the
-  corresponding top-level manifest (``conda.toml`` or ``pixi.toml``),
-  not a ``pyproject.toml`` embedding — omit ``--project-type`` to let
-  auto-detection find a pyproject.toml-embedded manifest.
+  (e.g. mid-conversion). Forcing a type recognizes that format
+  whether it is a top-level manifest (``conda.toml`` or ``pixi.toml``)
+  or a ``pyproject.toml`` embedding (``[tool.conda.workspace]`` or
+  ``[tool.pixi.workspace]``), and it is checked independently of
+  auto-detect precedence — so a coexisting higher-precedence manifest
+  of a *different* format never masks the one you asked for. It is an
+  error only when the requested format is present in neither form.
 
 publication_info
 ================
@@ -347,10 +350,12 @@ Optional arguments:
   forces a specific manifest format. Default behavior is auto-detect,
   with ``conda.toml`` winning over ``pixi.toml``, which wins over
   ``anaconda-project.yml`` (or its aliases), which wins over a
-  ``pyproject.toml`` embedding. Forcing a type only recognizes the
-  corresponding top-level manifest; it is an error to ask for a
-  format whose top-level manifest is not in the directory, even if a
-  ``pyproject.toml`` embedding of that format exists there.
+  ``pyproject.toml`` embedding. Forcing a type recognizes that format
+  whether it is the top-level manifest or a ``pyproject.toml``
+  embedding, checked independently of that precedence order, so a
+  coexisting higher-precedence manifest of a *different* format never
+  masks it. It is an error only when the requested format is present
+  in neither form in the directory.
 * ``env_paths=True`` populates ``env_specs[name]['path']`` with the
   on-disk prefix for each declared environment. For anaconda-project
   this is derived from each ``EnvSpec``; for pixi (top-level or


### PR DESCRIPTION
## Summary

Targets #440's branch directly (not `master`) — a docs-only follow-up to the second, separate item raised in [#440's review](https://github.com/anaconda/anaconda-project/pull/440#issuecomment-4970559442), landing alongside the code fix in #441 (now merged into this branch).

`docs/source/workspace-support.rst` described `--project-type` / `publication_info(project_type=)` in two places as only recognizing the corresponding **top-level** manifest, "not a `pyproject.toml` embedding." That was already inaccurate, and #441 makes it demonstrably wrong: `_locate_manifest_of_kind()` checks for the requested format as a top-level file **or** a `[tool.<key>.workspace]` `pyproject.toml` embedding, independently of auto-detect precedence. #441's own `test_force_pixi_via_pyproject_when_conda_toml_also_present` exercises exactly the pyproject-embedded override path the docs claimed didn't exist.

## Changes

Rewrites both passages to describe the actual behavior:

- **CLI flag docs** (the `--project-type` bullet)
- **`publication_info` optional-arguments list** (the `project_type=` bullet)

Both now state that forcing a type matches the requested format in *either* form — top-level manifest or `pyproject.toml` embedding — checked independently of precedence, so a coexisting higher-precedence manifest of a *different* format never masks it, and it is an error only when the requested format is present in neither form.

Docs-only; no code or test changes.

## On the precedence-reorder note from the same review

The review also flagged the `conda.toml > pixi.toml > anaconda-project.* > pyproject.toml` reorder as a behavior change for users with a "stray" `conda.toml`. We reject that premise and are signing off on the reorder as intended: a `conda.toml` is not an accidental stray file — its presence signals a deliberate migration to conda-workspaces, exactly as a `pixi.toml` signals a move off `anaconda-project`. A higher-precedence `conda.toml` winning is the correct, intended behavior. No change needed there.
